### PR TITLE
fix: return owning pubkey in username check response

### DIFF
--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -490,6 +490,48 @@ describe('Public Username Endpoints', () => {
       expect(json.reason).toContain('underscores')
     })
 
+    it('should return pubkey for active username', async () => {
+      const app = createTestApp()
+      const ownerPubkey = 'a'.repeat(64)
+      const db = createMockDB([{
+        id: 1, name: 'alice', username_display: 'alice', username_canonical: 'alice',
+        pubkey: ownerPubkey, status: 'active', reservation_expires_at: null
+      }])
+
+      const req = new Request('http://localhost/api/username/check/alice', {
+        method: 'GET'
+      })
+
+      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {} })
+      expect(res.status).toBe(200)
+      const json = await res.json() as any
+      expect(json.ok).toBe(true)
+      expect(json.available).toBe(false)
+      expect(json.status).toBe('active')
+      expect(json.pubkey).toBe(ownerPubkey)
+      expect(json.reason).toBe('Username is already taken')
+    })
+
+    it('should not return pubkey for reserved username', async () => {
+      const app = createTestApp()
+      const db = createMockDB([{
+        id: 1, name: 'bob', username_display: 'bob', username_canonical: 'bob',
+        pubkey: null, status: 'reserved', reservation_expires_at: null
+      }])
+
+      const req = new Request('http://localhost/api/username/check/bob', {
+        method: 'GET'
+      })
+
+      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {} })
+      expect(res.status).toBe(200)
+      const json = await res.json() as any
+      expect(json.ok).toBe(true)
+      expect(json.available).toBe(false)
+      expect(json.status).toBe('reserved')
+      expect(json.pubkey).toBeUndefined()
+    })
+
     it('should preserve display case in response', async () => {
       const app = createTestApp()
       const db = createMockDB()

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -105,7 +105,11 @@ username.get('/check/:name', async (c) => {
         name: usernameData.display,
         canonical: usernameData.canonical,
         status: existing.status,
-        reason: existing.status === 'revoked' ? undefined : reason
+        reason: existing.status === 'revoked' ? undefined : reason,
+        // Include owning pubkey for active names so clients can distinguish
+        // "taken by me" (admin-assigned) from "taken by someone else".
+        // Pubkeys are already public via NIP-05 resolution.
+        ...(existing.status === 'active' && existing.pubkey ? { pubkey: existing.pubkey } : {})
       }, 200, { 'Access-Control-Allow-Origin': '*' })
     }
 


### PR DESCRIPTION
## User Story

As a VIP creator who has had a username reserved and assigned to my account by an admin, I want to be able to claim that username through the normal Edit Profile flow in the app, so that I don't need further admin intervention after the initial assignment.

## Problem

When an admin assigns a reserved username to a creator's pubkey via `names.admin.divine.video`, the creator opens Edit Profile and types the username. The check endpoint returns `available: false` with no indication of ownership, so the app shows "Username already taken" and disables Save. The creator is stuck despite the name being rightfully theirs.

## Fix

The `GET /api/username/check/:name` endpoint now includes the `pubkey` field in its response for active usernames. This lets clients compare against the current user's pubkey to distinguish "taken by me" from "taken by someone else."

Pubkeys are already public via NIP-05 resolution (`GET /.well-known/nostr.json`), so this adds no new information exposure.

## Changes

- `src/routes/username.ts`: Add `pubkey` to check response for active names
- `src/routes/username.test.ts`: Two new tests (pubkey present for active, absent for reserved)

## Testing

**No staging environment exists** for divine-name-server (single wrangler config, production routes only).

Local evaluation:
- All 159 tests pass (`npx vitest run`), including 2 new tests for this change
- Change is additive only: adds one optional field (`pubkey`) to an existing JSON response
- No existing consumers are affected. The field is new, so no client currently reads it.
- Pubkey value comes directly from the existing D1 query result (`existing.pubkey`), no new database calls
- Field is only included for `status: 'active'` names with a non-null pubkey. Reserved names, revoked names, and names without an assigned pubkey return no pubkey field (preserving current behavior exactly).
- Verified the NIP-05 resolution endpoint (`/.well-known/nostr.json`) already returns pubkeys publicly, so this is not a new information exposure

**Confidence: high.** The change is a single conditional spread operator on an existing response object. No control flow changes, no new dependencies, no schema changes.

## Deployment note

Deploy directly to production via `npx wrangler deploy`. Verify with:
```
curl https://names.divine.video/api/username/check/<known-active-username>
```
Response should now include `"pubkey": "<hex>"` for active names.

## Related

- Closes #12
- Companion issue: divinevideo/divine-mobile#1956 (client-side fix needed to use the pubkey field)
- The mobile fix is the other half: `ProfileEditorBloc` needs to compare the returned pubkey against the current user's pubkey and treat "taken by me" as claimable.