### PR TITLE
feat: add machine-readable code field to check endpoint

### DIFF
--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -487,6 +487,7 @@ describe('Public Username Endpoints', () => {
       const json = await res.json() as any
       expect(json.ok).toBe(true)
       expect(json.available).toBe(false)
+      expect(json.code).toBe('invalid_format')
       expect(json.reason).toContain('underscores')
     })
 
@@ -508,6 +509,7 @@ describe('Public Username Endpoints', () => {
       expect(json.ok).toBe(true)
       expect(json.available).toBe(false)
       expect(json.status).toBe('active')
+      expect(json.code).toBe('taken')
       expect(json.pubkey).toBe(ownerPubkey)
       expect(json.reason).toBe('Username is already taken')
     })
@@ -550,7 +552,40 @@ describe('Public Username Endpoints', () => {
       expect(json.ok).toBe(true)
       expect(json.available).toBe(false)
       expect(json.status).toBe('reserved')
+      expect(json.code).toBe('reserved')
       expect(json.pubkey).toBeUndefined()
+    })
+
+    it('should return code:reserved for reserved word', async () => {
+      const app = createTestApp()
+      // Create a mock DB where reserved_words returns a hit
+      const db = createMockDB()
+      const originalPrepare = db.prepare.bind(db)
+      ;(db as any).prepare = (sql: string) => {
+        const stmt = originalPrepare(sql)
+        if (sql.includes('reserved_words')) {
+          return {
+            bind: (...params: any[]) => ({
+              first: async () => ({ word: params[0] }),
+              all: async () => ({ results: [{ word: params[0] }] }),
+              run: async () => ({ success: true, meta: { changes: 0 } })
+            })
+          }
+        }
+        return stmt
+      }
+
+      const req = new Request('http://localhost/api/username/check/admin', {
+        method: 'GET'
+      })
+
+      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {} })
+      expect(res.status).toBe(200)
+      const json = await res.json() as any
+      expect(json.ok).toBe(true)
+      expect(json.available).toBe(false)
+      expect(json.code).toBe('reserved')
+      expect(json.reason).toBe('Username is reserved')
     })
 
     it('should preserve display case in response', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -57,6 +57,7 @@ username.get('/check/:name', async (c) => {
           ok: true,
           available: false,
           name,
+          code: 'invalid_format',
           reason: error.message
         }, 200, { 'Access-Control-Allow-Origin': '*' })
       }
@@ -71,6 +72,7 @@ username.get('/check/:name', async (c) => {
         available: false,
         name: usernameData.display,
         canonical: usernameData.canonical,
+        code: 'reserved',
         reason: 'Username is reserved'
       }, 200, { 'Access-Control-Allow-Origin': '*' })
     }
@@ -89,6 +91,13 @@ username.get('/check/:name', async (c) => {
         }, 200, { 'Access-Control-Allow-Origin': '*' })
       }
 
+      const codeMap: Record<string, string> = {
+        active: 'taken',
+        reserved: 'reserved',
+        burned: 'burned',
+        'pending-confirmation': 'pending_confirmation',
+      }
+
       const reason = existing.status === 'active'
         ? 'Username is already taken'
         : existing.status === 'reserved'
@@ -105,6 +114,7 @@ username.get('/check/:name', async (c) => {
         name: usernameData.display,
         canonical: usernameData.canonical,
         status: existing.status,
+        code: existing.status === 'revoked' ? undefined : codeMap[existing.status] || 'unavailable',
         reason: existing.status === 'revoked' ? undefined : reason,
         // Include owning pubkey for active names so clients can distinguish
         // "taken by me" (admin-assigned) from "taken by someone else".


### PR DESCRIPTION
## Summary
- Adds a `code` field to `/api/username/check/:name` responses so clients can switch on machine-readable values instead of parsing the `reason` string
- Codes: `reserved`, `taken`, `burned`, `pending_confirmation`, `invalid_format`
- No `code` field when username is available (or revoked/recyclable)
- Fully backwards-compatible: `available` boolean and `reason` string are unchanged

## Context
Reported by users: reserved usernames shown as "already taken" in the app because the client falls through to a default when string-matching on `reason`. App-side fix tracked in divinevideo/divine-mobile#2107, blocked on this deploy.

## Test plan
- [x] All 161 tests pass
- [x] New test for reserved-word `code` response
- [x] Existing tests updated to assert `code` field
- [ ] After merge, verify auto-deploy via GitHub Actions
