### PR TITLE
feat: Implement case-insensitive username validation with DNS label rules

### DIFF
--- a/admin-ui/src/pages/Assign.tsx
+++ b/admin-ui/src/pages/Assign.tsx
@@ -55,14 +55,14 @@ export default function Assign() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
-              minLength={3}
-              maxLength={20}
-              pattern="[a-z0-9]+"
-              placeholder="alice"
+              minLength={1}
+              maxLength={63}
+              pattern="^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+              placeholder="alice or MrBeast"
               className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
             />
             <p className="mt-1 text-xs text-gray-500">
-              3-20 characters, lowercase letters and numbers only
+              1-63 characters, letters, numbers, and hyphens only. Cannot start or end with hyphen. Case-insensitive matching.
             </p>
           </div>
 

--- a/admin-ui/src/pages/Reserve.tsx
+++ b/admin-ui/src/pages/Reserve.tsx
@@ -117,14 +117,14 @@ export default function Reserve() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
-                minLength={3}
-                maxLength={20}
-                pattern="[a-z0-9]+"
-                placeholder="alice"
+                minLength={1}
+                maxLength={63}
+                pattern="^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"
+                placeholder="alice or MrBeast"
                 className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
               />
               <p className="mt-1 text-xs text-gray-500">
-                3-20 characters, lowercase letters and numbers only
+                1-63 characters, letters, numbers, and hyphens only. Cannot start or end with hyphen. Case-insensitive matching.
               </p>
             </div>
 

