### PR TITLE
feat: add username ops metadata and ranked admin search

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -5,7 +5,11 @@ import type {
   RevokeResponse,
   ReservedWord,
   BulkReserveResponse,
-  ApiResponse
+  ApiResponse,
+  SearchSort,
+  UsernameDetailResponse,
+  UsernameMetadataResponse,
+  UsernameStatsResponse
 } from '../types'
 
 const API_BASE = '/api/admin'
@@ -13,6 +17,7 @@ const API_BASE = '/api/admin'
 export async function searchUsernames(
   query: string,
   status?: string,
+  sort: SearchSort = 'relevance',
   page = 1,
   limit = 50
 ): Promise<SearchResult> {
@@ -26,10 +31,54 @@ export async function searchUsernames(
     params.set('status', status)
   }
 
+  params.set('sort', sort)
+
   const response = await fetch(`${API_BASE}/usernames/search?${params}`)
 
   if (!response.ok) {
     throw new Error(`Search failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+export async function getUsernameDetail(name: string): Promise<UsernameDetailResponse> {
+  const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}`)
+
+  if (!response.ok) {
+    throw new Error(`Load username failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+export async function updateUsernameMetadata(
+  name: string,
+  adminNotes: string | null,
+  tags: string[]
+): Promise<UsernameMetadataResponse> {
+  const response = await fetch(`${API_BASE}/username/metadata`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      admin_notes: adminNotes,
+      tags
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Save metadata failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+export async function getUsernameStats(): Promise<UsernameStatsResponse> {
+  const response = await fetch(`${API_BASE}/usernames/stats`)
+
+  if (!response.ok) {
+    throw new Error(`Stats failed: ${response.statusText}`)
   }
 
   return response.json()

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -31,6 +31,43 @@ export default function Layout() {
                 Dashboard
               </a>
               <a
+                href="https://moderation.admin.divine.video/admin"
+                className="text-white hover:text-blue-200 transition-colors flex items-center"
+                title="Video Moderation"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                </svg>
+                Moderation
+              </a>
+              <a
+                href="https://realness.admin.divine.video"
+                className="text-white hover:text-blue-200 transition-colors flex items-center"
+                title="AI Detection Dashboard"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                </svg>
+                Realness
+              </a>
+              <a
+                href="https://relay.admin.divine.video"
+                className="text-white hover:text-blue-200 transition-colors flex items-center"
+                title="Relay Manager"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+                </svg>
+                Relay
+              </a>
+              <a
                 href="https://faro.admin.divine.video"
                 className="text-white hover:text-blue-200 transition-colors flex items-center"
                 title="Nostr Content Reports"
@@ -65,6 +102,18 @@ export default function Layout() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
                 </svg>
                 Video Review
+              </a>
+              <a
+                href="https://discovery.admin.divine.video"
+                className="text-white hover:text-blue-200 transition-colors flex items-center"
+                title="Vine Discovery & Enrichment"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+                Discovery
               </a>
               <h1 className="text-xl font-bold text-white border-l border-blue-400 pl-4">
                 Name Server Admin

--- a/admin-ui/src/components/StatusBadge.tsx
+++ b/admin-ui/src/components/StatusBadge.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Displays color-coded status badges for username states (active, reserved, revoked, burned, recovered)
 // ABOUTME: Provides visual distinction between different username lifecycle states using Tailwind classes
 interface StatusBadgeProps {
-  status: 'active' | 'reserved' | 'revoked' | 'burned'
+  status: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
   isRecovered?: boolean
 }
 
@@ -11,6 +11,7 @@ export default function StatusBadge({ status, isRecovered }: StatusBadgeProps) {
     reserved: 'bg-yellow-100 text-yellow-800',
     revoked: 'bg-gray-100 text-gray-800',
     burned: 'bg-red-100 text-red-800',
+    'pending-confirmation': 'bg-blue-100 text-blue-800',
     recovered: 'bg-purple-100 text-purple-800'
   }
 

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -1,18 +1,27 @@
 // ABOUTME: Main admin dashboard page for searching and viewing usernames
-// ABOUTME: Supports search by username/pubkey/email with status filtering and pagination
+// ABOUTME: Supports metadata-aware search, operational stats, and pagination
 
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { searchUsernames } from '../api/client'
-import type { Username } from '../types'
+import { getUsernameStats, searchUsernames } from '../api/client'
+import type { SearchSort, Username, UsernameStats } from '../types'
 import StatusBadge from '../components/StatusBadge'
 import Pagination from '../components/Pagination'
+
+const SORT_OPTIONS: Array<{ value: SearchSort; label: string }> = [
+  { value: 'relevance', label: 'Best Match' },
+  { value: 'updated', label: 'Recently Updated' },
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' }
+]
 
 export default function Dashboard() {
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const [status, setStatus] = useState<string>('')
+  const [sort, setSort] = useState<SearchSort>('relevance')
   const [results, setResults] = useState<Username[]>([])
+  const [stats, setStats] = useState<UsernameStats | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(0)
   const [total, setTotal] = useState(0)
@@ -23,7 +32,7 @@ export default function Dashboard() {
     setLoading(true)
     setError(null)
     try {
-      const data = await searchUsernames(query, status || undefined, currentPage, 50)
+      const data = await searchUsernames(query, status || undefined, sort, currentPage, 50)
       setResults(data.results)
       setTotalPages(data.pagination.total_pages)
       setTotal(data.pagination.total)
@@ -33,11 +42,24 @@ export default function Dashboard() {
     } finally {
       setLoading(false)
     }
-  }, [query, status, currentPage])
+  }, [query, status, sort, currentPage])
+
+  const loadStats = useCallback(async () => {
+    try {
+      const data = await getUsernameStats()
+      setStats(data)
+    } catch (err) {
+      console.error('Stats failed:', err)
+    }
+  }, [])
 
   useEffect(() => {
     performSearch()
-  }, [query, status, currentPage, performSearch])
+  }, [query, status, sort, currentPage, performSearch])
+
+  useEffect(() => {
+    loadStats()
+  }, [loadStats])
 
   const truncate = (str: string | null, len: number) => {
     if (!str) return '-'
@@ -48,12 +70,25 @@ export default function Dashboard() {
     return new Date(timestamp * 1000).toLocaleDateString()
   }
 
+  const statCards = stats ? [
+    { label: 'All Names', value: stats.totals.all, tone: 'bg-slate-50 border-slate-200 text-slate-900' },
+    { label: 'Active', value: stats.totals.active, tone: 'bg-green-50 border-green-200 text-green-900' },
+    { label: 'Reserved', value: stats.totals.reserved, tone: 'bg-yellow-50 border-yellow-200 text-yellow-900' },
+    { label: 'With Notes', value: stats.metadata.with_notes, tone: 'bg-blue-50 border-blue-200 text-blue-900' },
+    { label: 'With Tags', value: stats.metadata.with_tags, tone: 'bg-indigo-50 border-indigo-200 text-indigo-900' },
+    { label: 'Untagged', value: stats.metadata.untagged, tone: 'bg-orange-50 border-orange-200 text-orange-900' },
+    { label: 'VIP', value: stats.metadata.vip, tone: 'bg-purple-50 border-purple-200 text-purple-900' },
+    { label: 'Updated 30d', value: stats.activity.updated_30d, tone: 'bg-emerald-50 border-emerald-200 text-emerald-900' }
+  ] : []
+
   const downloadSearchResultsCSV = () => {
     if (results.length === 0) return
 
-    const headers = ['Username', 'Pubkey', 'Email', 'Status', 'Created', 'Source', 'Created By']
+    const headers = ['Username', 'Tags', 'Notes', 'Pubkey', 'Email', 'Status', 'Created', 'Source', 'Created By']
     const rows = results.map((username: Username) => [
       username.name,
+      username.tags.join('; '),
+      username.admin_notes || '',
       username.pubkey || '',
       username.email || '',
       username.status,
@@ -83,12 +118,49 @@ export default function Dashboard() {
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Search Usernames</h2>
         <p className="mt-1 text-sm text-gray-600">
-          Search by username, pubkey, or email
+          Search by username, pubkey, email, tags, or internal notes
         </p>
       </div>
 
+      {stats && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            {statCards.map((card) => (
+              <div key={card.label} className={`rounded-lg border p-4 ${card.tone}`}>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em]">{card.label}</p>
+                <p className="mt-2 text-2xl font-bold">{card.value}</p>
+              </div>
+            ))}
+          </div>
+
+          {stats.top_tags.length > 0 && (
+            <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-900">Top Tags</h3>
+                  <p className="text-xs text-gray-500">Common labels across internal operations.</p>
+                </div>
+                <p className="text-xs text-gray-500">
+                  Claims 30d: <span className="font-semibold text-gray-700">{stats.activity.claimed_30d}</span>
+                </p>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {stats.top_tags.map((tag) => (
+                  <span
+                    key={tag.tag}
+                    className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"
+                  >
+                    {tag.tag} <span className="ml-2 rounded-full bg-white px-2 py-0.5 text-[11px] text-gray-500">{tag.count}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="bg-white shadow rounded-lg p-6">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <div>
             <label htmlFor="search" className="block text-sm font-medium text-gray-700">
               Search Query
@@ -125,6 +197,25 @@ export default function Dashboard() {
               <option value="recovered">Recovered (Vine)</option>
               <option value="revoked">Revoked</option>
               <option value="burned">Burned</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="sort" className="block text-sm font-medium text-gray-700">
+              Sort
+            </label>
+            <select
+              id="sort"
+              value={sort}
+              onChange={(e) => {
+                setSort(e.target.value as SearchSort)
+                setCurrentPage(1)
+              }}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
             </select>
           </div>
         </div>
@@ -231,7 +322,7 @@ export default function Dashboard() {
 
           {results.length === 0 ? (
             <div className="px-6 py-8 text-center">
-              <p className="text-gray-500">No results found</p>
+              <p className="text-gray-500">No results matched names, pubkeys, emails, tags, or notes.</p>
             </div>
           ) : (
             <>
@@ -241,6 +332,9 @@ export default function Dashboard() {
                     <tr>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Username
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Tags
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Pubkey
@@ -267,7 +361,30 @@ export default function Dashboard() {
                         className="hover:bg-blue-50 cursor-pointer"
                       >
                         <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600 hover:text-blue-800">
-                          {username.name}
+                          <div className="space-y-2">
+                            <div>{username.name}</div>
+                            {username.admin_notes && (
+                              <p className="max-w-xs whitespace-normal text-xs font-normal text-gray-500">
+                                {truncate(username.admin_notes, 80)}
+                              </p>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 text-sm text-gray-500">
+                          {username.tags.length > 0 ? (
+                            <div className="flex max-w-xs flex-wrap gap-1">
+                              {username.tags.map((tag) => (
+                                <span
+                                  key={`${username.id}-${tag}`}
+                                  className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            <span className="text-xs italic text-gray-400">No tags</span>
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">
                           {truncate(username.pubkey, 16)}

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows all metadata and provides actions like assign, revoke, burn
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { searchUsernames, assignUsername, revokeUsername } from '../api/client'
+import { getUsernameDetail, updateUsernameMetadata, assignUsername, revokeUsername } from '../api/client'
 import type { Username } from '../types'
 import StatusBadge from '../components/StatusBadge'
 
@@ -22,6 +22,12 @@ export default function UsernameDetail() {
   const [showRevoke, setShowRevoke] = useState(false)
   const [burnOnRevoke, setBurnOnRevoke] = useState(false)
   const [revokeLoading, setRevokeLoading] = useState(false)
+  const [draftNotes, setDraftNotes] = useState('')
+  const [draftTags, setDraftTags] = useState<string[]>([])
+  const [tagInput, setTagInput] = useState('')
+  const [saveLoading, setSaveLoading] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState<string | null>(null)
 
   useEffect(() => {
     loadUsername()
@@ -33,17 +39,58 @@ export default function UsernameDetail() {
     setError(null)
 
     try {
-      const result = await searchUsernames(name)
-      const found = result.results.find(u => u.name === name)
-      if (found) {
-        setUsername(found)
-      } else {
-        setError('Username not found')
-      }
+      const result = await getUsernameDetail(name)
+      setUsername(result.username)
+      setDraftNotes(result.username.admin_notes || '')
+      setDraftTags(result.username.tags || [])
+      setSaveError(null)
+      setSaveSuccess(null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load username')
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handleAddTag = () => {
+    const nextTag = tagInput.trim().replace(/\s+/g, ' ')
+    if (!nextTag) return
+
+    setDraftTags((currentTags) => {
+      const exists = currentTags.some((tag) => tag.toLowerCase() === nextTag.toLowerCase())
+      return exists ? currentTags : [...currentTags, nextTag]
+    })
+    setTagInput('')
+    setSaveSuccess(null)
+  }
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setDraftTags((currentTags) => currentTags.filter((tag) => tag !== tagToRemove))
+    setSaveSuccess(null)
+  }
+
+  const handleSaveMetadata = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!username) return
+
+    setSaveLoading(true)
+    setSaveError(null)
+    setSaveSuccess(null)
+
+    try {
+      const result = await updateUsernameMetadata(
+        username.name,
+        draftNotes.trim() ? draftNotes.trim() : null,
+        draftTags
+      )
+      setUsername(result.username)
+      setDraftNotes(result.username.admin_notes || '')
+      setDraftTags(result.username.tags || [])
+      setSaveSuccess('Internal tracking updated.')
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaveLoading(false)
     }
   }
 
@@ -133,9 +180,107 @@ export default function UsernameDetail() {
         <p className="mt-1 text-sm text-gray-600">
           {username.name}@divine.video
         </p>
+        {draftTags.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {draftTags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
-      {/* Details Card */}
+      <div className="bg-white shadow rounded-lg overflow-hidden mb-6">
+        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+          <h3 className="text-lg font-medium text-gray-900">Internal Tracking</h3>
+        </div>
+        <form onSubmit={handleSaveMetadata} className="px-6 py-4 space-y-5">
+          <div>
+            <label htmlFor="admin-notes" className="block text-sm font-medium text-gray-700">
+              Internal Notes
+            </label>
+            <textarea
+              id="admin-notes"
+              rows={5}
+              value={draftNotes}
+              onChange={(event) => {
+                setDraftNotes(event.target.value)
+                setSaveSuccess(null)
+              }}
+              placeholder="Add context for trust and safety, support, marketing, or outreach."
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="tag-input" className="block text-sm font-medium text-gray-700">
+              Tags
+            </label>
+            <div className="mt-1 flex gap-2">
+              <input
+                id="tag-input"
+                type="text"
+                value={tagInput}
+                onChange={(event) => setTagInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    handleAddTag()
+                  }
+                }}
+                placeholder="VIP, brand, creator, outreach..."
+                className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+              />
+              <button
+                type="button"
+                onClick={handleAddTag}
+                className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+              >
+                Add Tag
+              </button>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {draftTags.length > 0 ? (
+                draftTags.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => handleRemoveTag(tag)}
+                    className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100"
+                  >
+                    {tag}
+                    <span className="ml-2 text-blue-500">×</span>
+                  </button>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500">No internal tags yet.</p>
+              )}
+            </div>
+          </div>
+
+          {saveError && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">{saveError}</div>
+          )}
+          {saveSuccess && (
+            <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">{saveSuccess}</div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={saveLoading}
+              className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saveLoading ? 'Saving...' : 'Save Internal Tracking'}
+            </button>
+          </div>
+        </form>
+      </div>
+
       <div className="bg-white shadow rounded-lg overflow-hidden mb-6">
         <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
           <h3 className="text-lg font-medium text-gray-900">Details</h3>
@@ -194,13 +339,6 @@ export default function UsernameDetail() {
             <div>
               <p className="text-sm font-medium text-gray-500">Reserved Reason</p>
               <p className="mt-1 text-sm text-gray-900">{username.reserved_reason}</p>
-            </div>
-          )}
-
-          {username.admin_notes && (
-            <div>
-              <p className="text-sm font-medium text-gray-500">Admin Notes</p>
-              <p className="mt-1 text-sm text-gray-900">{username.admin_notes}</p>
             </div>
           )}
 

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,12 +1,15 @@
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
+export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
 
 export interface Username {
   id: number
   name: string
+  username_display?: string | null
+  username_canonical?: string | null
   pubkey: string | null
   email: string | null
   relays: string | null
-  status: 'active' | 'reserved' | 'revoked' | 'burned'
+  status: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
   recyclable: number
   created_at: number
   updated_at: number
@@ -16,6 +19,33 @@ export interface Username {
   admin_notes: string | null
   claim_source: ClaimSource
   created_by: string | null
+  tags: string[]
+}
+
+export interface UsernameStats {
+  totals: {
+    all: number
+    active: number
+    reserved: number
+    revoked: number
+    burned: number
+  }
+  metadata: {
+    with_notes: number
+    with_tags: number
+    untagged: number
+    vip: number
+  }
+  activity: {
+    claimed_7d: number
+    claimed_30d: number
+    updated_7d: number
+    updated_30d: number
+  }
+  top_tags: Array<{
+    tag: string
+    count: number
+  }>
 }
 
 export interface SearchResult {
@@ -32,6 +62,16 @@ export interface SearchResult {
 export interface ApiResponse {
   ok: boolean
   error?: string
+}
+
+export interface UsernameDetailResponse extends ApiResponse {
+  username: Username
+}
+
+export interface UsernameStatsResponse extends ApiResponse, UsernameStats {}
+
+export interface UsernameMetadataResponse extends ApiResponse {
+  username: Username
 }
 
 export interface ReserveResponse extends ApiResponse {

--- a/docs/superpowers/plans/2026-03-25-username-ops-metadata.md
+++ b/docs/superpowers/plans/2026-03-25-username-ops-metadata.md
@@ -1,0 +1,301 @@
+# Username Ops Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add internal notes, free-form tags, relevance-ranked search, sorting controls, and lightweight admin stats for username operations.
+
+**Architecture:** Keep `usernames` as the primary record and reuse `admin_notes` for the single internal note. Add a dedicated `username_tags` table plus backend helpers that aggregate tags into search/detail responses, then update the React admin UI to consume the richer API and expose stats, sorting, and metadata editing.
+
+**Tech Stack:** TypeScript, Hono, Cloudflare D1, Vitest, React 18, React Router, Vite, Tailwind CSS
+
+**Baseline note:** `npm run test:once` currently fails on pre-existing `tests/landing.spec.ts` because `@playwright/test` is not installed. Use targeted Vitest commands plus `admin-ui` build verification for this feature.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `migrations/0009_add_username_tags.sql` | Add `username_tags` table and indexes |
+| Modify | `src/db/queries.ts` | Add tag-aware query helpers, metadata update helper, stats helper, search ranking, and result shaping |
+| Modify | `src/db/queries.test.ts` | Cover tag replacement, detail fetch, stats, and ranked search behavior |
+| Modify | `src/routes/admin.ts` | Add detail, metadata, and stats endpoints; validate `sort` |
+| Modify | `src/routes/admin.test.ts` | Cover new admin endpoints and search validation |
+| Modify | `admin-ui/src/types/index.ts` | Add tags, stats, sort types, and detail response types |
+| Modify | `admin-ui/src/api/client.ts` | Add detail fetch, metadata save, stats fetch, and `sort` support |
+| Modify | `admin-ui/src/pages/Dashboard.tsx` | Add stats cards, sort control, tag display, and richer search behavior |
+| Modify | `admin-ui/src/pages/UsernameDetail.tsx` | Load dedicated detail endpoint and add note/tag editor |
+
+## Chunk 1: Backend data model and admin API
+
+### Task 1: Add failing tests for tags, detail fetch, stats, and ranked search
+
+**Files:**
+- Modify: `src/db/queries.test.ts`
+- Modify: `src/routes/admin.test.ts`
+
+- [ ] **Step 1: Write failing database query tests**
+
+Add tests that describe:
+
+- replacing a username’s tags normalizes and de-duplicates values
+- fetching a username by name returns its tags
+- stats include `with_notes`, `with_tags`, `untagged`, `vip`, and `top_tags`
+- ranked search prefers exact and prefix username matches over note-only matches
+
+- [ ] **Step 2: Write failing admin route tests**
+
+Add tests that describe:
+
+- `GET /admin/username/:name` returns one record with tags
+- `POST /admin/username/metadata` updates `admin_notes` and tags
+- `GET /admin/usernames/stats` returns aggregate counts
+- invalid `sort` values on search return `400`
+
+- [ ] **Step 3: Run the targeted tests to verify they fail for the right reason**
+
+Run: `npx vitest run src/db/queries.test.ts src/routes/admin.test.ts`
+
+Expected: FAIL with missing helper behavior and/or missing route support for tags, metadata, stats, or `sort`
+
+### Task 2: Add schema and query helpers
+
+**Files:**
+- Create: `migrations/0009_add_username_tags.sql`
+- Modify: `src/db/queries.ts`
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/0009_add_username_tags.sql` with:
+
+```sql
+CREATE TABLE IF NOT EXISTS username_tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username_id INTEGER NOT NULL,
+  tag_display TEXT NOT NULL,
+  tag_normalized TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  UNIQUE(username_id, tag_normalized),
+  FOREIGN KEY (username_id) REFERENCES usernames(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_username_tags_username_id
+  ON username_tags(username_id);
+
+CREATE INDEX IF NOT EXISTS idx_username_tags_tag_normalized
+  ON username_tags(tag_normalized);
+```
+
+- [ ] **Step 2: Extend the query types**
+
+In `src/db/queries.ts`, add:
+
+- `tags: string[]` to the shaped search/detail result type used by admin responses
+- `sort?: 'relevance' | 'newest' | 'oldest' | 'updated'` to `SearchParams`
+- a stats return type for the dashboard aggregates
+
+- [ ] **Step 3: Add tag normalization and replacement helpers**
+
+Implement helpers that:
+
+- normalize free-form tags
+- replace all tags for one username atomically
+- load tags for one or many usernames
+
+- [ ] **Step 4: Add username detail and stats helpers**
+
+Implement helpers roughly shaped like:
+
+```typescript
+getUsernameDetail(db, name)
+updateUsernameMetadata(db, { name, adminNotes, tags })
+getUsernameStats(db)
+```
+
+- [ ] **Step 5: Upgrade search ranking**
+
+Update `searchUsernames` to:
+
+- accept `sort`
+- match `admin_notes`
+- match tags via `EXISTS` or a joined subquery
+- return aggregated tags
+- rank by relevance when `sort` is `relevance` or omitted
+
+- [ ] **Step 6: Run the targeted tests to verify the query layer passes**
+
+Run: `npx vitest run src/db/queries.test.ts`
+
+Expected: PASS
+
+### Task 3: Add admin routes for detail, metadata, stats, and sort validation
+
+**Files:**
+- Modify: `src/routes/admin.ts`
+
+- [ ] **Step 1: Validate the `sort` query parameter**
+
+Allow only:
+
+- `relevance`
+- `newest`
+- `oldest`
+- `updated`
+
+- [ ] **Step 2: Add the detail endpoint**
+
+Implement:
+
+```typescript
+admin.get('/username/:name', async (c) => { ... })
+```
+
+Use the dedicated query helper and return `404` when no username exists.
+
+- [ ] **Step 3: Add the metadata update endpoint**
+
+Implement:
+
+```typescript
+admin.post('/username/metadata', async (c) => { ... })
+```
+
+Validate:
+
+- `name` is required
+- `tags` is an array when provided
+- `admin_notes` is a string or `null`
+
+- [ ] **Step 4: Add the stats endpoint**
+
+Implement:
+
+```typescript
+admin.get('/usernames/stats', async (c) => { ... })
+```
+
+- [ ] **Step 5: Run route and query tests**
+
+Run: `npx vitest run src/routes/admin.test.ts src/db/queries.test.ts`
+
+Expected: PASS
+
+## Chunk 2: Admin UI data layer and dashboard
+
+### Task 4: Add client and type support for tags, stats, detail, and metadata save
+
+**Files:**
+- Modify: `admin-ui/src/types/index.ts`
+- Modify: `admin-ui/src/api/client.ts`
+
+- [ ] **Step 1: Extend shared admin UI types**
+
+Add:
+
+- `tags: string[]` on `Username`
+- `SearchSort` union type
+- `UsernameStats` type
+- detail and metadata response types if needed
+
+- [ ] **Step 2: Extend the API client**
+
+Add functions roughly shaped like:
+
+```typescript
+searchUsernames(query, status, sort, page, limit)
+getUsernameDetail(name)
+updateUsernameMetadata(name, adminNotes, tags)
+getUsernameStats()
+```
+
+- [ ] **Step 3: Run a frontend typecheck/build to catch interface drift**
+
+Run: `npm run build`
+Workdir: `admin-ui`
+
+Expected: PASS
+
+### Task 5: Upgrade the dashboard with stats, sorting, and tags
+
+**Files:**
+- Modify: `admin-ui/src/pages/Dashboard.tsx`
+
+- [ ] **Step 1: Add failing UI behavior in code**
+
+Update the component to request stats and use the new search API shape:
+
+- load stats on page load
+- include `sort` in searches
+- render stats cards
+- render tag chips in the results table
+- default sort to `relevance`
+
+- [ ] **Step 2: Implement the minimal dashboard UI**
+
+Keep the existing layout patterns and add:
+
+- sort dropdown
+- compact stat cards
+- tags column or inline tag chips
+- note/tag-aware empty state messaging
+
+- [ ] **Step 3: Build the admin UI**
+
+Run: `npm run build`
+Workdir: `admin-ui`
+
+Expected: PASS
+
+## Chunk 3: Username detail metadata editing
+
+### Task 6: Switch detail loading to the dedicated endpoint and add note/tag editing
+
+**Files:**
+- Modify: `admin-ui/src/pages/UsernameDetail.tsx`
+
+- [ ] **Step 1: Add the new data flow**
+
+Replace the current `searchUsernames(name)` detail lookup with the dedicated detail API.
+
+- [ ] **Step 2: Add metadata editing UI**
+
+Add:
+
+- a textarea bound to `admin_notes`
+- a simple free-form tag editor with add/remove chips
+- save button and loading/error/success states
+
+- [ ] **Step 3: Preserve existing actions**
+
+Keep assign/revoke flows working after metadata edits and after reload.
+
+- [ ] **Step 4: Build the admin UI again**
+
+Run: `npm run build`
+Workdir: `admin-ui`
+
+Expected: PASS
+
+### Task 7: Final targeted verification
+
+**Files:**
+- Verify: `src/db/queries.test.ts`
+- Verify: `src/routes/admin.test.ts`
+- Verify: `admin-ui`
+
+- [ ] **Step 1: Run targeted backend tests**
+
+Run: `npx vitest run src/db/queries.test.ts src/routes/admin.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 2: Run the admin UI build**
+
+Run: `npm run build`
+Workdir: `admin-ui`
+
+Expected: PASS
+
+- [ ] **Step 3: Record the known baseline caveat**
+
+Note that full `npm run test:once` still includes the pre-existing `tests/landing.spec.ts` dependency issue unless `@playwright/test` is installed or that suite is split out of the Vitest run.

--- a/docs/superpowers/specs/2026-03-25-username-ops-metadata-design.md
+++ b/docs/superpowers/specs/2026-03-25-username-ops-metadata-design.md
@@ -1,0 +1,236 @@
+# Username Ops Metadata Design
+
+**Date:** 2026-03-25
+**Status:** Approved for implementation
+
+## Overview
+
+Extend the admin experience from a basic username registry into an internal operations surface for trust and safety, support, marketing, and outreach. The system should let internal teams keep private notes on each username, apply free-form tags such as `vip`, `brand`, or `impersonation-risk`, search that metadata effectively, and sort results by operational relevance instead of only creation date.
+
+## Goals
+
+- Let internal staff store one internal note per username for shared context.
+- Let internal staff add and remove free-form tags per username.
+- Improve search so queries match usernames, pubkeys, emails, tags, and notes.
+- Improve result ordering so exact and prefix username matches rank above weaker matches.
+- Add lightweight admin stats that summarize the state of the namespace and the tagging workflow.
+- Preserve the existing reserve, assign, revoke, and burn flows.
+
+## Non-Goals
+
+- No public-facing notes or tags.
+- No file attachments, uploads, or per-note documents.
+- No full case-management system with timelines, assignees, or audit history.
+- No locked taxonomy for tags in v1.
+
+## Data Model
+
+Use the existing `usernames.admin_notes` column as the single internal note field. Do not add a second note column.
+
+Add a new `username_tags` table for free-form tags:
+
+```sql
+CREATE TABLE username_tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username_id INTEGER NOT NULL,
+  tag_display TEXT NOT NULL,
+  tag_normalized TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  UNIQUE(username_id, tag_normalized),
+  FOREIGN KEY (username_id) REFERENCES usernames(id) ON DELETE CASCADE
+);
+```
+
+Add indexes for:
+
+- `username_tags.username_id`
+- `username_tags.tag_normalized`
+- `usernames.updated_at` if search/result sorting shows it is missing
+
+Normalization rules:
+
+- Trim leading and trailing whitespace
+- Collapse internal runs of whitespace to a single space
+- Lowercase `tag_normalized`
+- Preserve the first-entered display casing in `tag_display`
+- Ignore empty tags
+- De-duplicate per username by normalized value
+
+## Backend API
+
+Keep the existing admin API surface and add focused endpoints for metadata-driven workflows:
+
+### Existing Search Endpoint
+
+`GET /api/admin/usernames/search`
+
+Extend query parameters:
+
+- `q`: search string, still optional as an empty string
+- `status`: existing filter
+- `sort`: one of `relevance`, `newest`, `oldest`, `updated`
+- `tag`: optional exact tag filter by normalized value
+- `has_notes`: optional boolean filter
+
+Search results should include:
+
+- existing username fields
+- `tags: string[]`
+- `match_reason?: string` for debugging or UI hints if cheap to include
+
+### Username Detail Endpoint
+
+`GET /api/admin/username/:name`
+
+Return one canonical username record plus its tags. This replaces the current client behavior that calls the generic search endpoint and then guesses which row is the exact detail record.
+
+### Username Metadata Update Endpoint
+
+`POST /api/admin/username/metadata`
+
+Request body:
+
+```json
+{
+  "name": "alice",
+  "admin_notes": "Creator outreach in progress.",
+  "tags": ["VIP", "creator", "outreach"]
+}
+```
+
+Behavior:
+
+- validate canonical username exists
+- overwrite the note field
+- replace the tag set atomically
+- bump `updated_at`
+- return the updated record and normalized tags
+
+### Username Stats Endpoint
+
+`GET /api/admin/usernames/stats`
+
+Return lightweight aggregates only. No event warehouse or time-series service in v1.
+
+Recommended response shape:
+
+```json
+{
+  "ok": true,
+  "totals": {
+    "all": 0,
+    "active": 0,
+    "reserved": 0,
+    "revoked": 0,
+    "burned": 0
+  },
+  "metadata": {
+    "with_notes": 0,
+    "with_tags": 0,
+    "untagged": 0,
+    "vip": 0
+  },
+  "activity": {
+    "claimed_7d": 0,
+    "claimed_30d": 0,
+    "updated_7d": 0,
+    "updated_30d": 0
+  },
+  "top_tags": [
+    { "tag": "vip", "count": 0 }
+  ]
+}
+```
+
+## Search and Ranking
+
+The current `LIKE` search ordered by `created_at DESC` is not enough once tags and notes exist. Replace it with weighted ranking.
+
+Recommended precedence:
+
+1. exact canonical username match
+2. exact display username match
+3. username prefix match
+4. username substring match
+5. exact tag match
+6. tag substring match
+7. exact email or pubkey match
+8. pubkey or email substring match
+9. note substring match
+
+Within the same rank:
+
+- `sort=relevance`: highest relevance, then `updated_at DESC`
+- `sort=updated`: `updated_at DESC`
+- `sort=newest`: `created_at DESC`
+- `sort=oldest`: `created_at ASC`
+
+Implementation guidance:
+
+- keep search SQL in `src/db/queries.ts`
+- aggregate tags into each result row
+- use `EXISTS` or joined subqueries for tag matches to avoid duplicate username rows
+- escape `LIKE` patterns as the current code already does
+
+## Admin UI
+
+### Dashboard
+
+Turn the dashboard into an operations-oriented search screen:
+
+- keep the existing search box and status filter
+- add a sort dropdown with `Best match`, `Recently updated`, `Newest`, `Oldest`
+- show stats cards above the results table
+- display tag chips per row
+- keep CSV export available
+- make clicking a row open the dedicated detail route
+
+### Username Detail
+
+Upgrade the detail page into the editing surface for internal metadata:
+
+- load by dedicated detail endpoint
+- show tags near the page title
+- add a notes textarea for internal context
+- add a free-form tag editor that supports add/remove chips
+- keep assign/revoke actions intact
+
+Notes and tags remain internal-only and should never be included in public endpoints.
+
+## Stats
+
+The first stats slice should serve T&S, support, marketing, and outreach without turning into a separate analytics system.
+
+Recommended metrics:
+
+- total usernames
+- active, reserved, revoked, burned counts
+- names with notes
+- names with tags
+- untagged names
+- `vip` tag count
+- recent claims in 7 and 30 days
+- recent updates in 7 and 30 days
+- top tags
+
+## Error Handling
+
+- Missing usernames should return `404` on the detail and metadata endpoints.
+- Invalid tags should return `400` only for malformed payloads, not for ordinary free-form values.
+- Empty tag arrays are valid and mean “remove all tags”.
+- Search should continue to allow empty queries for browse mode.
+- Stats should degrade to zeros if optional metadata is absent.
+
+## Testing Strategy
+
+- Add migration coverage by verifying query helpers and route handlers against tagged data in unit tests.
+- Extend database query tests for tag replacement, detail fetch, stats, and relevance ordering.
+- Extend admin route tests for new detail, metadata, stats, and search `sort` validation.
+- Build the admin UI after frontend changes.
+- Feature verification can stay targeted because the repo already has one unrelated Playwright dependency gap in `tests/landing.spec.ts`.
+
+## Rollout Notes
+
+- Apply the new migration before deploying the updated worker.
+- The feature is backward-compatible for existing usernames with no tags or notes.
+- Existing `admin_notes` content should appear unchanged after rollout.

--- a/migrations/0009_add_username_tags.sql
+++ b/migrations/0009_add_username_tags.sql
@@ -1,0 +1,18 @@
+-- ABOUTME: Adds free-form internal tags for usernames in the admin UI
+-- ABOUTME: Supports note/tag search, sorting, and stats without changing public APIs
+
+CREATE TABLE IF NOT EXISTS username_tags (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username_id INTEGER NOT NULL,
+  tag_display TEXT NOT NULL,
+  tag_normalized TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  UNIQUE(username_id, tag_normalized),
+  FOREIGN KEY (username_id) REFERENCES usernames(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_username_tags_username_id
+  ON username_tags(username_id);
+
+CREATE INDEX IF NOT EXISTS idx_username_tags_tag_normalized
+  ON username_tags(tag_normalized);

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -22,7 +22,7 @@ function createMockDB() {
       claimed_at: 1700000000,
       revoked_at: null,
       reserved_reason: null,
-      admin_notes: null,
+      admin_notes: 'VIP creator account',
       reservation_email: null,
       confirmation_token: null,
       reservation_expires_at: null,
@@ -77,6 +77,59 @@ function createMockDB() {
       created_by: null
     }
   ]
+  const mockTags = [
+    { username_id: 1, tag_display: 'VIP', tag_normalized: 'vip' },
+    { username_id: 1, tag_display: 'creator', tag_normalized: 'creator' },
+    { username_id: 3, tag_display: 'support', tag_normalized: 'support' }
+  ]
+
+  const filterUsernames = (sql: string, params: any[]) => {
+    let filtered = [...mockResults]
+    const normalizedSql = sql.replace(/\s+/g, ' ').toLowerCase()
+    const hasSearchPattern = sql.includes('LIKE')
+
+    if (hasSearchPattern) {
+      const searchPattern = params[0]
+      if (searchPattern && typeof searchPattern === 'string') {
+        const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '').toLowerCase()
+        if (searchTerm.length > 0) {
+          filtered = filtered.filter((u) => {
+            const tags = mockTags
+              .filter((tag) => tag.username_id === u.id)
+              .flatMap((tag) => [tag.tag_display, tag.tag_normalized])
+            const haystack = [
+              u.name,
+              u.username_display,
+              u.username_canonical,
+              u.pubkey,
+              u.email,
+              u.admin_notes,
+              ...tags
+            ]
+              .filter(Boolean)
+              .map((value) => String(value).toLowerCase())
+
+            return haystack.some((value) => value.includes(searchTerm))
+          })
+        }
+      }
+    }
+
+    const statusParam = params.find((param) => ['active', 'reserved', 'revoked', 'burned', 'recovered'].includes(param))
+    if (typeof statusParam === 'string' && statusParam !== 'recovered') {
+      filtered = filtered.filter((u) => u.status === statusParam)
+    }
+
+    if (normalizedSql.includes('order by created_at asc')) {
+      filtered.sort((a, b) => a.created_at - b.created_at)
+    } else if (normalizedSql.includes('order by updated_at desc')) {
+      filtered.sort((a, b) => b.updated_at - a.updated_at || b.created_at - a.created_at)
+    } else {
+      filtered.sort((a, b) => b.created_at - a.created_at)
+    }
+
+    return filtered
+  }
 
   return {
     prepare: (sql: string) => {
@@ -87,92 +140,28 @@ function createMockDB() {
           boundParams = params
           return {
             first: async () => {
+              if (sql.includes('FROM username_tags') && !sql.includes('FROM usernames')) {
+                return { count: 0 }
+              }
+
               // Mock count query
               if (sql.includes('COUNT(*)')) {
-                // Filter based on bound params
-                let filtered = [...mockResults]
-                
-                // Check if WHERE clause uses LIKE patterns (has search query)
-                // If WHERE clause is "1=1", there's no search pattern
-                const hasSearchPattern = sql.includes('LIKE')
-                
-                if (hasSearchPattern) {
-                  // When there's a LIKE pattern, first 5 params are search patterns (all same value)
-                  // name, username_display, username_canonical, pubkey, email
-                  const searchPattern = boundParams[0]
-                  if (searchPattern && typeof searchPattern === 'string') {
-                    // Remove LIKE wildcards and escape characters to get the actual search term
-                    const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '')
-                    if (searchTerm.length > 0) {
-                      filtered = mockResults.filter(u =>
-                        (u.name && u.name.includes(searchTerm)) ||
-                        (u.username_display && u.username_display.includes(searchTerm)) ||
-                        (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
-                        (u.pubkey && u.pubkey.includes(searchTerm)) ||
-                        (u.email && u.email.includes(searchTerm))
-                      )
-                    }
-                  }
-                  
-                  // Status is at index 5 if search pattern exists (but only if it's not limit/offset)
-                  // Limit and offset are always the last 2 params, so status would be at index 5
-                  // only if boundParams.length > 7 (5 patterns, status, limit, offset)
-                  if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
-                    filtered = filtered.filter(u => u.status === boundParams[5])
-                  }
-                } else {
-                  // No search pattern - check for status filter
-                  // If WHERE is "1=1", no params. If WHERE is "status = ?", param is at index 0
-                  if (sql.includes('status = ?') && boundParams.length > 0 && boundParams[0]) {
-                    filtered = filtered.filter(u => u.status === boundParams[0])
-                  }
-                  // If WHERE is "1=1", no filtering needed - return all
-                }
-
-                return { count: filtered.length }
+                return { count: filterUsernames(sql, boundParams).length }
               }
               return null
             },
             all: async () => {
-              // Mock search query
-              let filtered = [...mockResults]
-              
-              // Check if WHERE clause uses LIKE patterns (has search query)
-              const hasSearchPattern = sql.includes('LIKE')
-              
-              if (hasSearchPattern) {
-                // When there's a LIKE pattern, first 5 params are search patterns (all same value)
-                // name, username_display, username_canonical, pubkey, email
-                // But limit and offset are always last two, so we need to exclude them
-                const searchPattern = boundParams[0]
-                if (searchPattern && typeof searchPattern === 'string') {
-                  // Remove LIKE wildcards and escape characters to get the actual search term
-                  const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '')
-                  if (searchTerm.length > 0) {
-                    filtered = mockResults.filter(u =>
-                      (u.name && u.name.includes(searchTerm)) ||
-                      (u.username_display && u.username_display.includes(searchTerm)) ||
-                      (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
-                      (u.pubkey && u.pubkey.includes(searchTerm)) ||
-                      (u.email && u.email.includes(searchTerm))
-                    )
-                  }
+              if (sql.includes('FROM username_tags') && !sql.includes('FROM usernames')) {
+                const requestedIds = boundParams.filter((param) => typeof param === 'number')
+                return {
+                  results: mockTags
+                    .filter((tag) => requestedIds.length === 0 || requestedIds.includes(tag.username_id))
+                    .map((tag) => ({ username_id: tag.username_id, tag_display: tag.tag_display }))
                 }
-                
-                // Status is at index 5 if search pattern exists (but only if it's not limit/offset)
-                // Limit and offset are always the last 2 params, so status would be at index 5
-                // only if boundParams.length > 7 (5 patterns, status, limit, offset)
-                if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
-                  filtered = filtered.filter(u => u.status === boundParams[5])
-                }
-              } else {
-                // No search pattern - check for status filter
-                // If WHERE is "1=1", no params. If WHERE is "status = ?", param is at index 0
-                if (sql.includes('status = ?') && boundParams.length > 0 && boundParams[0]) {
-                  filtered = filtered.filter(u => u.status === boundParams[0])
-                }
-                // If WHERE is "1=1", no filtering needed - return all
               }
+
+              // Mock search query
+              const filtered = filterUsernames(sql, boundParams)
 
               // Apply pagination
               // Limit and offset are always the last two params
@@ -180,9 +169,7 @@ function createMockDB() {
               const offset = boundParams[boundParams.length - 1] || 0
 
               return {
-                results: filtered
-                  .sort((a, b) => b.created_at - a.created_at)
-                  .slice(offset, offset + limit)
+                results: filtered.slice(offset, offset + limit)
               }
             }
           }
@@ -224,6 +211,16 @@ describe('searchUsernames', () => {
     expect(result.results[0].email).toBe('bob@example.com')
   })
 
+  it('should search by internal notes', async () => {
+    const db = createMockDB()
+    const params = { query: 'VIP' } as SearchParams
+
+    const result = await searchUsernames(db, params)
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].name).toBe('alice')
+  })
+
   it('should filter by status', async () => {
     const db = createMockDB()
     const params: SearchParams = { query: '', status: 'active' }
@@ -251,6 +248,15 @@ describe('searchUsernames', () => {
 
     expect(result.pagination.page).toBe(2)
     expect(result.pagination.limit).toBe(1)
+  })
+
+  it('should support oldest-first sorting', async () => {
+    const db = createMockDB()
+    const params = { query: '', sort: 'oldest' } as SearchParams & { sort: 'oldest' }
+
+    const result = await searchUsernames(db, params)
+
+    expect(result.results.map((username) => username.name)).toEqual(['alice', 'bob', 'charlie'])
   })
 
   it('should calculate total pages correctly', async () => {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Provides type-safe D1 database operations
 
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
+export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
 
 export interface Username {
   id: number
@@ -27,6 +28,11 @@ export interface Username {
   created_by: string | null
   atproto_did: string | null
   atproto_state: 'pending' | 'ready' | 'failed' | 'disabled' | null
+  tags?: string[]
+}
+
+export interface UsernameWithTags extends Username {
+  tags: string[]
 }
 
 export interface ReservationToken {
@@ -42,18 +48,42 @@ export interface ReservationToken {
 export interface SearchParams {
   query: string
   status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
+  sort?: SearchSort
   page?: number
   limit?: number
 }
 
 export interface SearchResult {
-  results: Username[]
+  results: UsernameWithTags[]
   pagination: {
     page: number
     limit: number
     total: number
     total_pages: number
   }
+}
+
+export interface UsernameStats {
+  totals: {
+    all: number
+    active: number
+    reserved: number
+    revoked: number
+    burned: number
+  }
+  metadata: {
+    with_notes: number
+    with_tags: number
+    untagged: number
+    vip: number
+  }
+  activity: {
+    claimed_7d: number
+    claimed_30d: number
+    updated_7d: number
+    updated_30d: number
+  }
+  top_tags: Array<{ tag: string; count: number }>
 }
 
 export async function isReservedWord(
@@ -89,6 +119,213 @@ export async function getUsernameByPubkey(
   ).bind(pubkey, 'active').first<Username>()
 
   return result
+}
+
+function normalizeTag(tag: string): { display: string; normalized: string } | null {
+  const display = tag.trim().replace(/\s+/g, ' ')
+  if (!display) {
+    return null
+  }
+
+  return {
+    display,
+    normalized: display.toLowerCase()
+  }
+}
+
+function normalizeTags(tags: string[]): Array<{ display: string; normalized: string }> {
+  const deduped = new Map<string, { display: string; normalized: string }>()
+
+  for (const tag of tags) {
+    if (typeof tag !== 'string') {
+      continue
+    }
+
+    const normalizedTag = normalizeTag(tag)
+    if (!normalizedTag) {
+      continue
+    }
+
+    if (!deduped.has(normalizedTag.normalized)) {
+      deduped.set(normalizedTag.normalized, normalizedTag)
+    }
+  }
+
+  return Array.from(deduped.values())
+}
+
+async function getTagsByUsernameIds(
+  db: D1Database,
+  usernameIds: number[]
+): Promise<Map<number, string[]>> {
+  const tagsByUsernameId = new Map<number, string[]>()
+
+  if (usernameIds.length === 0) {
+    return tagsByUsernameId
+  }
+
+  const placeholders = usernameIds.map(() => '?').join(', ')
+  const result = await db.prepare(
+    `SELECT username_id, tag_display
+     FROM username_tags
+     WHERE username_id IN (${placeholders})
+     ORDER BY tag_normalized ASC, tag_display ASC`
+  ).bind(...usernameIds).all<{ username_id: number; tag_display: string }>()
+
+  for (const row of result.results) {
+    const tags = tagsByUsernameId.get(row.username_id) || []
+    tags.push(row.tag_display)
+    tagsByUsernameId.set(row.username_id, tags)
+  }
+
+  return tagsByUsernameId
+}
+
+async function attachTags(
+  db: D1Database,
+  usernames: Username[]
+): Promise<UsernameWithTags[]> {
+  const tagsByUsernameId = await getTagsByUsernameIds(db, usernames.map((username) => username.id))
+
+  return usernames.map((username) => ({
+    ...username,
+    tags: tagsByUsernameId.get(username.id) || []
+  }))
+}
+
+async function countQuery(
+  db: D1Database,
+  sql: string,
+  ...params: unknown[]
+): Promise<number> {
+  const result = await db.prepare(sql).bind(...params).first<{ count: number }>()
+  return result?.count || 0
+}
+
+export async function getUsernameDetail(
+  db: D1Database,
+  name: string
+): Promise<UsernameWithTags | null> {
+  const username = await getUsernameByName(db, name)
+  if (!username) {
+    return null
+  }
+
+  const [withTags] = await attachTags(db, [username])
+  return withTags || null
+}
+
+export async function updateUsernameMetadata(
+  db: D1Database,
+  params: {
+    name: string
+    adminNotes: string | null
+    tags: string[]
+  }
+): Promise<UsernameWithTags | null> {
+  const username = await getUsernameByName(db, params.name)
+  if (!username) {
+    return null
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  const normalized = normalizeTags(params.tags)
+
+  await db.prepare(
+    `UPDATE usernames
+     SET admin_notes = ?,
+         updated_at = ?
+     WHERE id = ?`
+  ).bind(params.adminNotes, now, username.id).run()
+
+  await db.prepare(
+    'DELETE FROM username_tags WHERE username_id = ?'
+  ).bind(username.id).run()
+
+  for (const tag of normalized) {
+    await db.prepare(
+      `INSERT INTO username_tags (username_id, tag_display, tag_normalized, created_at)
+       VALUES (?, ?, ?, ?)`
+    ).bind(username.id, tag.display, tag.normalized, now).run()
+  }
+
+  return getUsernameDetail(db, username.username_canonical || username.name)
+}
+
+export async function getUsernameStats(
+  db: D1Database
+): Promise<UsernameStats> {
+  const now = Math.floor(Date.now() / 1000)
+  const sevenDaysAgo = now - (7 * 24 * 60 * 60)
+  const thirtyDaysAgo = now - (30 * 24 * 60 * 60)
+
+  const [
+    all,
+    active,
+    reserved,
+    revoked,
+    burned,
+    withNotes,
+    withTags,
+    untagged,
+    vip,
+    claimed7d,
+    claimed30d,
+    updated7d,
+    updated30d,
+    topTagsResult,
+  ] = await Promise.all([
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE status = ?`, 'active'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE status = ?`, 'reserved'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE status = ?`, 'revoked'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE status = ?`, 'burned'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE admin_notes IS NOT NULL AND TRIM(admin_notes) != ''`),
+    countQuery(db, `SELECT COUNT(DISTINCT username_id) AS count FROM username_tags`),
+    countQuery(
+      db,
+      `SELECT COUNT(*) AS count
+       FROM usernames
+       WHERE NOT EXISTS (
+         SELECT 1 FROM username_tags WHERE username_tags.username_id = usernames.id
+       )`
+    ),
+    countQuery(db, `SELECT COUNT(DISTINCT username_id) AS count FROM username_tags WHERE tag_normalized = ?`, 'vip'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?`, sevenDaysAgo),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?`, thirtyDaysAgo),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?`, sevenDaysAgo),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?`, thirtyDaysAgo),
+    db.prepare(
+      `SELECT tag_normalized AS tag, COUNT(*) AS count
+       FROM username_tags
+       GROUP BY tag_normalized
+       ORDER BY count DESC, tag_normalized ASC
+       LIMIT 10`
+    ).bind().all<{ tag: string; count: number }>(),
+  ])
+
+  return {
+    totals: {
+      all,
+      active,
+      reserved,
+      revoked,
+      burned,
+    },
+    metadata: {
+      with_notes: withNotes,
+      with_tags: withTags,
+      untagged,
+      vip,
+    },
+    activity: {
+      claimed_7d: claimed7d,
+      claimed_30d: claimed30d,
+      updated_7d: updated7d,
+      updated_30d: updated30d,
+    },
+    top_tags: topTagsResult.results,
+  }
 }
 
 export async function claimUsername(
@@ -225,43 +462,55 @@ export async function searchUsernames(
   db: D1Database,
   params: SearchParams
 ): Promise<SearchResult> {
-  const { query, status, page = 1, limit = 50 } = params
+  const { query, status, sort = 'relevance', page = 1, limit = 50 } = params
   const offset = (page - 1) * limit
+  const whereParts: string[] = []
+  const queryParams: unknown[] = []
+  const trimmedQuery = query.trim()
+  const normalizedQuery = trimmedQuery.toLowerCase()
 
-  // Build WHERE clause
-  let whereClause = ''
-  const queryParams: any[] = []
-
-  // If query is empty, don't filter by name/pubkey/email
-  if (query && query.length > 0) {
-    const escapedQuery = escapeLikePattern(query)
+  if (trimmedQuery) {
+    const escapedQuery = escapeLikePattern(normalizedQuery)
     const searchPattern = `%${escapedQuery}%`
-    whereClause = `(name LIKE ? OR username_display LIKE ? OR username_canonical LIKE ? OR pubkey LIKE ? OR email LIKE ?)`
-    queryParams.push(searchPattern, searchPattern, searchPattern, searchPattern, searchPattern)
+    whereParts.push(`(
+      LOWER(COALESCE(name, '')) LIKE ? ESCAPE '\\'
+      OR LOWER(COALESCE(username_display, '')) LIKE ? ESCAPE '\\'
+      OR LOWER(COALESCE(username_canonical, '')) LIKE ? ESCAPE '\\'
+      OR LOWER(COALESCE(pubkey, '')) LIKE ? ESCAPE '\\'
+      OR LOWER(COALESCE(email, '')) LIKE ? ESCAPE '\\'
+      OR LOWER(COALESCE(admin_notes, '')) LIKE ? ESCAPE '\\'
+      OR EXISTS (
+        SELECT 1 FROM username_tags ut
+        WHERE ut.username_id = usernames.id
+          AND (
+            LOWER(COALESCE(ut.tag_display, '')) LIKE ? ESCAPE '\\'
+            OR LOWER(COALESCE(ut.tag_normalized, '')) LIKE ? ESCAPE '\\'
+          )
+      )
+    )`)
+    queryParams.push(
+      searchPattern,
+      searchPattern,
+      searchPattern,
+      searchPattern,
+      searchPattern,
+      searchPattern,
+      searchPattern,
+      searchPattern
+    )
   }
 
   // Add status filter if provided
   if (status === 'recovered') {
     // "Recovered" = Vine accounts that have been claimed (active with pubkey, originally from Vine import)
     const recoveredCondition = `status = 'active' AND pubkey IS NOT NULL AND reserved_reason LIKE '%Vine%'`
-    if (whereClause) {
-      whereClause += ` AND ${recoveredCondition}`
-    } else {
-      whereClause = recoveredCondition
-    }
+    whereParts.push(recoveredCondition)
   } else if (status) {
-    if (whereClause) {
-      whereClause += ` AND status = ?`
-    } else {
-      whereClause = `status = ?`
-    }
+    whereParts.push('status = ?')
     queryParams.push(status)
   }
 
-  // If no filters, use WHERE 1=1 to get all results
-  if (!whereClause) {
-    whereClause = '1=1'
-  }
+  const whereClause = whereParts.length > 0 ? whereParts.join(' AND ') : '1=1'
 
   // Get total count
   const countResult = await db.prepare(
@@ -271,16 +520,66 @@ export async function searchUsernames(
   const total = countResult?.count || 0
   const totalPages = Math.ceil(total / limit)
 
+  let orderClause = 'created_at DESC'
+  const orderParams: unknown[] = []
+
+  if (sort === 'oldest') {
+    orderClause = 'created_at ASC'
+  } else if (sort === 'updated') {
+    orderClause = 'updated_at DESC, created_at DESC'
+  } else if (sort === 'newest') {
+    orderClause = 'created_at DESC'
+  } else if (trimmedQuery) {
+    const escapedQuery = escapeLikePattern(normalizedQuery)
+    const prefixPattern = `${escapedQuery}%`
+    const containsPattern = `%${escapedQuery}%`
+    orderClause = `CASE
+      WHEN LOWER(COALESCE(username_canonical, '')) = ? THEN 0
+      WHEN LOWER(COALESCE(username_display, '')) = ? THEN 1
+      WHEN LOWER(COALESCE(username_canonical, '')) LIKE ? ESCAPE '\\' THEN 2
+      WHEN LOWER(COALESCE(username_display, '')) LIKE ? ESCAPE '\\' THEN 3
+      WHEN EXISTS (
+        SELECT 1 FROM username_tags ut
+        WHERE ut.username_id = usernames.id
+          AND LOWER(COALESCE(ut.tag_normalized, '')) = ?
+      ) THEN 4
+      WHEN EXISTS (
+        SELECT 1 FROM username_tags ut
+        WHERE ut.username_id = usernames.id
+          AND LOWER(COALESCE(ut.tag_normalized, '')) LIKE ? ESCAPE '\\'
+      ) THEN 5
+      WHEN LOWER(COALESCE(pubkey, '')) = ? OR LOWER(COALESCE(email, '')) = ? THEN 6
+      WHEN LOWER(COALESCE(pubkey, '')) LIKE ? ESCAPE '\\' OR LOWER(COALESCE(email, '')) LIKE ? ESCAPE '\\' THEN 7
+      WHEN LOWER(COALESCE(admin_notes, '')) LIKE ? ESCAPE '\\' THEN 8
+      ELSE 9
+    END, updated_at DESC, created_at DESC`
+    orderParams.push(
+      normalizedQuery,
+      normalizedQuery,
+      prefixPattern,
+      prefixPattern,
+      normalizedQuery,
+      containsPattern,
+      normalizedQuery,
+      normalizedQuery,
+      containsPattern,
+      containsPattern,
+      containsPattern
+    )
+  }
+
   // Get paginated results
   const results = await db.prepare(
     `SELECT * FROM usernames
      WHERE ${whereClause}
-     ORDER BY created_at DESC
+     ORDER BY ${orderClause}
      LIMIT ? OFFSET ?`
-  ).bind(...queryParams, limit, offset).all<Username>()
+  ).bind(...queryParams, ...orderParams, limit, offset).all<Username>()
+
+  const withTags = await attachTags(db, results.results)
 
   return {
-    results: results.results,
+    results: withTags,
     pagination: {
       page,
       limit,

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -32,6 +32,57 @@ function createMockDB() {
       admin_notes: null
     }
   ]
+  let mockTags = [
+    { username_id: 1, tag_display: 'VIP', tag_normalized: 'vip' }
+  ]
+
+  const filterUsernames = (sql: string, params: any[]) => {
+    let filtered = [...mockResults]
+    const normalizedSql = sql.replace(/\s+/g, ' ').toLowerCase()
+    const hasSearchPattern = sql.includes('LIKE')
+
+    if (hasSearchPattern) {
+      const searchPattern = params[0]
+      if (searchPattern && typeof searchPattern === 'string') {
+        const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '').toLowerCase()
+        if (searchTerm.length > 0) {
+          filtered = filtered.filter((u) => {
+            const tags = mockTags
+              .filter((tag) => tag.username_id === u.id)
+              .flatMap((tag) => [tag.tag_display, tag.tag_normalized])
+            const haystack = [
+              u.name,
+              u.username_display,
+              u.username_canonical,
+              u.pubkey,
+              u.email,
+              u.admin_notes,
+              ...tags
+            ]
+              .filter(Boolean)
+              .map((value) => String(value).toLowerCase())
+
+            return haystack.some((value) => value.includes(searchTerm))
+          })
+        }
+      }
+    }
+
+    const statusParam = params.find((param) => ['active', 'reserved', 'revoked', 'burned', 'recovered'].includes(param))
+    if (typeof statusParam === 'string' && statusParam !== 'recovered') {
+      filtered = filtered.filter((u) => u.status === statusParam)
+    }
+
+    if (normalizedSql.includes('order by created_at asc')) {
+      filtered.sort((a, b) => a.created_at - b.created_at)
+    } else if (normalizedSql.includes('order by updated_at desc')) {
+      filtered.sort((a, b) => b.updated_at - a.updated_at || b.created_at - a.created_at)
+    } else {
+      filtered.sort((a, b) => b.created_at - a.created_at)
+    }
+
+    return filtered
+  }
 
   return {
     prepare: (sql: string) => {
@@ -41,37 +92,46 @@ function createMockDB() {
           boundParams = params
           return {
             first: async () => {
-              if (sql.includes('COUNT(*)')) {
-                let filtered = [...mockResults]
-                const hasSearchPattern = sql.includes('LIKE')
-                
-                if (hasSearchPattern) {
-                  const searchPattern = boundParams[0]
-                  if (searchPattern && typeof searchPattern === 'string') {
-                    const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '')
-                    if (searchTerm.length > 0) {
-                      filtered = mockResults.filter(u =>
-                        (u.name && u.name.includes(searchTerm)) ||
-                        (u.username_display && u.username_display.includes(searchTerm)) ||
-                        (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
-                        (u.pubkey && u.pubkey.includes(searchTerm)) ||
-                        (u.email && u.email.includes(searchTerm))
-                      )
-                    }
-                  }
-                  
-                  // Status is at index 5 if search pattern exists
-                  if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
-                    filtered = filtered.filter(u => u.status === boundParams[5])
-                  }
-                } else {
-                  // No search pattern - check for status filter
-                  if (sql.includes('status = ?') && boundParams.length > 0 && boundParams[0]) {
-                    filtered = filtered.filter(u => u.status === boundParams[0])
+              if (sql.includes('COUNT(DISTINCT username_id)') && sql.includes('FROM username_tags')) {
+                if (sql.includes('tag_normalized = ?')) {
+                  return {
+                    count: new Set(
+                      mockTags
+                        .filter((tag) => tag.tag_normalized === boundParams[0])
+                        .map((tag) => tag.username_id)
+                    ).size
                   }
                 }
-                
-                return { count: filtered.length }
+
+                return { count: new Set(mockTags.map((tag) => tag.username_id)).size }
+              }
+
+              if (sql.includes('COUNT(*)') && sql.includes('FROM usernames')) {
+                if (sql.includes('admin_notes IS NOT NULL')) {
+                  return {
+                    count: mockResults.filter((u) => typeof u.admin_notes === 'string' && u.admin_notes.trim().length > 0).length
+                  }
+                }
+
+                if (sql.includes('NOT EXISTS')) {
+                  return {
+                    count: mockResults.filter((u) => !mockTags.some((tag) => tag.username_id === u.id)).length
+                  }
+                }
+
+                if (sql.includes('claimed_at IS NOT NULL AND claimed_at >= ?')) {
+                  return {
+                    count: mockResults.filter((u) => typeof u.claimed_at === 'number' && u.claimed_at >= boundParams[0]).length
+                  }
+                }
+
+                if (sql.includes('updated_at >= ?')) {
+                  return {
+                    count: mockResults.filter((u) => u.updated_at >= boundParams[0]).length
+                  }
+                }
+
+                return { count: filterUsernames(sql, boundParams).length }
               }
               
               // Check for existing username lookup
@@ -95,47 +155,61 @@ function createMockDB() {
               if (sql.includes('reserved_words')) {
                 return { results: [] }
               }
-              
-              let filtered = [...mockResults]
-              const hasSearchPattern = sql.includes('LIKE')
-              
-              if (hasSearchPattern) {
-                const searchPattern = boundParams[0]
-                if (searchPattern && typeof searchPattern === 'string') {
-                  const searchTerm = searchPattern.replace(/%/g, '').replace(/\\/g, '')
-                  if (searchTerm.length > 0) {
-                    filtered = mockResults.filter(u =>
-                      (u.name && u.name.includes(searchTerm)) ||
-                      (u.username_display && u.username_display.includes(searchTerm)) ||
-                      (u.username_canonical && u.username_canonical.includes(searchTerm)) ||
-                      (u.pubkey && u.pubkey.includes(searchTerm)) ||
-                      (u.email && u.email.includes(searchTerm))
-                    )
-                  }
+
+              if (sql.includes('FROM username_tags') && sql.includes('GROUP BY tag_normalized')) {
+                const counts = new Map<string, number>()
+                for (const tag of mockTags) {
+                  counts.set(tag.tag_normalized, (counts.get(tag.tag_normalized) || 0) + 1)
                 }
-                
-                // Status is at index 5 if search pattern exists
-                if (boundParams.length > 7 && typeof boundParams[5] === 'string') {
-                  filtered = filtered.filter(u => u.status === boundParams[5])
-                }
-              } else {
-                // No search pattern - check for status filter
-                if (sql.includes('status = ?') && boundParams.length > 0 && boundParams[0]) {
-                  filtered = filtered.filter(u => u.status === boundParams[0])
+
+                return {
+                  results: Array.from(counts.entries()).map(([tag, count]) => ({ tag, count }))
                 }
               }
-              
+
+              if (sql.includes('FROM username_tags') && !sql.includes('FROM usernames')) {
+                const requestedIds = boundParams.filter((param) => typeof param === 'number')
+                return {
+                  results: mockTags
+                    .filter((tag) => requestedIds.length === 0 || requestedIds.includes(tag.username_id))
+                    .map((tag) => ({ username_id: tag.username_id, tag_display: tag.tag_display }))
+                }
+              }
+
+              const filtered = filterUsernames(sql, boundParams)
+
               // Apply pagination
               const limit = boundParams[boundParams.length - 2] || 50
               const offset = boundParams[boundParams.length - 1] || 0
               
               return {
-                results: filtered
-                  .sort((a, b) => b.created_at - a.created_at)
-                  .slice(offset, offset + limit)
+                results: filtered.slice(offset, offset + limit)
               }
             },
             run: async () => {
+              if (sql.includes('UPDATE usernames') && sql.includes('admin_notes = ?')) {
+                const [adminNotes, updatedAt, id] = boundParams
+                const username = mockResults.find((result) => result.id === id)
+                if (username) {
+                  username.admin_notes = adminNotes
+                  username.updated_at = updatedAt
+                }
+              }
+
+              if (sql.includes('DELETE FROM username_tags')) {
+                const usernameId = boundParams[0]
+                mockTags = mockTags.filter((tag) => tag.username_id !== usernameId)
+              }
+
+              if (sql.includes('INSERT INTO username_tags')) {
+                const [usernameId, tagDisplay, tagNormalized] = boundParams
+                mockTags.push({
+                  username_id: usernameId,
+                  tag_display: tagDisplay,
+                  tag_normalized: tagNormalized
+                })
+              }
+
               return { success: true }
             }
           }
@@ -227,6 +301,18 @@ describe('Admin Search Endpoint', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(false)
     expect(json.error).toContain('Invalid status parameter')
+  })
+
+  it('should return 400 if sort parameter is invalid', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/usernames/search?q=test&sort=weird')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {} })
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.ok).toBe(false)
+    expect(json.error).toContain('Invalid sort parameter')
   })
 
   it('should return 400 if page is negative', async () => {
@@ -350,6 +436,61 @@ describe('Admin Search Endpoint', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(true)
     expect(json.results).toBeDefined()
+  })
+})
+
+describe('Admin Username Metadata Endpoints', () => {
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    app.route('/admin', admin)
+    return app
+  }
+
+  it('should return username detail by exact name', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/testuser')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.username.name).toBe('testuser')
+  })
+
+  it('should update admin notes and tags for a username', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/metadata', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'testuser',
+        admin_notes: 'VIP creator account',
+        tags: ['VIP', 'creator']
+      })
+    })
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.username.admin_notes).toBe('VIP creator account')
+    expect(json.username.tags).toEqual(['VIP', 'creator'])
+  })
+
+  it('should return username stats', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/usernames/stats')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.totals).toBeDefined()
+    expect(json.metadata).toBeDefined()
+    expect(json.top_tags).toBeDefined()
   })
 })
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,7 +3,7 @@
 
 import { Hono } from 'hono'
 import { bech32 } from '@scure/base'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, getUsernameDetail, updateUsernameMetadata, getUsernameStats, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -72,6 +72,7 @@ admin.get('/usernames/search', async (c) => {
   try {
     const query = c.req.query('q')
     const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
+    const sort = c.req.query('sort') as SearchSort | undefined
     const pageStr = c.req.query('page') || '1'
     const limitStr = c.req.query('limit') || '50'
 
@@ -90,6 +91,11 @@ admin.get('/usernames/search', async (c) => {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
     }
 
+    const validSorts: SearchSort[] = ['relevance', 'newest', 'oldest', 'updated']
+    if (sort && !validSorts.includes(sort)) {
+      return c.json({ ok: false, error: 'Invalid sort parameter' }, 400)
+    }
+
     // Validate page parameter
     const page = parseInt(pageStr)
     if (isNaN(page) || page < 1) {
@@ -105,7 +111,7 @@ admin.get('/usernames/search', async (c) => {
     // Cap limit at 100
     const cappedLimit = Math.min(limit, 100)
 
-    const result = await searchUsernames(c.env.DB, { query, status, page, limit: cappedLimit })
+    const result = await searchUsernames(c.env.DB, { query, status, sort, page, limit: cappedLimit })
 
     return c.json({
       ok: true,
@@ -113,6 +119,74 @@ admin.get('/usernames/search', async (c) => {
     })
   } catch (error) {
     console.error('Search error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.get('/usernames/stats', async (c) => {
+  try {
+    const stats = await getUsernameStats(c.env.DB)
+    return c.json({
+      ok: true,
+      ...stats
+    })
+  } catch (error) {
+    console.error('Username stats error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.get('/username/:name', async (c) => {
+  try {
+    const name = c.req.param('name')
+    const username = await getUsernameDetail(c.env.DB, name)
+
+    if (!username) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    return c.json({ ok: true, username })
+  } catch (error) {
+    console.error('Username detail error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.post('/username/metadata', async (c) => {
+  try {
+    const body = await c.req.json<{ name?: string; admin_notes?: string | null; tags?: string[] }>()
+    const { name, admin_notes = null, tags = [] } = body
+
+    if (!name) {
+      return c.json({ ok: false, error: 'Name is required' }, 400)
+    }
+
+    if (admin_notes !== null && typeof admin_notes !== 'string') {
+      return c.json({ ok: false, error: 'admin_notes must be a string or null' }, 400)
+    }
+
+    if (!Array.isArray(tags) || tags.some((tag) => typeof tag !== 'string')) {
+      return c.json({ ok: false, error: 'tags must be an array of strings' }, 400)
+    }
+
+    const usernameData = validateUsername(name)
+    const username = await updateUsernameMetadata(c.env.DB, {
+      name: usernameData.canonical,
+      adminNotes: admin_notes,
+      tags
+    })
+
+    if (!username) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    return c.json({ ok: true, username })
+  } catch (error) {
+    if (error instanceof UsernameValidationError) {
+      return c.json({ ok: false, error: error.message }, 400)
+    }
+
+    console.error('Username metadata error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })


### PR DESCRIPTION
## Summary
- add internal username metadata support with tags, stats, dedicated detail fetch, and metadata update endpoints
- rank admin search across names, pubkeys, emails, notes, and tags, with explicit sort controls
- upgrade the admin dashboard and username detail pages for ops-friendly stats, tags, and notes editing

## Test Plan
- [x] npx vitest run src/db/queries.test.ts src/routes/admin.test.ts
- [x] npm run build (workdir: admin-ui)
