### PR TITLE
feat: add public username API route and improve error messages

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -150,7 +150,10 @@ admin.post('/username/reserve', async (c) => {
     // Check if already exists
     const existing = await getUsernameByName(c.env.DB, usernameData.canonical)
     if (existing) {
-      return c.json({ ok: false, error: 'That username is already reserved' }, 409)
+      const error = existing.status === 'active'
+        ? 'That username is already taken'
+        : `That username is already ${existing.status}`
+      return c.json({ ok: false, error }, 409)
     }
 
     // Include override reason in the reserved_reason if provided
@@ -209,7 +212,10 @@ admin.post('/username/reserve-bulk', async (c) => {
         // Check if already exists
         const existing = await getUsernameByName(c.env.DB, usernameData.canonical)
         if (existing) {
-          results.push({ name, status: 'failed', success: false, error: 'That username is already reserved' })
+          const error = existing.status === 'active'
+            ? 'That username is already taken'
+            : `That username is already ${existing.status}`
+          results.push({ name, status: 'failed', success: false, error })
           continue
         }
         await reserveUsername(c.env.DB, usernameData.display, usernameData.canonical, reason)

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -165,7 +165,7 @@ describe('Username Claiming - Case Insensitive', () => {
     const res2 = await app.fetch(req2, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {} })
     expect(res2.status).toBe(409) // Conflict
     const json2 = await res2.json() as any
-    expect(json2.error).toBe('That username is already reserved')
+    expect(json2.error).toBe('That username is already taken')
   })
 
   it('should validate username format correctly', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -70,7 +70,7 @@ username.post('/claim', async (c) => {
     const existing = await getUsernameByName(c.env.DB, nameCanonical)
     if (existing) {
       if (existing.status === 'active' && existing.pubkey !== pubkey) {
-        return c.json({ ok: false, error: 'That username is already reserved' }, 409)
+        return c.json({ ok: false, error: 'That username is already taken' }, 409)
       }
       if (existing.status === 'reserved') {
         return c.json({ ok: false, error: 'Username is reserved' }, 403)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,8 @@ compatibility_date = "2024-11-15"
 # Routes
 routes = [
   { pattern = "divine.video/.well-known/*", zone_name = "divine.video" },
-  { pattern = "names.admin.divine.video/*", zone_name = "divine.video" }
+  { pattern = "names.admin.divine.video/*", zone_name = "divine.video" },
+  { pattern = "names.divine.video/api/username/*", zone_name = "divine.video" }
 ]
 
 [[d1_databases]]


### PR DESCRIPTION
## Summary
- Add `names.divine.video/api/username/*` route for public access to the claim endpoint
- Differentiate error messages: "already taken" (409) vs "already reserved" (403)
- Admin endpoints now show specific status in errors (taken/reserved/revoked/burned)

## Test plan
- [ ] Deploy and verify `https://names.divine.video/api/username/claim` is accessible
- [ ] Verify `https://names.divine.video/api/admin/*` returns 522 (no route)
- [ ] Test claim errors return correct messages based on username status