### PR TITLE
feat: show tag metadata in name detail

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -6,7 +6,8 @@ import type {
   RevokeResponse,
   ReservedWord,
   BulkReserveResponse,
-  ApiResponse
+  ApiResponse,
+  TagDetail
 } from '../types'
 
 const API_BASE = '/api/admin'
@@ -200,7 +201,7 @@ export async function deleteReservedWord(word: string): Promise<ApiResponse> {
 export async function addTagToUsername(
   name: string,
   tag: string
-): Promise<ApiResponse & { tags: string[] }> {
+): Promise<ApiResponse & { tags: string[]; tag_details: TagDetail[] }> {
   const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}/tags`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -217,7 +218,7 @@ export async function addTagToUsername(
 export async function removeTagFromUsername(
   name: string,
   tag: string
-): Promise<ApiResponse & { tags: string[] }> {
+): Promise<ApiResponse & { tags: string[]; tag_details: TagDetail[] }> {
   const response = await fetch(
     `${API_BASE}/username/${encodeURIComponent(name)}/tags/${encodeURIComponent(tag)}`,
     { method: 'DELETE' }

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTagFromUsername, getAllTags } from '../api/client'
-import type { Username } from '../types'
+import type { Username, TagDetail } from '../types'
 import StatusBadge from '../components/StatusBadge'
 
 export default function UsernameDetail() {
@@ -25,6 +25,7 @@ export default function UsernameDetail() {
 
   // Tag states
   const [tags, setTags] = useState<string[]>([])
+  const [tagDetails, setTagDetails] = useState<TagDetail[]>([])
   const [tagInput, setTagInput] = useState('')
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [allKnownTags, setAllKnownTags] = useState<{ tag: string; count: number }[]>([])
@@ -55,6 +56,7 @@ export default function UsernameDetail() {
       if (result.ok && result.username) {
         setUsername(result.username)
         setTags(result.username.tags || [])
+        setTagDetails(result.username.tag_details || [])
       } else {
         setError(result.error || 'Username not found')
       }
@@ -112,6 +114,7 @@ export default function UsernameDetail() {
       const result = await addTagToUsername(name, tagToAdd.trim())
       if (result.ok) {
         setTags(result.tags)
+        setTagDetails(result.tag_details || [])
         setTagInput('')
         setShowSuggestions(false)
         // Refresh known tags
@@ -134,11 +137,21 @@ export default function UsernameDetail() {
       const result = await removeTagFromUsername(name, tagToRemove)
       if (result.ok) {
         setTags(result.tags)
+        setTagDetails(result.tag_details || [])
         getAllTags().then(data => setAllKnownTags(data.tags || [])).catch(() => {})
       }
     } catch (err) {
       console.error('Failed to remove tag:', err)
     }
+  }
+
+  const getTagDetail = (tag: string): TagDetail | undefined =>
+    tagDetails.find(td => td.tag === tag)
+
+  const formatTagMeta = (detail: TagDetail): string => {
+    const date = new Date(detail.created_at * 1000).toLocaleDateString()
+    const who = detail.created_by || 'unknown'
+    return `Added by ${who} on ${date}`
   }
 
   const filteredSuggestions = allKnownTags
@@ -351,21 +364,30 @@ export default function UsernameDetail() {
         </div>
         <div className="px-6 py-4">
           <div className="flex flex-wrap gap-2 mb-3">
-            {tags.map(tag => (
-              <span
-                key={tag}
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800"
-              >
-                {tag}
-                <button
-                  onClick={() => handleRemoveTag(tag)}
-                  className="ml-0.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-600"
-                  title={`Remove ${tag}`}
+            {tags.map(tag => {
+              const detail = getTagDetail(tag)
+              return (
+                <span
+                  key={tag}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800"
+                  title={detail ? formatTagMeta(detail) : undefined}
                 >
-                  ×
-                </button>
-              </span>
-            ))}
+                  {tag}
+                  {detail && (
+                    <span className="text-blue-500 text-xs font-normal ml-1">
+                      by {detail.created_by || 'unknown'}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => handleRemoveTag(tag)}
+                    className="ml-0.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-600"
+                    title={`Remove ${tag}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              )
+            })}
             {tags.length === 0 && (
               <span className="text-sm text-gray-400 italic">No tags</span>
             )}

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,5 +1,11 @@
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
 
