### PR TITLE
feat: add recovered Vine accounts filter and CSV export

### DIFF
--- a/admin-ui/src/components/StatusBadge.tsx
+++ b/admin-ui/src/components/StatusBadge.tsx
@@ -1,20 +1,24 @@
-// ABOUTME: Displays color-coded status badges for username states (active, reserved, revoked, burned)
+// ABOUTME: Displays color-coded status badges for username states (active, reserved, revoked, burned, recovered)
 // ABOUTME: Provides visual distinction between different username lifecycle states using Tailwind classes
 interface StatusBadgeProps {
   status: 'active' | 'reserved' | 'revoked' | 'burned'
+  isRecovered?: boolean
 }
 
-export default function StatusBadge({ status }: StatusBadgeProps) {
-  const colors = {
+export default function StatusBadge({ status, isRecovered }: StatusBadgeProps) {
+  const colors: Record<string, string> = {
     active: 'bg-green-100 text-green-800',
     reserved: 'bg-yellow-100 text-yellow-800',
     revoked: 'bg-gray-100 text-gray-800',
-    burned: 'bg-red-100 text-red-800'
+    burned: 'bg-red-100 text-red-800',
+    recovered: 'bg-purple-100 text-purple-800'
   }
 
+  const displayStatus = isRecovered ? 'recovered' : status
+
   return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors[status]}`}>
-      {status}
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors[displayStatus] || colors[status]}`}>
+      {displayStatus}
     </span>
   )
 }

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -120,6 +120,7 @@ export default function Dashboard() {
               <option value="">All Statuses</option>
               <option value="active">Active</option>
               <option value="reserved">Reserved</option>
+              <option value="recovered">Recovered (Vine)</option>
               <option value="revoked">Revoked</option>
               <option value="burned">Burned</option>
             </select>
@@ -149,6 +150,16 @@ export default function Dashboard() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
               Active
+            </a>
+            <a
+              href="/api/admin/export/csv?status=recovered"
+              download="usernames-recovered.csv"
+              className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-purple-100 text-purple-700 hover:bg-purple-200"
+            >
+              <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Recovered (Vine)
             </a>
             <a
               href="/api/admin/export/csv?status=reserved"
@@ -260,7 +271,10 @@ export default function Dashboard() {
                           {truncate(username.email, 30)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
-                          <StatusBadge status={username.status} />
+                          <StatusBadge
+                            status={username.status}
+                            isRecovered={username.status === 'active' && !!username.pubkey && !!username.reserved_reason?.toLowerCase().includes('vine')}
+                          />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           {formatDate(username.created_at)}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -35,7 +35,7 @@ export interface ReservationToken {
 
 export interface SearchParams {
   query: string
-  status?: 'active' | 'reserved' | 'revoked' | 'burned'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
   page?: number
   limit?: number
 }
@@ -225,7 +225,15 @@ export async function searchUsernames(
   }
 
   // Add status filter if provided
-  if (status) {
+  if (status === 'recovered') {
+    // "Recovered" = Vine accounts that have been claimed (active with pubkey, originally from Vine import)
+    const recoveredCondition = `status = 'active' AND pubkey IS NOT NULL AND reserved_reason LIKE '%Vine%'`
+    if (whereClause) {
+      whereClause += ` AND ${recoveredCondition}`
+    } else {
+      whereClause = recoveredCondition
+    }
+  } else if (status) {
     if (whereClause) {
       whereClause += ` AND status = ?`
     } else {
@@ -311,8 +319,15 @@ export async function deleteReservedWord(
 
 export async function exportUsernamesByStatus(
   db: D1Database,
-  status?: 'active' | 'reserved' | 'revoked' | 'burned'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
 ): Promise<Username[]> {
+  if (status === 'recovered') {
+    const result = await db.prepare(
+      `SELECT * FROM usernames WHERE status = 'active' AND pubkey IS NOT NULL AND reserved_reason LIKE '%Vine%' ORDER BY claimed_at DESC, name`
+    ).all<Username>()
+    return result.results
+  }
+
   if (status) {
     const result = await db.prepare(
       'SELECT * FROM usernames WHERE status = ? ORDER BY name'

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2,10 +2,36 @@
 // ABOUTME: Protected by Cloudflare Access, handles reserve/revoke/burn/assign
 
 import { Hono } from 'hono'
+import { bech32 } from '@scure/base'
 import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
+
+/** Convert a 64-char hex pubkey to npub bech32 format */
+function hexToNpub(hex: string): string {
+  try {
+    const bytes = new Uint8Array(hex.match(/.{2}/g)!.map(b => parseInt(b, 16)))
+    // Convert 8-bit bytes to 5-bit words for bech32
+    const words: number[] = []
+    let acc = 0
+    let bits = 0
+    for (const byte of bytes) {
+      acc = (acc << 8) | byte
+      bits += 8
+      while (bits >= 5) {
+        bits -= 5
+        words.push((acc >> bits) & 31)
+      }
+    }
+    if (bits > 0) {
+      words.push((acc << (5 - bits)) & 31)
+    }
+    return bech32.encode('npub', words)
+  } catch {
+    return ''
+  }
+}
 
 type Bindings = {
   DB: D1Database
@@ -45,7 +71,7 @@ admin.use('*', async (c, next) => {
 admin.get('/usernames/search', async (c) => {
   try {
     const query = c.req.query('q')
-    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | undefined
+    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
     const pageStr = c.req.query('page') || '1'
     const limitStr = c.req.query('limit') || '50'
 
@@ -59,7 +85,7 @@ admin.get('/usernames/search', async (c) => {
     }
 
     // Validate status parameter
-    const validStatuses = ['active', 'reserved', 'revoked', 'burned']
+    const validStatuses = ['active', 'reserved', 'revoked', 'burned', 'recovered']
     if (status && !validStatuses.includes(status)) {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
     }
@@ -484,10 +510,10 @@ admin.post('/username/assign-bulk', async (c) => {
 
 admin.get('/export/csv', async (c) => {
   try {
-    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | undefined
+    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
 
     // Validate status parameter
-    const validStatuses = ['active', 'reserved', 'revoked', 'burned']
+    const validStatuses = ['active', 'reserved', 'revoked', 'burned', 'recovered']
     if (status && !validStatuses.includes(status)) {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
     }
@@ -495,14 +521,15 @@ admin.get('/export/csv', async (c) => {
     const usernames = await exportUsernamesByStatus(c.env.DB, status)
 
     // Build CSV content
-    const headers = ['name', 'pubkey', 'status', 'created_at', 'claimed_at', 'revoked_at', 'reserved_reason']
+    const headers = ['name', 'pubkey', 'npub', 'status', 'created_at', 'claimed_at', 'revoked_at', 'reserved_reason']
     const csvRows = [headers.join(',')]
 
     for (const u of usernames) {
       const row = [
         u.name,
         u.pubkey || '',
-        u.status,
+        u.pubkey ? hexToNpub(u.pubkey) : '',
+        status === 'recovered' ? 'recovered' : u.status,
         u.created_at ? new Date(u.created_at * 1000).toISOString() : '',
         u.claimed_at ? new Date(u.claimed_at * 1000).toISOString() : '',
         u.revoked_at ? new Date(u.revoked_at * 1000).toISOString() : '',


### PR DESCRIPTION
## Summary
- Adds a **"Recovered (Vine)"** filter to the admin dashboard so Alyesha and the support/creator liaison team can see which Vine accounts have been claimed
- Recovered accounts show a **purple badge** to visually distinguish them from regular active accounts
- Adds a **"Recovered (Vine)" CSV export** button with username, pubkey, and **npub** columns
- All CSV exports now include an **npub** (bech32) column alongside hex pubkey

## How it works
"Recovered" is a virtual status filter — it matches accounts where:
- `status = 'active'` (account has been claimed)
- `pubkey IS NOT NULL` (has a nostr identity)
- `reserved_reason LIKE '%Vine%'` (was originally imported from Vine)

## Test plan
- [ ] Filter by "Recovered (Vine)" in the admin dashboard — should show only claimed Vine accounts
- [ ] Verify purple "recovered" badge appears on these accounts
- [ ] Download "Recovered (Vine)" CSV — should contain username, pubkey, npub, and claimed_at
- [ ] Verify other status filters (Active, Reserved, etc.) still work correctly
- [ ] Verify npub column appears in all CSV exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)