### PR TITLE
fix: normalize check endpoint pubkey to lowercase

### DIFF
--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -512,6 +512,27 @@ describe('Public Username Endpoints', () => {
       expect(json.reason).toBe('Username is already taken')
     })
 
+    it('should normalize active username pubkey to lowercase', async () => {
+      const app = createTestApp()
+      const ownerPubkeyUpper = 'A'.repeat(64)
+      const db = createMockDB([{
+        id: 1, name: 'alice', username_display: 'alice', username_canonical: 'alice',
+        pubkey: ownerPubkeyUpper, status: 'active', reservation_expires_at: null
+      }])
+
+      const req = new Request('http://localhost/api/username/check/alice', {
+        method: 'GET'
+      })
+
+      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {} })
+      expect(res.status).toBe(200)
+      const json = await res.json() as any
+      expect(json.ok).toBe(true)
+      expect(json.available).toBe(false)
+      expect(json.status).toBe('active')
+      expect(json.pubkey).toBe(ownerPubkeyUpper.toLowerCase())
+    })
+
     it('should not return pubkey for reserved username', async () => {
       const app = createTestApp()
       const db = createMockDB([{
@@ -956,4 +977,3 @@ describe('Public Name Reservation', () => {
     })
   })
 })
-

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -109,7 +109,7 @@ username.get('/check/:name', async (c) => {
         // Include owning pubkey for active names so clients can distinguish
         // "taken by me" (admin-assigned) from "taken by someone else".
         // Pubkeys are already public via NIP-05 resolution.
-        ...(existing.status === 'active' && existing.pubkey ? { pubkey: existing.pubkey } : {})
+        ...(existing.status === 'active' && existing.pubkey ? { pubkey: existing.pubkey.toLowerCase() } : {})
       }, 200, { 'Access-Control-Allow-Origin': '*' })
     }
 


### PR DESCRIPTION
## Summary
- normalize `pubkey` in `GET /api/username/check/:name` responses to lowercase when status is `active`
- add a regression test proving uppercase stored pubkeys are returned as lowercase

## Why
- mobile compares ownership using exact string equality
- normalizing response pubkeys avoids false negatives from legacy/uppercase stored values

## Validation
- `npm run test:once -- src/routes/username.test.ts` (34/34 passing)
