### PR TITLE
fix: remove unused hono-nostr-auth dependency breaking CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^3.0.0",
         "@scure/base": "^2.0.0",
-        "hono": "^4.10.6",
-        "hono-nostr-auth": "^0.1.1"
+        "hono": "^4.10.6"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251115.0",
@@ -1000,33 +999,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@noble/secp256k1": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-3.0.0.tgz",
@@ -1850,18 +1822,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
-      }
-    },
-    "node_modules/hono-nostr-auth": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hono-nostr-auth/-/hono-nostr-auth-0.1.1.tgz",
-      "integrity": "sha512-sdJZ172h1IN8h/BPG2fkuafu2PfSdBqwyz9tpiHp5ZM4+x5fcepra3YBXc2D85qGW/N3MEXlw/Cb9kZyb2W5FA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "^1.2.0"
-      },
-      "peerDependencies": {
-        "hono": "^3.9.0"
       }
     },
     "node_modules/is-arrayish": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "@noble/secp256k1": "^3.0.0",
     "@scure/base": "^2.0.0",
-    "hono": "^4.10.6",
-    "hono-nostr-auth": "^0.1.1"
+    "hono": "^4.10.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251115.0",


### PR DESCRIPTION
## Summary
- Removes `hono-nostr-auth` from dependencies — it was added in the initial commit but never imported in source code (NIP-98 is implemented manually in `src/middleware/nip98.ts`)
- This peer dependency conflict (`hono-nostr-auth` requires `hono@^3.9.0`, project uses `hono@^4.10.6`) has caused **all 28 CI deploys to fail** since the repo was created
- Unblocks automatic deployment via GitHub Actions

## Context
PR #15 (machine-readable `code` field) is merged but not deployed because CI has never successfully run. This fix unblocks that deploy and all future pushes to main.

## Test plan
- [x] All 161 tests pass
- [x] `npm install` succeeds without peer dep errors
- [ ] After merge, verify GitHub Actions deploy succeeds for the first time
- [ ] Verify https://names.divine.video/api/username/check/testuser12345xy returns `code` field