+export interface TagDetail {
+  tag: string
+  created_at: number
+  created_by: string | null
+}
+
 export interface Username {
   id: number
   name: string
@@ -17,6 +23,7 @@ export interface Username {
   claim_source: ClaimSource
   created_by: string | null
   tags?: string[]
+  tag_details?: TagDetail[]
 }
 
 export interface SearchResult {

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, createReservation, reserveUsername, addTag, removeTag, getTagsForUsername, getTagsForUsernames, getAllTags, type SearchParams } from './queries'
+import { searchUsernames, claimUsername, createReservation, reserveUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, type SearchParams } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -323,6 +323,23 @@ describe('username tags', () => {
     ])
     await expect(addTag(db, 1, '', 'matthew@divine.video')).rejects.toThrow()
     await expect(addTag(db, 1, '   ', 'matthew@divine.video')).rejects.toThrow()
+  })
+
+  it('returns tag details with created_by and created_at', async () => {
+    const db = createFakeD1([
+      { name: 'kingbach', username_canonical: 'kingbach', status: 'reserved', id: 1 },
+    ])
+    await addTag(db, 1, 'vip', 'matthew@divine.video')
+    await addTag(db, 1, 'vine-legacy', 'liz@divine.video')
+    const details = await getTagDetailsForUsername(db, 1)
+    expect(details).toHaveLength(2)
+    const vip = details.find(d => d.tag === 'vip')
+    expect(vip).toBeDefined()
+    expect(vip!.created_by).toBe('matthew@divine.video')
+    expect(typeof vip!.created_at).toBe('number')
+    const legacy = details.find(d => d.tag === 'vine-legacy')
+    expect(legacy).toBeDefined()
+    expect(legacy!.created_by).toBe('liz@divine.video')
   })
 
   it('batch loads tags for multiple usernames', async () => {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -556,6 +556,12 @@ export async function removeTag(
   ).bind(usernameId, normalized).run()
 }
 
+export interface TagDetail {
+  tag: string
+  created_at: number
+  created_by: string | null
+}
+
 export async function getTagsForUsername(
   db: D1Database,
   usernameId: number
@@ -564,6 +570,16 @@ export async function getTagsForUsername(
     'SELECT tag FROM username_tags WHERE username_id = ? ORDER BY tag'
   ).bind(usernameId).all<{ tag: string }>()
   return result.results.map(r => r.tag)
+}
+
+export async function getTagDetailsForUsername(
+  db: D1Database,
+  usernameId: number
+): Promise<TagDetail[]> {
+  const result = await db.prepare(
+    'SELECT tag, created_at, created_by FROM username_tags WHERE username_id = ? ORDER BY tag'
+  ).bind(usernameId).all<TagDetail>()
+  return result.results
 }
 
 export async function getTagsForUsernames(

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,7 +3,7 @@
 
 import { Hono } from 'hono'
 import { bech32 } from '@scure/base'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -141,7 +141,8 @@ admin.get('/username/:name', async (c) => {
     }
 
     const tags = await getTagsForUsername(c.env.DB, username.id)
-    return c.json({ ok: true, username: { ...username, tags } })
+    const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+    return c.json({ ok: true, username: { ...username, tags, tag_details: tagDetails } })
   } catch (error) {
     console.error('Username lookup error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
@@ -787,7 +788,8 @@ admin.post('/username/:name/tags', async (c) => {
   }
 
   const tags = await getTagsForUsername(c.env.DB, username.id)
-  return c.json({ ok: true, tags })
+  const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+  return c.json({ ok: true, tags, tag_details: tagDetails })
 })
 
 admin.delete('/username/:name/tags/:tag', async (c) => {
@@ -799,7 +801,8 @@ admin.delete('/username/:name/tags/:tag', async (c) => {
 
   await removeTag(c.env.DB, username.id, tag)
   const tags = await getTagsForUsername(c.env.DB, username.id)
-  return c.json({ ok: true, tags })
+  const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+  return c.json({ ok: true, tags, tag_details: tagDetails })
 })
 
 admin.get('/tags', async (c) => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,7 +3,7 @@
 
 import { Hono } from 'hono'
 import { bech32 } from '@scure/base'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -140,8 +140,8 @@ admin.get('/username/:name', async (c) => {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
 
-    const tags = await getTagsForUsername(c.env.DB, username.id)
     const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+    const tags = tagDetails.map(td => td.tag)
     return c.json({ ok: true, username: { ...username, tags, tag_details: tagDetails } })
   } catch (error) {
     console.error('Username lookup error:', error)
@@ -787,8 +787,8 @@ admin.post('/username/:name/tags', async (c) => {
     return c.json({ ok: false, error: e.message }, 400)
   }
 
-  const tags = await getTagsForUsername(c.env.DB, username.id)
   const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+  const tags = tagDetails.map(td => td.tag)
   return c.json({ ok: true, tags, tag_details: tagDetails })
 })
 
@@ -800,8 +800,8 @@ admin.delete('/username/:name/tags/:tag', async (c) => {
   if (!username) return c.json({ ok: false, error: 'Username not found' }, 404)
 
   await removeTag(c.env.DB, username.id, tag)
-  const tags = await getTagsForUsername(c.env.DB, username.id)
   const tagDetails = await getTagDetailsForUsername(c.env.DB, username.id)
+  const tags = tagDetails.map(td => td.tag)
   return c.json({ ok: true, tags, tag_details: tagDetails })
 })
 


### PR DESCRIPTION
  ## Description
  Surfaces tag metadata (who applied each tag and when) in the admin UI name detail page.

  ## Related Issue
  Fixes #29

  ## Changes Made
  - Added `getTagDetailsForUsername()` query returning `tag, created_at, created_by` from `username_tags`
  - Updated GET/POST/DELETE tag endpoints to include `tag_details` in response
  - Added `TagDetail` type to frontend
  - Tag chips show who applied each tag (inline) with full date on hover tooltip

  ## Checklist
  - [x] TypeScript compiles (0 errors)
  - [x] All 193 tests pass
  - [x] Backward compatible — existing `tags: string[]` field unchanged