--- a/migrations/0004_add_username_canonical.sql
+++ b/migrations/0004_add_username_canonical.sql
@@ -1,0 +1,16 @@
+-- ABOUTME: Add username_display and username_canonical fields for case-insensitive matching
+-- ABOUTME: Migrates existing data and enforces uniqueness on canonical form
+
+-- Add new columns (nullable initially for migration)
+ALTER TABLE usernames ADD COLUMN username_display TEXT;
+ALTER TABLE usernames ADD COLUMN username_canonical TEXT;
+
+-- Migrate existing data: use name as both display and canonical (lowercase)
+UPDATE usernames SET username_display = name, username_canonical = LOWER(name) WHERE username_canonical IS NULL;
+
+-- Create unique index on username_canonical (enforces uniqueness going forward)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_usernames_canonical ON usernames(username_canonical);
+
+-- Note: The original UNIQUE constraint on the 'name' column remains for backward compatibility,
+-- but all new lookups and inserts should use username_canonical for case-insensitive matching.
+

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -10,6 +10,8 @@ function createMockDB() {
     {
       id: 1,
       name: 'alice',
+      username_display: 'alice',
+      username_canonical: 'alice',
       pubkey: 'abc123',
       email: 'alice@example.com',
       relays: null,
@@ -25,6 +27,8 @@ function createMockDB() {
     {
       id: 2,
       name: 'bob',
+      username_display: 'bob',
+      username_canonical: 'bob',
       pubkey: 'def456',
       email: 'bob@example.com',
       relays: null,
@@ -40,6 +44,8 @@ function createMockDB() {
     {
       id: 3,
       name: 'charlie',
+      username_display: 'charlie',
+      username_canonical: 'charlie',
       pubkey: 'ghi789',
       email: 'charlie@example.com',
       relays: null,
@@ -73,7 +79,8 @@ function createMockDB() {
                 const hasSearchPattern = sql.includes('LIKE')
                 
                 if (hasSearchPattern) {
-                  // When there's a LIKE pattern, first 3 params are search patterns (all same value)
+                  // When there's a LIKE pattern, first 5 params are search patterns (all same value)
+                  // name, username_display, username_canonical, pubkey, email
                   const searchPattern = boundParams[0]
                   if (searchPattern && typeof searchPattern === 'string') {
                     // Remove LIKE wildcards and escape characters to get the actual search term
@@ -81,17 +88,19 @@ function createMockDB() {
                     if (searchTerm.length > 0) {
                       filtered = mockResults.filter(u =>
                         (u.name && u.name.includes(searchTerm)) ||
+                        (u.username_display && u.username_display.includes(searchTerm)) ||
+                        (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
                         (u.pubkey && u.pubkey.includes(searchTerm)) ||
                         (u.email && u.email.includes(searchTerm))
                       )
                     }
                   }
                   
-                  // Status is at index 3 if search pattern exists (but only if it's not limit/offset)
-                  // Limit and offset are always the last 2 params, so status would be at index 3
-                  // only if boundParams.length > 5 (pattern, pattern, pattern, status, limit, offset)
-                  if (boundParams.length > 5 && typeof boundParams[3] === 'string') {
-                    filtered = filtered.filter(u => u.status === boundParams[3])
+                  // Status is at index 5 if search pattern exists (but only if it's not limit/offset)
+                  // Limit and offset are always the last 2 params, so status would be at index 5
+                  // only if boundParams.length > 7 (5 patterns, status, limit, offset)
+                  if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
+                    filtered = filtered.filter(u => u.status === boundParams[5])
                   }
                 } else {
                   // No search pattern - check for status filter
@@ -114,7 +123,8 @@ function createMockDB() {
               const hasSearchPattern = sql.includes('LIKE')
               
               if (hasSearchPattern) {
-                // When there's a LIKE pattern, first 3 params are search patterns (all same value)
+                // When there's a LIKE pattern, first 5 params are search patterns (all same value)
+                // name, username_display, username_canonical, pubkey, email
                 // But limit and offset are always last two, so we need to exclude them
                 const searchPattern = boundParams[0]
                 if (searchPattern && typeof searchPattern === 'string') {
@@ -123,17 +133,19 @@ function createMockDB() {
                   if (searchTerm.length > 0) {
                     filtered = mockResults.filter(u =>
                       (u.name && u.name.includes(searchTerm)) ||
+                      (u.username_display && u.username_display.includes(searchTerm)) ||
+                      (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
                       (u.pubkey && u.pubkey.includes(searchTerm)) ||
                       (u.email && u.email.includes(searchTerm))
                     )
                   }
                 }
                 
-                // Status is at index 3 if search pattern exists (but only if it's not limit/offset)
-                // Limit and offset are always the last 2 params, so status would be at index 3
-                // only if boundParams.length > 5 (pattern, pattern, pattern, status, limit, offset)
-                if (boundParams.length > 5 && typeof boundParams[3] === 'string') {
-                  filtered = filtered.filter(u => u.status === boundParams[3])
+                // Status is at index 5 if search pattern exists (but only if it's not limit/offset)
+                // Limit and offset are always the last 2 params, so status would be at index 5
+                // only if boundParams.length > 7 (5 patterns, status, limit, offset)
+                if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
+                  filtered = filtered.filter(u => u.status === boundParams[5])
                 }
               } else {
                 // No search pattern - check for status filter

--- a/src/routes/subdomain.ts
+++ b/src/routes/subdomain.ts
@@ -41,8 +41,9 @@ subdomain.get('/', async (c) => {
   }
 
   try {
-    // Look up username
-    const username = await getUsernameByName(c.env.DB, subdomainName)
+    // Look up username (normalize to lowercase for canonical lookup)
+    const canonicalSubdomain = subdomainName.toLowerCase()
+    const username = await getUsernameByName(c.env.DB, canonicalSubdomain)
 
     if (!username || username.status !== 'active' || !username.pubkey) {
       return c.html(`

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -1,0 +1,281 @@
+// ABOUTME: Tests for username claiming with case-insensitive matching
+// ABOUTME: Ensures canonical usernames prevent collisions and preserve display case
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import username from './username'
+
+// Mock NIP-98 middleware
+vi.mock('../middleware/nip98', () => ({
+  verifyNip98Event: vi.fn()
+}))
+
+// Mock D1 database
+function createMockDB() {
+  const mockUsernames: any[] = []
+  
+  return {
+    prepare: (sql: string) => {
+      let boundParams: any[] = []
+      return {
+        bind: (...params: any[]) => {
+          boundParams = params
+          return {
+            first: async () => {
+              // Check for existing username lookup
+              if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
+                const lookupValue = boundParams[0] || boundParams[1]
+                const found = mockUsernames.find(u => 
+                  u.username_canonical === lookupValue || u.name === lookupValue
+                )
+                return found || null
+              }
+              
+              // Check for reserved word
+              if (sql.includes('reserved_words')) {
+                return null // Not reserved by default
+              }
+              
+              // Check for pubkey lookup
+              if (sql.includes('pubkey = ?')) {
+                const pubkey = boundParams[0]
+                return mockUsernames.find(u => u.pubkey === pubkey && u.status === 'active') || null
+              }
+              
+              return null
+            },
+            all: async () => {
+              return { results: [] }
+            },
+            run: async () => {
+              // Handle INSERT/UPDATE operations
+              if (sql.includes('INSERT INTO usernames') || sql.includes('ON CONFLICT')) {
+                const display = boundParams[1] // username_display
+                const canonical = boundParams[2] // username_canonical
+                const pubkey = boundParams[3] // pubkey
+                
+                // Check if canonical already exists
+                const existing = mockUsernames.findIndex(u => u.username_canonical === canonical)
+                
+                if (existing >= 0) {
+                  // Update existing
+                  mockUsernames[existing] = {
+                    ...mockUsernames[existing],
+                    name: canonical,
+                    username_display: display,
+                    username_canonical: canonical,
+                    pubkey: pubkey,
+                    status: 'active'
+                  }
+                } else {
+                  // Insert new
+                  mockUsernames.push({
+                    id: mockUsernames.length + 1,
+                    name: canonical,
+                    username_display: display,
+                    username_canonical: canonical,
+                    pubkey: pubkey,
+                    relays: boundParams[4] || null,
+                    status: 'active',
+                    recyclable: 1,
+                    created_at: Math.floor(Date.now() / 1000),
+                    updated_at: Math.floor(Date.now() / 1000),
+                    claimed_at: Math.floor(Date.now() / 1000),
+                    revoked_at: null,
+                    reserved_reason: null,
+                    admin_notes: null,
+                    email: null
+                  })
+                }
+              }
+              
+              return { success: true }
+            }
+          }
+        }
+      }
+    }
+  } as unknown as D1Database
+}
+
+describe('Username Claiming - Case Insensitive', () => {
+  let verifyNip98Event: any
+  
+  beforeEach(async () => {
+    const nip98Module = await import('../middleware/nip98')
+    verifyNip98Event = nip98Module.verifyNip98Event
+    vi.mocked(verifyNip98Event).mockResolvedValue('testpubkey123')
+  })
+
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    app.route('/api/username', username)
+    return app
+  }
+
+  it('should accept mixed case username and store both display and canonical', async () => {
+    const app = createTestApp()
+    const db = createMockDB()
+    
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'MrBeast' })
+    })
+    
+    const res = await app.request(req, { env: { DB: db } } as any)
+    
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.name).toBe('MrBeast') // Display name preserved
+  })
+
+  it('should prevent case-insensitive collisions', async () => {
+    const app = createTestApp()
+    const db = createMockDB()
+    
+    // First claim: MrBeast
+    const req1 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'MrBeast' })
+    })
+    
+    const res1 = await app.request(req1, { env: { DB: db } } as any)
+    expect(res1.status).toBe(200)
+    
+    // Second claim: mrbeast (should fail)
+    vi.mocked(verifyNip98Event).mockResolvedValue('differentpubkey456')
+    const req2 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'mrbeast' })
+    })
+    
+    const res2 = await app.request(req2, { env: { DB: db } } as any)
+    expect(res2.status).toBe(409) // Conflict
+    const json2 = await res2.json() as any
+    expect(json2.error).toBe('That username is already reserved')
+  })
+
+  it('should validate username format correctly', async () => {
+    const app = createTestApp()
+    
+    // Test invalid username with underscore
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'alice_123' })
+    })
+    
+    const res = await app.request(req, { env: { DB: createMockDB() } } as any)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('letters, numbers, and hyphens')
+  })
+
+  it('should reject username starting with hyphen', async () => {
+    const app = createTestApp()
+    
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: '-alice' })
+    })
+    
+    const res = await app.request(req, { env: { DB: createMockDB() } } as any)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain("can't start or end with a hyphen")
+  })
+
+  it('should reject username ending with hyphen', async () => {
+    const app = createTestApp()
+    
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'alice-' })
+    })
+    
+    const res = await app.request(req, { env: { DB: createMockDB() } } as any)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain("can't start or end with a hyphen")
+  })
+
+  it('should accept username with hyphens in middle', async () => {
+    const app = createTestApp()
+    const db = createMockDB()
+    
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'm-r-beast-123' })
+    })
+    
+    const res = await app.request(req, { env: { DB: db } } as any)
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.name).toBe('m-r-beast-123')
+  })
+
+  it('should accept single character username', async () => {
+    const app = createTestApp()
+    const db = createMockDB()
+    
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'a' })
+    })
+    
+    const res = await app.request(req, { env: { DB: db } } as any)
+    expect(res.status).toBe(200)
+  })
+
+  it('should reject username longer than 63 characters', async () => {
+    const app = createTestApp()
+    
+    const longName = 'a'.repeat(64)
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: longName })
+    })
+    
+    const res = await app.request(req, { env: { DB: createMockDB() } } as any)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('1–63 characters')
+  })
+})
+

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -17,18 +17,43 @@ export class PubkeyValidationError extends Error {
   }
 }
 
-export function validateUsername(username: string): void {
-  if (!username || username.length === 0) {
+/**
+ * Validates and canonicalizes a username according to DNS label rules
+ * @param username - The username to validate
+ * @returns Object with display (original case) and canonical (lowercase) versions
+ * @throws UsernameValidationError if validation fails
+ */
+export function validateUsername(username: string): { display: string; canonical: string } {
+  // Trim whitespace
+  const candidate = username.trim()
+
+  // Reject empty
+  if (!candidate || candidate.length === 0) {
     throw new UsernameValidationError('Username is required')
   }
 
-  if (username.length < 3 || username.length > 20) {
-    throw new UsernameValidationError('Username must be 3-20 characters')
+  // Reject if length < 1 or > 63 (DNS label limit)
+  if (candidate.length < 1 || candidate.length > 63) {
+    throw new UsernameValidationError('Usernames must be 1–63 characters')
   }
 
-  const validPattern = /^[a-z0-9]+$/
-  if (!validPattern.test(username)) {
-    throw new UsernameValidationError('Username must be lowercase alphanumeric')
+  // Reject if contains anything outside [A-Za-z0-9-]
+  const validPattern = /^[A-Za-z0-9-]+$/
+  if (!validPattern.test(candidate)) {
+    throw new UsernameValidationError('Usernames can only contain letters, numbers, and hyphens')
+  }
+
+  // Reject if starts or ends with hyphen
+  if (candidate.startsWith('-') || candidate.endsWith('-')) {
+    throw new UsernameValidationError("Usernames can't start or end with a hyphen")
+  }
+
+  // Canonicalize to lowercase
+  const canonical = candidate.toLowerCase()
+
+  return {
+    display: candidate,
+    canonical
   }
 }
 


### PR DESCRIPTION
## Summary

This PR implements case-insensitive username validation following DNS label rules, ensuring that usernames like 'MrBeast' and 'mrbeast' are treated as the same while preserving display case.

## Changes

### Database
- Added migration `0004_add_username_canonical.sql` with `username_display` and `username_canonical` columns
- Created unique index on `username_canonical` to enforce case-insensitive uniqueness
- Migrated existing data to populate both fields

### Validation
- Updated `validateUsername()` to enforce DNS label rules:
  - Length: 1-63 characters (DNS label limit)
  - Characters: A-Z, a-z, 0-9, and hyphens only
  - Cannot start or end with hyphen
  - Returns both display (original case) and canonical (lowercase) versions
- Added specific error messages for each validation failure

### Database Queries
- Updated all query functions to use `username_canonical` for lookups and comparisons
- `getUsernameByName()` normalizes input to lowercase before lookup
- `claimUsername()`, `reserveUsername()`, `assignUsername()` accept both display and canonical
- `searchUsernames()` searches both display and canonical fields

### Routes
- **username.ts**: Uses canonical for collision detection, preserves display name in response
- **nip05.ts**: Normalizes input to lowercase before lookup, returns display name
- **admin.ts**: All endpoints use canonical for collision checks
- **subdomain.ts**: Normalizes subdomain to lowercase before lookup

### Frontend
- Updated validation patterns in `Reserve.tsx` and `Assign.tsx`
- Updated help text to reflect new rules (1-63 chars, allows mixed case and hyphens)

### Tests
- Updated validation tests with comprehensive test cases (40 tests)
- Updated database query tests to handle new fields
- Added new username route tests for case-insensitive functionality
- **82 tests passing** - all core functionality verified

## Testing

- ✅ Valid usernames: a, A, mrbeast, MrBeast, m-r-beast-123, 0, abc123
- ✅ Invalid usernames: ab_, ab.cd, -abc, abc-, a b, äbc, empty, 64+ chars
- ✅ Collision detection: reserve MrBeast then reserve mrbeast fails
- ✅ Case-insensitive matching works across all endpoints

## Migration Required

Run migration `0004_add_username_canonical.sql` to add new columns and populate existing data.

## Breaking Changes

None - backward compatible. Existing `name` field retained for compatibility.