### PR TITLE
feat: Keycast OAuth for admin auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ worker-configuration.d.ts
 
 # Private journal
 .private-journal/
+.wrangler-dev/

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Root application component configuring React Router for the admin UI
 // ABOUTME: Sets up nested routes with Layout wrapper and all admin pages (Dashboard, Reserve, Assign, Revoke, Reserved Words)
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { AuthProvider } from './context/AuthContext'
 import Layout from './components/Layout'
 import Dashboard from './pages/Dashboard'
 import Reserve from './pages/Reserve'
@@ -11,18 +12,20 @@ import UsernameDetail from './pages/UsernameDetail'
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="username/:name" element={<UsernameDetail />} />
-          <Route path="reserve" element={<Reserve />} />
-          <Route path="assign" element={<Assign />} />
-          <Route path="revoke" element={<Revoke />} />
-          <Route path="reserved-words" element={<ReservedWords />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="username/:name" element={<UsernameDetail />} />
+            <Route path="reserve" element={<Reserve />} />
+            <Route path="assign" element={<Assign />} />
+            <Route path="revoke" element={<Revoke />} />
+            <Route path="reserved-words" element={<ReservedWords />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }
 

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -1,9 +1,11 @@
 // ABOUTME: Main layout component providing navigation bar and routing container for admin UI
 // ABOUTME: Uses React Router Outlet to render child pages (Search, Reserve, Assign, Revoke, Reserved Words)
 import { Link, Outlet, useLocation } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
 
 export default function Layout() {
   const location = useLocation()
+  const { email, logout } = useAuth()
 
   const isActive = (path: string) => location.pathname === path
 
@@ -119,7 +121,7 @@ export default function Layout() {
                 Name Server Admin
               </h1>
             </div>
-            <div className="flex space-x-4">
+            <div className="flex items-center space-x-4">
               <Link to="/" className={navLinkClass('/')}>
                 Search
               </Link>
@@ -135,6 +137,17 @@ export default function Layout() {
               <Link to="/reserved-words" className={navLinkClass('/reserved-words')}>
                 Reserved Words
               </Link>
+              {email && (
+                <span className="text-blue-200 text-xs border-l border-blue-400 pl-4 ml-2">
+                  {email}
+                </span>
+              )}
+              <button
+                onClick={logout}
+                className="text-blue-200 hover:text-white text-xs"
+              >
+                Logout
+              </button>
             </div>
           </div>
         </div>

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import Login from '../pages/Login'
+
+interface AuthState {
+  email: string
+  pubkey: string | null
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthState | null>(null)
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be inside AuthProvider')
+  return ctx
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<'loading' | 'authenticated' | 'unauthenticated'>('loading')
+  const [email, setEmail] = useState('')
+  const [pubkey, setPubkey] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/admin/auth/status')
+      .then(r => r.json())
+      .then(data => {
+        if (data.authenticated) {
+          setState('authenticated')
+          setEmail(data.email || '')
+          setPubkey(data.pubkey || null)
+        } else {
+          setState('unauthenticated')
+        }
+      })
+      .catch(() => {
+        // Auth check failed -- might be CF Access handling it, try loading normally
+        setState('authenticated')
+        setEmail('')
+      })
+  }, [])
+
+  const logout = () => {
+    fetch('/api/admin/auth/logout', { method: 'POST' })
+      .then(() => {
+        setState('unauthenticated')
+        setEmail('')
+        setPubkey(null)
+      })
+  }
+
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    )
+  }
+
+  if (state === 'unauthenticated') {
+    return <Login />
+  }
+
+  return (
+    <AuthContext.Provider value={{ email, pubkey, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -1,9 +1,12 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import Login from '../pages/Login'
 
+type AuthMethod = 'cf-access' | 'keycast'
+
 interface AuthState {
   email: string
   pubkey: string | null
+  method: AuthMethod | null
   logout: () => void
 }
 
@@ -19,6 +22,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<'loading' | 'authenticated' | 'unauthenticated'>('loading')
   const [email, setEmail] = useState('')
   const [pubkey, setPubkey] = useState<string | null>(null)
+  const [method, setMethod] = useState<AuthMethod | null>(null)
 
   useEffect(() => {
     fetch('/api/admin/auth/status')
@@ -28,6 +32,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setState('authenticated')
           setEmail(data.email || '')
           setPubkey(data.pubkey || null)
+          setMethod(data.method || null)
         } else {
           setState('unauthenticated')
         }
@@ -38,11 +43,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const logout = () => {
+    // CF Access sessions are JWTs injected by the edge; only Cloudflare can clear them.
+    // Redirect the browser to CF Access's own logout endpoint; it tears down the
+    // Access session cookie and bounces back. The Keycast session cookie (if any)
+    // stays; we clear it server-side below as a belt-and-suspenders step first.
+    if (method === 'cf-access') {
+      fetch('/api/admin/auth/logout', { method: 'POST' }).finally(() => {
+        window.location.href = '/cdn-cgi/access/logout'
+      })
+      return
+    }
+
     fetch('/api/admin/auth/logout', { method: 'POST' })
       .then(() => {
         setState('unauthenticated')
         setEmail('')
         setPubkey(null)
+        setMethod(null)
       })
   }
 
@@ -59,7 +76,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ email, pubkey, logout }}>
+    <AuthContext.Provider value={{ email, pubkey, method, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -33,9 +33,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       })
       .catch(() => {
-        // Auth check failed -- might be CF Access handling it, try loading normally
-        setState('authenticated')
-        setEmail('')
+        setState('unauthenticated')
       })
   }, [])
 

--- a/admin-ui/src/pages/Login.tsx
+++ b/admin-ui/src/pages/Login.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+export default function Login() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleLogin = async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const resp = await fetch('/api/admin/auth/start', { method: 'POST' })
+      const data = await resp.json()
+
+      if (data.authorize_url) {
+        window.location.href = data.authorize_url
+      } else {
+        setError(data.error || 'OAuth not configured')
+        setLoading(false)
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Connection failed')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <div className="max-w-sm w-full text-center">
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Name Server Admin</h1>
+          <p className="text-sm text-gray-500 mt-1">Sign in to manage usernames</p>
+        </div>
+
+        <button
+          onClick={handleLogin}
+          disabled={loading}
+          className="w-full flex items-center justify-center gap-3 px-4 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+          </svg>
+          {loading ? 'Connecting...' : 'Sign in with Keycast'}
+        </button>
+
+        {error && (
+          <p className="mt-3 text-sm text-red-600">{error}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/admin-ui/src/pages/Login.tsx
+++ b/admin-ui/src/pages/Login.tsx
@@ -1,8 +1,34 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  missing_params: 'OAuth callback was missing required parameters. Try signing in again.',
+  not_configured: 'OAuth is not configured on this environment. Contact an administrator.',
+  token_exchange_failed: 'Sign-in failed at the token exchange step. The state may have expired; try again.',
+  access_denied: 'You declined the sign-in request.',
+}
+
+function describeAuthError(code: string): string {
+  return AUTH_ERROR_MESSAGES[code] ?? `Sign-in failed: ${code}`
+}
 
 export default function Login() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Surface OAuth callback errors that land in the URL as ?auth_error=<code>.
+  // Clean the query string after reading so a refresh doesn't re-show a stale error.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('auth_error')
+    if (code) {
+      setError(describeAuthError(code))
+      params.delete('auth_error')
+      params.delete('auth_success')
+      const cleanSearch = params.toString()
+      const cleanUrl = `${window.location.pathname}${cleanSearch ? `?${cleanSearch}` : ''}${window.location.hash}`
+      window.history.replaceState({}, '', cleanUrl)
+    }
+  }, [])
 
   const handleLogin = async () => {
     setLoading(true)

--- a/src/auth/keycast-oauth.test.ts
+++ b/src/auth/keycast-oauth.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for Keycast UCAN access-token helpers
+// ABOUTME: Pins UCAN fact-array shape so Keycast-authed admins keep a real email
+
+import { describe, it, expect } from 'vitest'
+import { extractEmailFromUcan } from './keycast-oauth'
+
+/** Build a fake UCAN-shaped JWT. Signature segment is irrelevant for decoding. */
+function buildUcan(payload: Record<string, unknown>): string {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'EdDSA', typ: 'JWT' }))
+  const body = base64UrlEncode(JSON.stringify(payload))
+  return `${header}.${body}.sig`
+}
+
+function base64UrlEncode(s: string): string {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('extractEmailFromUcan', () => {
+  it('returns email from the UCAN fct array (Keycast shape)', () => {
+    const token = buildUcan({
+      iss: 'did:key:server',
+      aud: 'did:key:user',
+      fct: [
+        {
+          tenant_id: 1,
+          email: 'admin@divine.video',
+          redirect_origin: 'https://names.admin.divine.video',
+        },
+      ],
+    })
+    expect(extractEmailFromUcan(token)).toBe('admin@divine.video')
+  })
+
+  it('returns email from the first fact that has one when multiple facts are present', () => {
+    const token = buildUcan({
+      fct: [
+        { tenant_id: 1 },
+        { email: 'first@example.com' },
+        { email: 'second@example.com' },
+      ],
+    })
+    expect(extractEmailFromUcan(token)).toBe('first@example.com')
+  })
+
+  it('returns null when fct is absent', () => {
+    const token = buildUcan({ iss: 'did:key:server' })
+    expect(extractEmailFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when fct is not an array', () => {
+    const token = buildUcan({ fct: { email: 'nope@example.com' } })
+    expect(extractEmailFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when no fact carries an email', () => {
+    const token = buildUcan({ fct: [{ tenant_id: 1 }, { redirect_origin: 'x' }] })
+    expect(extractEmailFromUcan(token)).toBeNull()
+  })
+
+  it('skips empty-string email values', () => {
+    const token = buildUcan({ fct: [{ email: '' }, { email: 'real@example.com' }] })
+    expect(extractEmailFromUcan(token)).toBe('real@example.com')
+  })
+
+  it('does NOT read a top-level payload.email claim (old buggy behavior)', () => {
+    // Guard against regression to the previous implementation that looked at
+    // payload.email / payload.sub_email. Keycast never emits those.
+    const token = buildUcan({ email: 'top-level@example.com', sub_email: 'sub@example.com' })
+    expect(extractEmailFromUcan(token)).toBeNull()
+  })
+
+  it('returns null on undefined or malformed tokens', () => {
+    expect(extractEmailFromUcan(undefined)).toBeNull()
+    expect(extractEmailFromUcan('')).toBeNull()
+    expect(extractEmailFromUcan('not-a-jwt')).toBeNull()
+    expect(extractEmailFromUcan('one')).toBeNull()
+    expect(extractEmailFromUcan('header.not-base64-json.sig')).toBeNull()
+  })
+
+  it('handles URL-safe base64 padding variants', () => {
+    // Payload with chars that force + / = in standard base64 before URL-safe substitution
+    const token = buildUcan({ fct: [{ email: 'pädding+test@example.com' }] })
+    expect(extractEmailFromUcan(token)).toBe('pädding+test@example.com')
+  })
+})

--- a/src/auth/keycast-oauth.test.ts
+++ b/src/auth/keycast-oauth.test.ts
@@ -1,8 +1,45 @@
-// ABOUTME: Tests for Keycast UCAN access-token helpers
-// ABOUTME: Pins UCAN fact-array shape so Keycast-authed admins keep a real email
+// ABOUTME: Tests for Keycast OAuth flow helpers
+// ABOUTME: Covers PKCE start, code-for-token exchange, session storage, and UCAN parsing
 
-import { describe, it, expect } from 'vitest'
-import { extractEmailFromUcan } from './keycast-oauth'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  deleteSession,
+  exchangeCodeForToken,
+  extractEmailFromUcan,
+  generatePkceChallenge,
+  getSession,
+  OAUTH_STATE_PREFIX,
+  OAUTH_STATE_TTL,
+  SESSION_PREFIX,
+  startOAuthFlow,
+  type OAuthSession,
+} from './keycast-oauth'
+
+/** Minimal in-memory KV double for tests. Honors put/get/delete; TTL is captured but not auto-expired. */
+function createFakeKv() {
+  const store = new Map<string, { value: string; expirationTtl?: number }>()
+  const kv = {
+    async get(key: string) {
+      const entry = store.get(key)
+      return entry ? entry.value : null
+    },
+    async put(key: string, value: string, options?: { expirationTtl?: number }) {
+      store.set(key, { value, expirationTtl: options?.expirationTtl })
+    },
+    async delete(key: string) {
+      store.delete(key)
+    },
+    _store: store,
+    _ttl(key: string): number | undefined {
+      return store.get(key)?.expirationTtl
+    },
+  }
+  return kv as KVNamespace & { _store: typeof store; _ttl: (k: string) => number | undefined }
+}
+
+function base64UrlEncode(s: string): string {
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
 
 /** Build a fake UCAN-shaped JWT. Signature segment is irrelevant for decoding. */
 function buildUcan(payload: Record<string, unknown>): string {
@@ -11,8 +48,19 @@ function buildUcan(payload: Record<string, unknown>): string {
   return `${header}.${body}.sig`
 }
 
-function base64UrlEncode(s: string): string {
-  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+function buildTokenResponse(overrides: Partial<{
+  access_token: string
+  bunker_url: string
+  expires_in: number
+  refresh_token: string
+}> = {}) {
+  return {
+    access_token: buildUcan({ fct: [{ email: 'admin@divine.video', tenant_id: 1 }] }),
+    bunker_url:
+      'bunker://aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899?relay=wss%3A%2F%2Frelay.example.com',
+    expires_in: 3600,
+    ...overrides,
+  }
 }
 
 describe('extractEmailFromUcan', () => {
@@ -81,5 +129,235 @@ describe('extractEmailFromUcan', () => {
     // Payload with chars that force + / = in standard base64 before URL-safe substitution
     const token = buildUcan({ fct: [{ email: 'pädding+test@example.com' }] })
     expect(extractEmailFromUcan(token)).toBe('pädding+test@example.com')
+  })
+})
+
+describe('generatePkceChallenge', () => {
+  it('produces a verifier and an S256 challenge derived from it', async () => {
+    const { verifier, challenge } = await generatePkceChallenge()
+    // Both must be URL-safe base64 (no +, /, =)
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/)
+
+    // Challenge must equal base64url(sha256(verifier))
+    const encoded = new TextEncoder().encode(verifier)
+    const digest = await crypto.subtle.digest('SHA-256', encoded)
+    const bytes = new Uint8Array(digest)
+    const expected = btoa(String.fromCharCode(...bytes))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    expect(challenge).toBe(expected)
+  })
+
+  it('produces a fresh verifier per call', async () => {
+    const a = await generatePkceChallenge()
+    const b = await generatePkceChallenge()
+    expect(a.verifier).not.toBe(b.verifier)
+  })
+})
+
+describe('startOAuthFlow', () => {
+  it('stores state with the configured TTL and returns an authorize URL with all required params', async () => {
+    const kv = createFakeKv()
+    const { authorizeUrl } = await startOAuthFlow(
+      kv,
+      'https://login.example.com',
+      'test-client',
+      'https://app.example.com/callback',
+    )
+
+    expect(authorizeUrl.startsWith('https://login.example.com/api/oauth/authorize?')).toBe(true)
+
+    const params = new URL(authorizeUrl).searchParams
+    expect(params.get('client_id')).toBe('test-client')
+    expect(params.get('redirect_uri')).toBe('https://app.example.com/callback')
+    expect(params.get('response_type')).toBe('code')
+    expect(params.get('code_challenge_method')).toBe('S256')
+    expect(params.get('scope')).toBe('policy:full')
+    expect(params.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]+$/)
+
+    const state = params.get('state')
+    expect(state).toBeTruthy()
+
+    // State entry exists under the prefix with the OAuth state TTL, carrying the verifier + redirect
+    const stateKey = OAUTH_STATE_PREFIX + state!
+    expect(kv._ttl(stateKey)).toBe(OAUTH_STATE_TTL)
+    const stored = JSON.parse((await kv.get(stateKey)) ?? 'null')
+    expect(stored.redirect_uri).toBe('https://app.example.com/callback')
+    expect(typeof stored.code_verifier).toBe('string')
+    expect(stored.code_verifier.length).toBeGreaterThan(0)
+  })
+
+  it('uses a random state value per call', async () => {
+    const kv = createFakeKv()
+    const a = await startOAuthFlow(kv, 'https://k', 'c', 'https://r')
+    const b = await startOAuthFlow(kv, 'https://k', 'c', 'https://r')
+    const stateA = new URL(a.authorizeUrl).searchParams.get('state')
+    const stateB = new URL(b.authorizeUrl).searchParams.get('state')
+    expect(stateA).not.toBe(stateB)
+  })
+})
+
+describe('exchangeCodeForToken', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function primeState(kv: KVNamespace, state: string, verifier = 'test-verifier', redirect = 'https://app.example.com/callback') {
+    await kv.put(
+      OAUTH_STATE_PREFIX + state,
+      JSON.stringify({ code_verifier: verifier, redirect_uri: redirect }),
+    )
+  }
+
+  it('posts the correct body to Keycast and returns a populated session', async () => {
+    const kv = createFakeKv()
+    await primeState(kv, 'the-state')
+
+    const tokenBody = buildTokenResponse()
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(tokenBody), { status: 200 }))
+
+    const { sessionId, session } = await exchangeCodeForToken(
+      kv,
+      'https://login.example.com',
+      'test-client',
+      'the-code',
+      'the-state',
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = fetchSpy.mock.calls[0]
+    expect(calledUrl).toBe('https://login.example.com/api/oauth/token')
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    const sent = JSON.parse(init.body as string)
+    expect(sent).toEqual({
+      grant_type: 'authorization_code',
+      code: 'the-code',
+      redirect_uri: 'https://app.example.com/callback',
+      code_verifier: 'test-verifier',
+      client_id: 'test-client',
+    })
+
+    expect(sessionId).toMatch(/^[0-9a-f-]{36}$/) // crypto.randomUUID
+    expect(session.email).toBe('admin@divine.video')
+    expect(session.pubkey).toBe(
+      'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899',
+    )
+    expect(session.expires_at).toBeGreaterThan(Date.now())
+    expect(session.expires_at).toBeLessThanOrEqual(Date.now() + 3600 * 1000)
+
+    // Session persisted under SESSION_PREFIX with the KV TTL mirroring expires_in
+    const storedRaw = await kv.get(SESSION_PREFIX + sessionId)
+    expect(storedRaw).not.toBeNull()
+    expect(JSON.parse(storedRaw!)).toMatchObject({ email: 'admin@divine.video' })
+  })
+
+  it('consumes state so it cannot be replayed', async () => {
+    const kv = createFakeKv()
+    await primeState(kv, 'single-use')
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(buildTokenResponse()), { status: 200 }))
+
+    await exchangeCodeForToken(kv, 'https://k', 'c', 'code', 'single-use')
+
+    await expect(
+      exchangeCodeForToken(kv, 'https://k', 'c', 'code', 'single-use'),
+    ).rejects.toThrow(/Invalid OAuth state/)
+  })
+
+  it('throws when state is missing', async () => {
+    const kv = createFakeKv()
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    await expect(
+      exchangeCodeForToken(kv, 'https://k', 'c', 'code', 'never-stored'),
+    ).rejects.toThrow(/Invalid OAuth state/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when the token endpoint returns a non-2xx response, including the upstream body', async () => {
+    const kv = createFakeKv()
+    await primeState(kv, 'bad')
+    fetchSpy.mockResolvedValue(new Response('invalid_grant', { status: 400 }))
+
+    await expect(
+      exchangeCodeForToken(kv, 'https://k', 'c', 'code', 'bad'),
+    ).rejects.toThrow(/Token exchange failed: 400 invalid_grant/)
+  })
+
+  it("falls back to 'keycast-user' when the UCAN carries no email", async () => {
+    const kv = createFakeKv()
+    await primeState(kv, 's')
+    const tokenBody = buildTokenResponse({
+      access_token: buildUcan({ fct: [{ tenant_id: 1 }] }),
+    })
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(tokenBody), { status: 200 }))
+
+    const { session } = await exchangeCodeForToken(kv, 'https://k', 'c', 'code', 's')
+    expect(session.email).toBe('keycast-user')
+  })
+
+  it('sets pubkey to null when bunker_url is malformed', async () => {
+    const kv = createFakeKv()
+    await primeState(kv, 's')
+    const tokenBody = buildTokenResponse({ bunker_url: 'not-a-bunker-url' })
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify(tokenBody), { status: 200 }))
+
+    const { session } = await exchangeCodeForToken(kv, 'https://k', 'c', 'code', 's')
+    expect(session.pubkey).toBeNull()
+  })
+})
+
+describe('getSession / deleteSession', () => {
+  it('returns the stored session when not expired', async () => {
+    const kv = createFakeKv()
+    const session: OAuthSession = {
+      email: 'x@example.com',
+      pubkey: 'a'.repeat(64),
+      expires_at: Date.now() + 60_000,
+    }
+    await kv.put(SESSION_PREFIX + 'sid', JSON.stringify(session))
+
+    const got = await getSession(kv, 'sid')
+    expect(got).toEqual(session)
+  })
+
+  it('returns null when the session is missing', async () => {
+    const kv = createFakeKv()
+    expect(await getSession(kv, 'nope')).toBeNull()
+  })
+
+  it('returns null when expires_at is in the past', async () => {
+    const kv = createFakeKv()
+    const expired: OAuthSession = {
+      email: 'x@example.com',
+      pubkey: null,
+      expires_at: Date.now() - 1_000,
+    }
+    await kv.put(SESSION_PREFIX + 'sid', JSON.stringify(expired))
+
+    expect(await getSession(kv, 'sid')).toBeNull()
+  })
+
+  it('deleteSession removes the session', async () => {
+    const kv = createFakeKv()
+    const session: OAuthSession = {
+      email: 'x@example.com',
+      pubkey: null,
+      expires_at: Date.now() + 60_000,
+    }
+    await kv.put(SESSION_PREFIX + 'sid', JSON.stringify(session))
+
+    await deleteSession(kv, 'sid')
+    expect(await kv.get(SESSION_PREFIX + 'sid')).toBeNull()
+    expect(await getSession(kv, 'sid')).toBeNull()
   })
 })

--- a/src/auth/keycast-oauth.test.ts
+++ b/src/auth/keycast-oauth.test.ts
@@ -2,10 +2,12 @@
 // ABOUTME: Covers PKCE start, code-for-token exchange, session storage, and UCAN parsing
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { base58 } from '@scure/base'
 import {
   deleteSession,
   exchangeCodeForToken,
   extractEmailFromUcan,
+  extractPubkeyFromUcan,
   generatePkceChallenge,
   getSession,
   OAUTH_STATE_PREFIX,
@@ -14,6 +16,16 @@ import {
   startOAuthFlow,
   type OAuthSession,
 } from './keycast-oauth'
+
+/** Encode a hex pubkey as a Keycast-shape did:key (secp256k1 multicodec + base58). */
+function pubkeyToDidKey(hexPubkey: string): string {
+  const pubkeyBytes = new Uint8Array(hexPubkey.match(/.{2}/g)!.map(b => parseInt(b, 16)))
+  const bytes = new Uint8Array(34)
+  bytes[0] = 0xe7
+  bytes[1] = 0x01
+  bytes.set(pubkeyBytes, 2)
+  return `did:key:z${base58.encode(bytes)}`
+}
 
 /** Minimal in-memory KV double for tests. Honors put/get/delete; TTL is captured but not auto-expired. */
 function createFakeKv() {
@@ -48,6 +60,9 @@ function buildUcan(payload: Record<string, unknown>): string {
   return `${header}.${body}.sig`
 }
 
+const TEST_USER_PUBKEY = '97f5edd026071916a50012333a379c976896469d5e77061982721d51baea2f33'
+const TEST_BUNKER_PUBKEY = 'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899'
+
 function buildTokenResponse(overrides: Partial<{
   access_token: string
   bunker_url: string
@@ -55,9 +70,11 @@ function buildTokenResponse(overrides: Partial<{
   refresh_token: string
 }> = {}) {
   return {
-    access_token: buildUcan({ fct: [{ email: 'admin@divine.video', tenant_id: 1 }] }),
-    bunker_url:
-      'bunker://aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899?relay=wss%3A%2F%2Frelay.example.com',
+    access_token: buildUcan({
+      aud: pubkeyToDidKey(TEST_USER_PUBKEY),
+      fct: [{ email: 'admin@divine.video', tenant_id: 1 }],
+    }),
+    bunker_url: `bunker://${TEST_BUNKER_PUBKEY}?relay=wss%3A%2F%2Frelay.example.com`,
     expires_in: 3600,
     ...overrides,
   }
@@ -249,9 +266,9 @@ describe('exchangeCodeForToken', () => {
 
     expect(sessionId).toMatch(/^[0-9a-f-]{36}$/) // crypto.randomUUID
     expect(session.email).toBe('admin@divine.video')
-    expect(session.pubkey).toBe(
-      'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899',
-    )
+    // pubkey must come from UCAN aud (user pubkey), not bunker_url (derived bunker pubkey)
+    expect(session.pubkey).toBe(TEST_USER_PUBKEY)
+    expect(session.pubkey).not.toBe(TEST_BUNKER_PUBKEY)
     expect(session.expires_at).toBeGreaterThan(Date.now())
     expect(session.expires_at).toBeLessThanOrEqual(Date.now() + 3600 * 1000)
 
@@ -305,14 +322,63 @@ describe('exchangeCodeForToken', () => {
     expect(session.email).toBe('keycast-user')
   })
 
-  it('sets pubkey to null when bunker_url is malformed', async () => {
+  it('sets pubkey to null when the UCAN aud is missing', async () => {
     const kv = createFakeKv()
     await primeState(kv, 's')
-    const tokenBody = buildTokenResponse({ bunker_url: 'not-a-bunker-url' })
+    const tokenBody = buildTokenResponse({
+      access_token: buildUcan({ fct: [{ email: 'x@y' }] }),
+    })
     fetchSpy.mockResolvedValue(new Response(JSON.stringify(tokenBody), { status: 200 }))
 
     const { session } = await exchangeCodeForToken(kv, 'https://k', 'c', 'code', 's')
     expect(session.pubkey).toBeNull()
+  })
+})
+
+describe('extractPubkeyFromUcan', () => {
+  it('decodes a Keycast did:key aud to hex pubkey', () => {
+    const token = buildUcan({ aud: pubkeyToDidKey(TEST_USER_PUBKEY) })
+    expect(extractPubkeyFromUcan(token)).toBe(TEST_USER_PUBKEY)
+  })
+
+  it('returns null when aud is missing', () => {
+    const token = buildUcan({ fct: [{ email: 'x@y' }] })
+    expect(extractPubkeyFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when aud is not a did:key', () => {
+    const token = buildUcan({ aud: 'did:web:example.com' })
+    expect(extractPubkeyFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when the multicodec prefix is not secp256k1 (0xe7 0x01)', () => {
+    // Build a did:key with an Ed25519 multicodec prefix (0xed 0x01) instead
+    const bytes = new Uint8Array(34)
+    bytes[0] = 0xed
+    bytes[1] = 0x01
+    bytes.set(new Uint8Array(32).fill(0xaa), 2)
+    const token = buildUcan({ aud: `did:key:z${base58.encode(bytes)}` })
+    expect(extractPubkeyFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when the decoded payload is the wrong length', () => {
+    // 33 bytes instead of 34 (missing one byte of the pubkey)
+    const bytes = new Uint8Array(33)
+    bytes[0] = 0xe7
+    bytes[1] = 0x01
+    const token = buildUcan({ aud: `did:key:z${base58.encode(bytes)}` })
+    expect(extractPubkeyFromUcan(token)).toBeNull()
+  })
+
+  it('returns null when aud cannot be base58 decoded', () => {
+    const token = buildUcan({ aud: 'did:key:z0OIl' }) // contains 0 and O which are not in base58 alphabet
+    expect(extractPubkeyFromUcan(token)).toBeNull()
+  })
+
+  it('returns null on malformed tokens', () => {
+    expect(extractPubkeyFromUcan(undefined)).toBeNull()
+    expect(extractPubkeyFromUcan('')).toBeNull()
+    expect(extractPubkeyFromUcan('one.bad.token')).toBeNull()
   })
 })
 

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -174,16 +174,26 @@ function extractPubkeyFromBunkerUrl(bunkerUrl: string): string | null {
 }
 
 /**
- * Try to extract email from UCAN/JWT access token.
- * UCANs are JWTs -- decode the payload and look for common email claims.
+ * Extract email from a Keycast UCAN access token.
+ *
+ * Keycast UCANs (see keycast api/src/api/http/auth.rs::generate_server_signed_ucan)
+ * place email inside the UCAN facts array (`fct`) per the UCAN 0.10 spec, not as a
+ * top-level JWT claim. Decoding as `payload.email` misses it and every Keycast-authed
+ * admin falls through to the generic fallback in exchangeCodeForToken().
  */
-function extractEmailFromUcan(token: string | undefined): string | null {
+export function extractEmailFromUcan(token: string | undefined): string | null {
   if (!token) return null
   try {
     const parts = token.split('.')
     if (parts.length < 2) return null
     const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')))
-    return payload.email || payload.sub_email || null
+    const facts = Array.isArray(payload.fct) ? payload.fct : []
+    for (const fact of facts) {
+      if (fact && typeof fact.email === 'string' && fact.email.length > 0) {
+        return fact.email
+      }
+    }
+    return null
   } catch {
     return null
   }

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -122,6 +122,11 @@ export async function exchangeCodeForToken(
   // did:key (secp256k1 multicodec + base58), which is what authorization checks
   // like ADMIN_PUBKEYS need to compare against.
   const pubkey = extractPubkeyFromUcan(tokenData.access_token)
+  if (pubkey === null) {
+    // Surfaces Keycast DID-format changes early; without this the session
+    // silently gets null pubkey and every admin call fails with "not an admin".
+    console.warn('[keycast-oauth] extractPubkeyFromUcan returned null — aud claim missing, wrong shape, or non-secp256k1 multicodec')
+  }
   const email = extractEmailFromUcan(tokenData.access_token) || 'keycast-user'
 
   const session: OAuthSession = {

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -1,9 +1,9 @@
 // ABOUTME: Keycast OAuth PKCE flow for admin authentication
 // ABOUTME: Session-ID-based sessions stored in KV, consumed via HTTP-only cookie
 
-const OAUTH_STATE_PREFIX = 'nameserver:oauth-state:'
-const SESSION_PREFIX = 'nameserver:session:'
-const OAUTH_STATE_TTL = 300 // 5 minutes
+export const OAUTH_STATE_PREFIX = 'nameserver:oauth-state:'
+export const SESSION_PREFIX = 'nameserver:session:'
+export const OAUTH_STATE_TTL = 300 // 5 minutes
 
 export interface OAuthSession {
   email: string

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -1,0 +1,194 @@
+// ABOUTME: Keycast OAuth PKCE flow for admin authentication
+// ABOUTME: Session-ID-based sessions stored in KV, consumed via HTTP-only cookie
+
+const OAUTH_STATE_PREFIX = 'nameserver:oauth-state:'
+const SESSION_PREFIX = 'nameserver:session:'
+const OAUTH_STATE_TTL = 300 // 5 minutes
+
+export interface OAuthSession {
+  email: string
+  pubkey: string | null
+  access_token: string
+  expires_at: number
+  refresh_token: string | null
+}
+
+/**
+ * Generate PKCE code_verifier and code_challenge (S256).
+ */
+export async function generatePkceChallenge(): Promise<{ verifier: string; challenge: string }> {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  const verifier = base64UrlEncode(array)
+
+  const encoded = new TextEncoder().encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', encoded)
+  const challenge = base64UrlEncode(new Uint8Array(digest))
+
+  return { verifier, challenge }
+}
+
+function base64UrlEncode(buffer: Uint8Array): string {
+  let binary = ''
+  for (const byte of buffer) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * Start the OAuth flow: generate PKCE, store state in KV, return authorize URL.
+ */
+export async function startOAuthFlow(
+  kv: KVNamespace,
+  keycastUrl: string,
+  clientId: string,
+  redirectUri: string,
+): Promise<{ authorizeUrl: string }> {
+  const { verifier, challenge } = await generatePkceChallenge()
+  const state = crypto.randomUUID()
+
+  await kv.put(
+    OAUTH_STATE_PREFIX + state,
+    JSON.stringify({ code_verifier: verifier, redirect_uri: redirectUri }),
+    { expirationTtl: OAUTH_STATE_TTL },
+  )
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    scope: 'policy:full',
+    state,
+  })
+
+  return { authorizeUrl: `${keycastUrl}/api/oauth/authorize?${params.toString()}` }
+}
+
+/**
+ * Exchange authorization code for token and create session.
+ * Returns the session ID to set as a cookie.
+ */
+export async function exchangeCodeForToken(
+  kv: KVNamespace,
+  keycastUrl: string,
+  clientId: string,
+  code: string,
+  state: string,
+): Promise<{ sessionId: string; session: OAuthSession }> {
+  // Retrieve and consume state
+  const stateKey = OAUTH_STATE_PREFIX + state
+  const stateData = await kv.get(stateKey)
+  if (!stateData) {
+    throw new Error('Invalid OAuth state -- expired or already used')
+  }
+  await kv.delete(stateKey)
+
+  const { code_verifier, redirect_uri } = JSON.parse(stateData) as {
+    code_verifier: string
+    redirect_uri: string
+  }
+
+  // Exchange code for token
+  const resp = await fetch(`${keycastUrl}/api/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri,
+      code_verifier,
+      client_id: clientId,
+    }),
+  })
+
+  if (!resp.ok) {
+    const body = await resp.text()
+    throw new Error(`Token exchange failed: ${resp.status} ${body}`)
+  }
+
+  const tokenData = await resp.json() as {
+    access_token?: string
+    bunker_url: string
+    expires_in: number
+    refresh_token?: string
+  }
+
+  // Extract identity from the response
+  const pubkey = extractPubkeyFromBunkerUrl(tokenData.bunker_url)
+  const email = extractEmailFromUcan(tokenData.access_token) || 'keycast-user'
+
+  const session: OAuthSession = {
+    email,
+    pubkey,
+    access_token: tokenData.access_token || '',
+    expires_at: Date.now() + tokenData.expires_in * 1000,
+    refresh_token: tokenData.refresh_token || null,
+  }
+
+  // Store session keyed by random ID
+  const sessionId = crypto.randomUUID()
+  await kv.put(
+    SESSION_PREFIX + sessionId,
+    JSON.stringify(session),
+    { expirationTtl: tokenData.expires_in },
+  )
+
+  return { sessionId, session }
+}
+
+/**
+ * Get session by ID. Returns null if expired or missing.
+ */
+export async function getSession(
+  kv: KVNamespace,
+  sessionId: string,
+): Promise<OAuthSession | null> {
+  const raw = await kv.get(SESSION_PREFIX + sessionId)
+  if (!raw) return null
+
+  const session = JSON.parse(raw) as OAuthSession
+  if (session.expires_at <= Date.now()) return null
+
+  return session
+}
+
+/**
+ * Delete session (logout).
+ */
+export async function deleteSession(
+  kv: KVNamespace,
+  sessionId: string,
+): Promise<void> {
+  await kv.delete(SESSION_PREFIX + sessionId)
+}
+
+/**
+ * Extract pubkey from bunker URL: bunker://{hex-pubkey}?relay=...
+ */
+function extractPubkeyFromBunkerUrl(bunkerUrl: string): string | null {
+  try {
+    const match = bunkerUrl.match(/^bunker:\/\/([0-9a-f]{64})/)
+    return match ? match[1] : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Try to extract email from UCAN/JWT access token.
+ * UCANs are JWTs -- decode the payload and look for common email claims.
+ */
+function extractEmailFromUcan(token: string | undefined): string | null {
+  if (!token) return null
+  try {
+    const parts = token.split('.')
+    if (parts.length < 2) return null
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')))
+    return payload.email || payload.sub_email || null
+  } catch {
+    return null
+  }
+}

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Keycast OAuth PKCE flow for admin authentication
 // ABOUTME: Session-ID-based sessions stored in KV, consumed via HTTP-only cookie
 
+import { base58 } from '@scure/base'
+
 export const OAUTH_STATE_PREFIX = 'nameserver:oauth-state:'
 export const SESSION_PREFIX = 'nameserver:session:'
 export const OAUTH_STATE_TTL = 300 // 5 minutes
@@ -114,8 +116,12 @@ export async function exchangeCodeForToken(
     refresh_token?: string
   }
 
-  // Extract identity from the response
-  const pubkey = extractPubkeyFromBunkerUrl(tokenData.bunker_url)
+  // Extract identity from the UCAN, not from bunker_url. The bunker_url encodes
+  // a derived bunker pubkey (keycast::bunker_key::derive_bunker_keys), not the
+  // user's Nostr pubkey. The user pubkey lives in the UCAN `aud` claim as a
+  // did:key (secp256k1 multicodec + base58), which is what authorization checks
+  // like ADMIN_PUBKEYS need to compare against.
+  const pubkey = extractPubkeyFromUcan(tokenData.access_token)
   const email = extractEmailFromUcan(tokenData.access_token) || 'keycast-user'
 
   const session: OAuthSession = {
@@ -162,12 +168,27 @@ export async function deleteSession(
 }
 
 /**
- * Extract pubkey from bunker URL: bunker://{hex-pubkey}?relay=...
+ * Extract the user's Nostr pubkey from a Keycast UCAN.
+ *
+ * The UCAN `aud` claim is a did:key of the form `did:key:z<base58>` where the
+ * decoded base58 bytes are the 0xe7 0x01 secp256k1 multicodec prefix followed
+ * by the 32-byte Nostr pubkey. See keycast `nostr_pubkey_to_did`.
  */
-function extractPubkeyFromBunkerUrl(bunkerUrl: string): string | null {
+export function extractPubkeyFromUcan(token: string | undefined): string | null {
+  if (!token) return null
   try {
-    const match = bunkerUrl.match(/^bunker:\/\/([0-9a-f]{64})/)
-    return match ? match[1] : null
+    const parts = token.split('.')
+    if (parts.length < 2) return null
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')))
+    const aud = typeof payload.aud === 'string' ? payload.aud : null
+    if (!aud || !aud.startsWith('did:key:z')) return null
+
+    const bytes = base58.decode(aud.slice('did:key:z'.length))
+    if (bytes.length !== 34 || bytes[0] !== 0xe7 || bytes[1] !== 0x01) return null
+
+    return Array.from(bytes.slice(2))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('')
   } catch {
     return null
   }

--- a/src/auth/keycast-oauth.ts
+++ b/src/auth/keycast-oauth.ts
@@ -8,9 +8,7 @@ const OAUTH_STATE_TTL = 300 // 5 minutes
 export interface OAuthSession {
   email: string
   pubkey: string | null
-  access_token: string
   expires_at: number
-  refresh_token: string | null
 }
 
 /**
@@ -123,9 +121,7 @@ export async function exchangeCodeForToken(
   const session: OAuthSession = {
     email,
     pubkey,
-    access_token: tokenData.access_token || '',
     expires_at: Date.now() + tokenData.expires_in * 1000,
-    refresh_token: tokenData.refresh_token || null,
   }
 
   // Store session keyed by random ID

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,6 @@ app.route('/api/username', username)
 // Auth routes are mounted inside admin.ts, exempted from auth check
 app.route('/api/admin', admin)
 
-
 // Internal service API (service-authenticated bearer token)
 app.route('/api/internal', internalAtproto)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ type Bindings = {
   DB: D1Database
   ASSETS: Fetcher
   SESSION_KV?: KVNamespace
+  ADMIN_PUBKEYS?: string
   FASTLY_API_TOKEN?: string
   FASTLY_STORE_ID?: string
   ATPROTO_SYNC_TOKEN?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import username from './routes/username'
 import nip05 from './routes/nip05'
 import subdomain from './routes/subdomain'
 import admin from './routes/admin'
+import authRoutes from './routes/auth'
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
 import { getAllActiveUsernames, expireStaleReservations } from './db/queries'
@@ -14,9 +15,12 @@ import { bulkSyncToFastly, parseRelayHints } from './utils/fastly-sync'
 type Bindings = {
   DB: D1Database
   ASSETS: Fetcher
+  SESSION_KV?: KVNamespace
   FASTLY_API_TOKEN?: string
   FASTLY_STORE_ID?: string
   ATPROTO_SYNC_TOKEN?: string
+  KEYCAST_URL?: string
+  KEYCAST_CLIENT_ID?: string
 }
 
 const app = new Hono<{ Bindings: Bindings }>()
@@ -51,7 +55,10 @@ app.use('/', async (c, next) => {
 // Username API
 app.route('/api/username', username)
 
-// Admin API (protected by Cloudflare Access)
+// Auth API (Keycast OAuth, must be before /api/admin to match first)
+app.route('/api/admin/auth', authRoutes)
+
+// Admin API (protected by Cloudflare Access or Keycast session)
 app.route('/api/admin', admin)
 
 // Internal service API (service-authenticated bearer token)

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ app.route('', publicRoutes)
 // Service info fallback for non-public, non-admin hostnames
 app.use('/', async (c, next) => {
   const hostname = new URL(c.req.url).hostname
-  if (hostname === 'names.admin.divine.video') {
+  if (hostname === 'names.admin.divine.video' || hostname === 'admin.localhost') {
     return next() // Let admin SPA catch-all handle it
   }
   return c.json({
@@ -70,8 +70,8 @@ app.route('', nip05)
 app.get('*', async (c) => {
   const url = new URL(c.req.url)
 
-  // Only handle admin subdomain SPA routes
-  if (url.hostname === 'names.admin.divine.video') {
+  // Only handle admin subdomain SPA routes (plus admin.localhost for local dev)
+  if (url.hostname === 'names.admin.divine.video' || url.hostname === 'admin.localhost') {
     // Don't intercept API routes
     if (url.pathname.startsWith('/api/')) {
       return c.notFound()

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import username from './routes/username'
 import nip05 from './routes/nip05'
 import subdomain from './routes/subdomain'
 import admin from './routes/admin'
-import authRoutes from './routes/auth'
+// Auth routes are mounted inside admin.ts (same Hono app, exempt from auth middleware)
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
 import { getAllActiveUsernames, expireStaleReservations } from './db/queries'
@@ -55,11 +55,10 @@ app.use('/', async (c, next) => {
 // Username API
 app.route('/api/username', username)
 
-// Auth API (Keycast OAuth, must be before /api/admin to match first)
-app.route('/api/admin/auth', authRoutes)
-
 // Admin API (protected by Cloudflare Access or Keycast session)
+// Auth routes are mounted inside admin.ts, exempted from auth check
 app.route('/api/admin', admin)
+
 
 // Internal service API (service-authenticated bearer token)
 app.route('/api/internal', internalAtproto)

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -26,7 +26,7 @@ function createMockDB() {
 
 describe('Admin Search Endpoint', () => {
   function createTestApp() {
-    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
     app.route('/admin', admin)
     return app
   }
@@ -35,7 +35,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -47,7 +47,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -60,7 +60,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&status=active')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -73,7 +73,7 @@ describe('Admin Search Endpoint', () => {
 
     const longQuery = 'a'.repeat(101)
     const req = new Request(`http://localhost/admin/usernames/search?q=${longQuery}`)
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -85,7 +85,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -100,7 +100,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&status=invalid')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -112,7 +112,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=-1')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -124,7 +124,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=0')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -136,7 +136,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=abc')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -148,7 +148,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=-1')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -160,7 +160,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=0')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -172,7 +172,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=xyz')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -184,7 +184,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -198,7 +198,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&status=active')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -210,7 +210,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&page=1&limit=10')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -223,7 +223,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=a')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -234,7 +234,7 @@ describe('Admin Search Endpoint', () => {
 
 describe('Admin Bulk Reserve Endpoint', () => {
   function createTestApp() {
-    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
     app.route('/admin', admin)
     return app
   }
@@ -247,7 +247,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice,bob,charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -264,7 +264,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice bob charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -280,7 +280,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: ['alice', 'bob', 'charlie'] })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -296,7 +296,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice, bob charlie,dave' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -312,7 +312,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({})
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -328,7 +328,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: '   ' }) // whitespace only
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -345,7 +345,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: tooMany })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -361,7 +361,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice,bob,charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -386,7 +386,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice_123' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -408,7 +408,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: '@alice,@bob,@@charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -463,7 +463,7 @@ describe('Admin Notify Assignment Endpoint', () => {
   }
 
   function createTestApp() {
-    const app = new Hono<{ Bindings: { DB: D1Database; SENDGRID_API_KEY?: string } }>()
+    const app = new Hono<{ Bindings: { DB: D1Database; SENDGRID_API_KEY?: string; BYPASS_LOCAL_AUTH?: string } }>()
     app.route('/admin', admin)
     return app
   }
@@ -475,7 +475,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -490,7 +490,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -505,7 +505,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'not-an-email' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -520,7 +520,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'nonexistent', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(404)
     const json = await res.json() as any
@@ -535,7 +535,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB('reserved'), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB('reserved'), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(409)
     const json = await res.json() as any
@@ -550,7 +550,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(503)
     const json = await res.json() as any
@@ -565,7 +565,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -577,7 +577,7 @@ describe('Admin Notify Assignment Endpoint', () => {
 
 describe('Admin Hostname Auth Guard', () => {
   function createTestApp() {
-    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
     app.route('/api/admin', admin)
     return app
   }
@@ -586,7 +586,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://names.divine.video/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(403)
     const json = await res.json() as any
@@ -598,7 +598,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://evil.example.com/api/admin/export/csv')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(403)
     const json = await res.json() as any
@@ -613,7 +613,7 @@ describe('Admin Hostname Auth Guard', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'alice', pubkey: 'a'.repeat(64) })
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(403)
   })
@@ -624,7 +624,7 @@ describe('Admin Hostname Auth Guard', () => {
     const req = new Request('https://names.admin.divine.video/api/admin/usernames/search?q=test', {
       headers: { 'Cf-Access-Jwt-Assertion': 'fake-jwt-for-test' }
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -636,7 +636,7 @@ describe('Admin Hostname Auth Guard', () => {
       const app = createTestApp()
 
       const req = new Request('http://localhost/api/admin/username/testuser')
-      const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
       expect(res.status).toBe(200)
       const json = await res.json() as any
@@ -649,7 +649,7 @@ describe('Admin Hostname Auth Guard', () => {
       const app = createTestApp()
 
       const req = new Request('http://localhost/api/admin/username/nonexistent')
-      const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
       expect(res.status).toBe(404)
       const json = await res.json() as any
@@ -662,24 +662,55 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://names.admin.divine.video/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(401)
   })
 
-  it('should allow admin API requests from localhost for local dev', async () => {
+  it('should allow admin API requests from localhost when BYPASS_LOCAL_AUTH=true', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/api/admin/usernames/search?q=test')
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('should require real auth on localhost when BYPASS_LOCAL_AUTH is not set', async () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/api/admin/usernames/search?q=test')
     const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
+    expect(res.status).toBe(401)
+  })
+
+  it('should require real auth on localhost when BYPASS_LOCAL_AUTH=false', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/api/admin/usernames/search?q=test')
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'false' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('should allow /api/admin/auth/* on localhost without BYPASS_LOCAL_AUTH', async () => {
+    // OAuth bootstrapping: the callback and /start endpoints must be reachable
+    // without an existing session, otherwise Keycast login can never initiate.
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/api/admin/auth/status')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
     expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.authenticated).toBe(false)
   })
 })
 
 describe('Admin Tag Endpoints', () => {
   function createTestApp() {
-    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
     app.route('/admin', admin)
     return app
   }
@@ -710,7 +741,7 @@ describe('Admin Tag Endpoints', () => {
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
     })
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.ok).toBe(true)
@@ -726,13 +757,13 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     // Then remove it
     const res = await app.fetch(new Request('http://localhost/admin/username/kingbach/tags/vip', {
       method: 'DELETE',
       headers: { 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.ok).toBe(true)
@@ -748,17 +779,17 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     await app.fetch(new Request('http://localhost/admin/username/lelepons/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     const res = await app.fetch(new Request('http://localhost/admin/tags', {
       method: 'GET',
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.tags).toContainEqual({ tag: 'vip', count: 2 })
@@ -772,7 +803,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(404)
   })
 
@@ -784,7 +815,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({}),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.ok).toBe(false)
@@ -799,7 +830,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'a'.repeat(51) }),
-    }), { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.ok).toBe(false)

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -708,6 +708,118 @@ describe('Admin Hostname Auth Guard', () => {
   })
 })
 
+describe('OAuth Start Config Validation', () => {
+  function createFakeKv(): KVNamespace {
+    const store = new Map<string, string>()
+    return {
+      async get(key: string) { return store.get(key) ?? null },
+      async put(key: string, value: string) { store.set(key, value) },
+      async delete(key: string) { store.delete(key) },
+    } as unknown as KVNamespace
+  }
+
+  function createTestApp() {
+    const app = new Hono<{
+      Bindings: {
+        DB: D1Database
+        SESSION_KV: KVNamespace
+        KEYCAST_URL?: string
+        KEYCAST_CLIENT_ID?: string
+        OAUTH_CALLBACK_BASE_URL?: string
+      }
+    }>()
+    app.route('/api/admin', admin)
+    return app
+  }
+
+  const baseEnv = () => ({
+    DB: createMockDB(),
+    SESSION_KV: createFakeKv(),
+    KEYCAST_CLIENT_ID: 'test-client',
+  })
+
+  it('rejects non-HTTPS KEYCAST_URL pointing at a public host', async () => {
+    const app = createTestApp()
+    const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
+    const env = { ...baseEnv(), KEYCAST_URL: 'http://login.example.com' }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as any
+    expect(json.error).toContain('KEYCAST_URL must be HTTPS')
+  })
+
+  it('accepts https:// KEYCAST_URL', async () => {
+    const app = createTestApp()
+    const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
+    const env = { ...baseEnv(), KEYCAST_URL: 'https://login.divine.video' }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts http://localhost KEYCAST_URL for local dev', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/api/admin/auth/start', { method: 'POST' })
+    const env = { ...baseEnv(), KEYCAST_URL: 'http://localhost:3000' }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts http://*.localhost KEYCAST_URL for local dev', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/api/admin/auth/start', { method: 'POST' })
+    const env = { ...baseEnv(), KEYCAST_URL: 'http://login.localhost:3000' }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects OAUTH_CALLBACK_BASE_URL pointing at a non-localhost host', async () => {
+    const app = createTestApp()
+    const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
+    const env = {
+      ...baseEnv(),
+      KEYCAST_URL: 'https://login.divine.video',
+      OAUTH_CALLBACK_BASE_URL: 'https://evil.example.com',
+    }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as any
+    expect(json.error).toContain('OAUTH_CALLBACK_BASE_URL')
+  })
+
+  it('accepts OAUTH_CALLBACK_BASE_URL=http://admin.localhost:8787', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/api/admin/auth/start', { method: 'POST' })
+    const env = {
+      ...baseEnv(),
+      KEYCAST_URL: 'http://localhost:3000',
+      OAUTH_CALLBACK_BASE_URL: 'http://admin.localhost:8787',
+    }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.authorize_url).toContain('admin.localhost%3A8787')
+  })
+
+  it('rejects OAUTH_CALLBACK_BASE_URL with a non-http(s) scheme', async () => {
+    const app = createTestApp()
+    const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
+    const env = {
+      ...baseEnv(),
+      KEYCAST_URL: 'https://login.divine.video',
+      OAUTH_CALLBACK_BASE_URL: 'javascript:void(0)',
+    }
+    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(503)
+  })
+})
+
 describe('Admin Tag Endpoints', () => {
   function createTestApp() {
     const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -658,13 +658,13 @@ describe('Admin Hostname Auth Guard', () => {
     })
   })
 
-  it('should block admin API requests from names.admin.divine.video without CF Access JWT', async () => {
+  it('should block admin API requests from names.admin.divine.video without auth', async () => {
     const app = createTestApp()
 
     const req = new Request('https://names.admin.divine.video/api/admin/usernames/search?q=test')
     const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(401)
   })
 
   it('should allow admin API requests from localhost for local dev', async () => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -39,11 +39,18 @@ function hexToNpub(hex: string): string {
 type Bindings = {
   DB: D1Database
   SESSION_KV?: KVNamespace
+  ADMIN_PUBKEYS?: string
   FASTLY_API_TOKEN?: string
   FASTLY_STORE_ID?: string
   SENDGRID_API_KEY?: string
   KEYCAST_URL?: string
   KEYCAST_CLIENT_ID?: string
+}
+
+/** Check if a pubkey is in the comma-separated ADMIN_PUBKEYS allowlist. */
+function isAdminPubkey(pubkey: string | null, adminPubkeys: string | undefined): boolean {
+  if (!pubkey || !adminPubkeys) return false
+  return adminPubkeys.split(',').map(p => p.trim().toLowerCase()).includes(pubkey.toLowerCase())
 }
 
 const admin = new Hono<{ Bindings: Bindings }>()
@@ -91,6 +98,11 @@ admin.use('*', async (c, next) => {
   if (sessionId && c.env.SESSION_KV) {
     const session = await getSession(c.env.SESSION_KV, sessionId)
     if (session) {
+      // Authorization: check pubkey against admin allowlist
+      // Pattern from divine-invite-darshan (Daniel's admin_pubkeys config)
+      if (!isAdminPubkey(session.pubkey, c.env.ADMIN_PUBKEYS)) {
+        return c.json({ ok: false, error: 'Forbidden: not an admin' }, 403)
+      }
       c.set('adminEmail' as never, session.email as never)
       return next()
     }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -45,6 +45,7 @@ type Bindings = {
   SENDGRID_API_KEY?: string
   KEYCAST_URL?: string
   KEYCAST_CLIENT_ID?: string
+  BYPASS_LOCAL_AUTH?: string
 }
 
 /** Check if a pubkey is in the comma-separated ADMIN_PUBKEYS allowlist. */
@@ -79,8 +80,10 @@ admin.use('*', async (c, next) => {
     return next()
   }
 
-  // Dev bypass
-  if (isLocalDev) {
+  // Dev bypass, opt-in via BYPASS_LOCAL_AUTH=true in .dev.vars.
+  // Default is off so wrangler dev can exercise the real CF Access / Keycast paths
+  // against a locally-running Keycast stack.
+  if (isLocalDev && c.env.BYPASS_LOCAL_AUTH === 'true') {
     c.set('adminEmail' as never, 'dev@local' as never)
     return next()
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,9 +1,11 @@
 // ABOUTME: Admin endpoints for username management
-// ABOUTME: Protected by Cloudflare Access, handles reserve/revoke/burn/assign
+// ABOUTME: Protected by Cloudflare Access or Keycast OAuth session
 
 import { Hono } from 'hono'
+import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { getSession } from '../auth/keycast-oauth'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -35,17 +37,20 @@ function hexToNpub(hex: string): string {
 
 type Bindings = {
   DB: D1Database
+  SESSION_KV?: KVNamespace
   FASTLY_API_TOKEN?: string
   FASTLY_STORE_ID?: string
   SENDGRID_API_KEY?: string
+  KEYCAST_URL?: string
+  KEYCAST_CLIENT_ID?: string
 }
 
 const admin = new Hono<{ Bindings: Bindings }>()
 
-// Defense-in-depth: verify requests come through Cloudflare Access
-// Cloudflare Access protects names.admin.divine.video at the edge,
-// but the worker is also reachable via names.divine.video which has
-// no Access policy. This middleware blocks that bypass.
+// Defense-in-depth: verify requests are authenticated.
+// Accepts CF Access JWT (edge-injected) or Keycast OAuth session cookie.
+// The worker is reachable via names.divine.video (no Access policy),
+// so the hostname guard blocks that bypass regardless of auth method.
 admin.use('*', async (c, next) => {
   const url = new URL(c.req.url)
 
@@ -57,15 +62,31 @@ admin.use('*', async (c, next) => {
     return c.json({ ok: false, error: 'Unauthorized' }, 403)
   }
 
-  // In production, require Cloudflare Access JWT header
-  if (isAdminHost) {
-    const cfJwt = c.req.header('Cf-Access-Jwt-Assertion')
-    if (!cfJwt) {
-      return c.json({ ok: false, error: 'Unauthorized' }, 403)
+  // Dev bypass
+  if (isLocalDev) {
+    c.set('adminEmail' as never, 'dev@local' as never)
+    return next()
+  }
+
+  // Path 1: CF Access JWT (existing, edge-injected)
+  const cfJwt = c.req.header('Cf-Access-Jwt-Assertion')
+  if (cfJwt) {
+    const email = (c.get('adminEmail' as never) as string) || 'unknown'
+    c.set('adminEmail' as never, email as never)
+    return next()
+  }
+
+  // Path 2: Keycast session cookie
+  const sessionId = getCookie(c, '__session')
+  if (sessionId && c.env.SESSION_KV) {
+    const session = await getSession(c.env.SESSION_KV, sessionId)
+    if (session) {
+      c.set('adminEmail' as never, session.email as never)
+      return next()
     }
   }
 
-  await next()
+  return c.json({ ok: false, error: 'Unauthorized' }, 401)
 })
 
 admin.get('/usernames/search', async (c) => {
@@ -247,7 +268,7 @@ admin.post('/username/reserve', async (c) => {
 
     // Include override reason in the reserved_reason if provided
     const finalReason = overrideReason ? `${reason} [Override: ${overrideReason}]` : reason
-    const createdBy = c.req.header('Cf-Access-Authenticated-User-Email') || null
+    const createdBy = (c.get('adminEmail' as never) as string) || null
     await reserveUsername(c.env.DB, usernameData.display, usernameData.canonical, finalReason, 'admin', createdBy)
 
     if (overrideReason) {
@@ -295,7 +316,7 @@ admin.post('/username/reserve-bulk', async (c) => {
     }
 
     // Process each name
-    const createdBy = c.req.header('Cf-Access-Authenticated-User-Email') || null
+    const createdBy = (c.get('adminEmail' as never) as string) || null
     const results = []
     for (const name of nameList) {
       try {
@@ -430,7 +451,7 @@ admin.post('/username/assign', async (c) => {
       throw error
     }
 
-    const createdBy = c.req.header('Cf-Access-Authenticated-User-Email') || null
+    const createdBy = (c.get('adminEmail' as never) as string) || null
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
 
     // Sync to Fastly KV for edge routing
@@ -477,7 +498,7 @@ admin.post('/username/assign-bulk', async (c) => {
     }
 
     // Process each assignment
-    const createdBy = c.req.header('Cf-Access-Authenticated-User-Email') || null
+    const createdBy = (c.get('adminEmail' as never) as string) || null
     const results = []
     for (const assignment of assignments) {
       const { name, pubkey } = assignment
@@ -776,7 +797,7 @@ admin.post('/username/:name/tags', async (c) => {
     return c.json({ ok: false, error: 'tag is required' }, 400)
   }
 
-  const createdBy = c.req.header('Cf-Access-Authenticated-User-Email') || 'unknown'
+  const createdBy = (c.get('adminEmail' as never) as string) || 'unknown'
 
   const username = await getUsernameByName(c.env.DB, name)
   if (!username) return c.json({ ok: false, error: 'Username not found' }, 404)

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -9,6 +9,7 @@ import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, sea
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
+import authRoutes from './auth'
 
 /** Convert a 64-char hex pubkey to npub bech32 format */
 function hexToNpub(hex: string): string {
@@ -47,19 +48,28 @@ type Bindings = {
 
 const admin = new Hono<{ Bindings: Bindings }>()
 
+// Auth routes mounted first -- they handle their own hostname guard
+// and must be accessible without an existing session (chicken-and-egg).
+admin.route('/auth', authRoutes)
+
 // Defense-in-depth: verify requests are authenticated.
 // Accepts CF Access JWT (edge-injected) or Keycast OAuth session cookie.
 // The worker is reachable via names.divine.video (no Access policy),
 // so the hostname guard blocks that bypass regardless of auth method.
 admin.use('*', async (c, next) => {
   const url = new URL(c.req.url)
-
   // Only allow admin API on the admin subdomain (and localhost for dev)
   const isAdminHost = url.hostname === 'names.admin.divine.video'
   const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
 
   if (!isAdminHost && !isLocalDev) {
     return c.json({ ok: false, error: 'Unauthorized' }, 403)
+  }
+
+  // Auth routes handle their own security (hostname guard only).
+  // Skip the auth check so unauthenticated users can start the OAuth flow.
+  if (c.req.path.startsWith('/api/admin/auth/')) {
+    return next()
   }
 
   // Dev bypass
@@ -71,7 +81,7 @@ admin.use('*', async (c, next) => {
   // Path 1: CF Access JWT (existing, edge-injected)
   const cfJwt = c.req.header('Cf-Access-Jwt-Assertion')
   if (cfJwt) {
-    const email = (c.get('adminEmail' as never) as string) || 'unknown'
+    const email = c.req.header('Cf-Access-Authenticated-User-Email') || 'unknown'
     c.set('adminEmail' as never, email as never)
     return next()
   }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -66,9 +66,10 @@ admin.route('/auth', authRoutes)
 // so the hostname guard blocks that bypass regardless of auth method.
 admin.use('*', async (c, next) => {
   const url = new URL(c.req.url)
-  // Only allow admin API on the admin subdomain (and localhost for dev)
-  const isAdminHost = url.hostname === 'names.admin.divine.video'
-  const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  // Only allow admin API on the admin subdomain (and localhost for dev).
+  // admin.localhost resolves to 127.0.0.1 via RFC 6761 and mirrors prod routing locally.
+  const isAdminHost = url.hostname === 'names.admin.divine.video' || url.hostname === 'admin.localhost'
+  const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === 'admin.localhost'
 
   if (!isAdminHost && !isLocalDev) {
     return c.json({ ok: false, error: 'Unauthorized' }, 403)

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,147 @@
+// ABOUTME: Keycast OAuth routes for admin authentication
+// ABOUTME: PKCE flow with cookie-based sessions, mounted at /api/admin/auth
+
+import { Hono } from 'hono'
+import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
+import {
+  startOAuthFlow,
+  exchangeCodeForToken,
+  getSession,
+  deleteSession,
+} from '../auth/keycast-oauth'
+
+type Bindings = {
+  SESSION_KV: KVNamespace
+  KEYCAST_URL?: string
+  KEYCAST_CLIENT_ID?: string
+}
+
+const auth = new Hono<{ Bindings: Bindings }>()
+
+// Hostname guard only -- no CF Access or session check.
+// Auth routes must be accessible to unauthenticated users.
+auth.use('*', async (c, next) => {
+  const url = new URL(c.req.url)
+  const isAdminHost = url.hostname === 'names.admin.divine.video'
+  const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+
+  if (!isAdminHost && !isLocalDev) {
+    return c.json({ ok: false, error: 'Unauthorized' }, 403)
+  }
+
+  await next()
+})
+
+/**
+ * POST /api/admin/auth/start
+ * Initiate Keycast OAuth PKCE flow. Returns the authorize URL.
+ */
+auth.post('/start', async (c) => {
+  if (!c.env.KEYCAST_CLIENT_ID || !c.env.KEYCAST_URL) {
+    return c.json({ error: 'OAuth not configured (KEYCAST_CLIENT_ID or KEYCAST_URL missing)' }, 503)
+  }
+
+  if (!c.env.SESSION_KV) {
+    return c.json({ error: 'Session storage not configured' }, 503)
+  }
+
+  const origin = new URL(c.req.url).origin
+  const redirectUri = `${origin}/api/admin/auth/callback`
+
+  const { authorizeUrl } = await startOAuthFlow(
+    c.env.SESSION_KV,
+    c.env.KEYCAST_URL,
+    c.env.KEYCAST_CLIENT_ID,
+    redirectUri,
+  )
+
+  return c.json({ authorize_url: authorizeUrl })
+})
+
+/**
+ * GET /api/admin/auth/callback
+ * OAuth callback. Exchanges code for token, sets session cookie, redirects to admin UI.
+ */
+auth.get('/callback', async (c) => {
+  const code = c.req.query('code')
+  const state = c.req.query('state')
+  const error = c.req.query('error')
+
+  if (error) {
+    return c.redirect('/?auth_error=' + encodeURIComponent(error))
+  }
+
+  if (!code || !state) {
+    return c.redirect('/?auth_error=missing_params')
+  }
+
+  if (!c.env.KEYCAST_URL || !c.env.KEYCAST_CLIENT_ID || !c.env.SESSION_KV) {
+    return c.redirect('/?auth_error=not_configured')
+  }
+
+  try {
+    const { sessionId } = await exchangeCodeForToken(
+      c.env.SESSION_KV,
+      c.env.KEYCAST_URL,
+      c.env.KEYCAST_CLIENT_ID,
+      code,
+      state,
+    )
+
+    setCookie(c, '__session', sessionId, {
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+      maxAge: 86400, // 24 hours
+    })
+
+    return c.redirect('/?auth_success=true')
+  } catch (err) {
+    console.error('OAuth token exchange failed:', err)
+    return c.redirect('/?auth_error=token_exchange_failed')
+  }
+})
+
+/**
+ * GET /api/admin/auth/status
+ * Check current session status.
+ */
+auth.get('/status', async (c) => {
+  if (!c.env.SESSION_KV) {
+    return c.json({ authenticated: false })
+  }
+
+  const sessionId = getCookie(c, '__session')
+  if (!sessionId) {
+    return c.json({ authenticated: false })
+  }
+
+  const session = await getSession(c.env.SESSION_KV, sessionId)
+  if (!session) {
+    return c.json({ authenticated: false })
+  }
+
+  return c.json({
+    authenticated: true,
+    email: session.email,
+    pubkey: session.pubkey,
+  })
+})
+
+/**
+ * POST /api/admin/auth/logout
+ * Clear session and cookie.
+ */
+auth.post('/logout', async (c) => {
+  const sessionId = getCookie(c, '__session')
+  if (sessionId && c.env.SESSION_KV) {
+    await deleteSession(c.env.SESSION_KV, sessionId)
+  }
+
+  deleteCookie(c, '__session', { path: '/' })
+
+  return c.json({ ok: true })
+})
+
+export default auth

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -19,6 +19,44 @@ type Bindings = {
 
 const auth = new Hono<{ Bindings: Bindings }>()
 
+/**
+ * Accept HTTPS everywhere, or http:// only for localhost variants
+ * (bare `localhost`, IPv4 / IPv6 loopback, or any `*.localhost` per RFC 6761).
+ */
+function isAllowedKeycastUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl)
+    if (url.protocol === 'https:') return true
+    if (url.protocol !== 'http:') return false
+    return isLoopbackHost(url.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The callback origin override is only honored when it points at a
+ * localhost variant, so an accidental prod setting can't redirect OAuth.
+ */
+function isLocalDevCallbackOrigin(rawOrigin: string): boolean {
+  try {
+    const url = new URL(rawOrigin)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+    return isLoopbackHost(url.hostname)
+  } catch {
+    return false
+  }
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    (hostname.endsWith('.localhost') && hostname.length > '.localhost'.length)
+  )
+}
+
 // Hostname guard only -- no CF Access or session check.
 // Auth routes must be accessible to unauthenticated users.
 auth.use('*', async (c, next) => {
@@ -46,10 +84,25 @@ auth.post('/start', async (c) => {
     return c.json({ error: 'Session storage not configured' }, 503)
   }
 
+  // KEYCAST_URL must be HTTPS outside local dev. A misconfigured http:// Keycast
+  // would leak the OAuth state parameter over cleartext on the authorize redirect.
+  if (!isAllowedKeycastUrl(c.env.KEYCAST_URL)) {
+    console.error('[auth/start] rejecting non-HTTPS KEYCAST_URL:', c.env.KEYCAST_URL)
+    return c.json({ error: 'OAuth misconfigured: KEYCAST_URL must be HTTPS outside local dev' }, 503)
+  }
+
   // OAUTH_CALLBACK_BASE_URL lets local dev override the callback origin because
   // Miniflare strips the port under `wrangler dev --host`. In production the
   // computed origin from c.req.url is correct and the override stays unset.
-  const origin = c.env.OAUTH_CALLBACK_BASE_URL ?? new URL(c.req.url).origin
+  // Only accept overrides pointing at localhost variants so a prod misconfig
+  // (e.g., accidental `OAUTH_CALLBACK_BASE_URL` in production `[vars]`) can't
+  // redirect OAuth through an attacker-controlled host.
+  const override = c.env.OAUTH_CALLBACK_BASE_URL
+  if (override && !isLocalDevCallbackOrigin(override)) {
+    console.error('[auth/start] rejecting non-localhost OAUTH_CALLBACK_BASE_URL:', override)
+    return c.json({ error: 'OAuth misconfigured: OAUTH_CALLBACK_BASE_URL must be a localhost origin' }, 503)
+  }
+  const origin = override ?? new URL(c.req.url).origin
   const redirectUri = `${origin}/api/admin/auth/callback`
 
   const { authorizeUrl } = await startOAuthFlow(
@@ -93,8 +146,13 @@ auth.get('/callback', async (c) => {
     )
 
     // Cookie maxAge matches KV session TTL (both derived from token expiry).
-    // Cap at 24 hours so sessions don't outlive a workday.
-    const maxAge = Math.min(session.expires_at - Date.now(), 86400 * 1000) / 1000
+    // Cap at 24 hours so sessions don't outlive a workday. Math.max(0, ...)
+    // guards against a malformed Keycast response that returns a past expiry,
+    // which would otherwise compute a negative maxAge.
+    const maxAge = Math.max(
+      0,
+      Math.min(session.expires_at - Date.now(), 86400 * 1000) / 1000,
+    )
     setCookie(c, '__session', sessionId, {
       path: '/',
       httpOnly: true,

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -111,6 +111,14 @@ auth.get('/callback', async (c) => {
  * Check current session status.
  */
 auth.get('/status', async (c) => {
+  // Path 1: CF Access (edge-injected headers)
+  const cfJwt = c.req.header('Cf-Access-Jwt-Assertion')
+  if (cfJwt) {
+    const email = c.req.header('Cf-Access-Authenticated-User-Email') || 'unknown'
+    return c.json({ authenticated: true, email, pubkey: null, method: 'cf-access' })
+  }
+
+  // Path 2: Keycast session cookie
   if (!c.env.SESSION_KV) {
     return c.json({ authenticated: false })
   }
@@ -129,6 +137,7 @@ auth.get('/status', async (c) => {
     authenticated: true,
     email: session.email,
     pubkey: session.pubkey,
+    method: 'keycast',
   })
 })
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -14,6 +14,7 @@ type Bindings = {
   SESSION_KV: KVNamespace
   KEYCAST_URL?: string
   KEYCAST_CLIENT_ID?: string
+  OAUTH_CALLBACK_BASE_URL?: string
 }
 
 const auth = new Hono<{ Bindings: Bindings }>()
@@ -22,8 +23,8 @@ const auth = new Hono<{ Bindings: Bindings }>()
 // Auth routes must be accessible to unauthenticated users.
 auth.use('*', async (c, next) => {
   const url = new URL(c.req.url)
-  const isAdminHost = url.hostname === 'names.admin.divine.video'
-  const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  const isAdminHost = url.hostname === 'names.admin.divine.video' || url.hostname === 'admin.localhost'
+  const isLocalDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === 'admin.localhost'
 
   if (!isAdminHost && !isLocalDev) {
     return c.json({ ok: false, error: 'Unauthorized' }, 403)
@@ -45,7 +46,10 @@ auth.post('/start', async (c) => {
     return c.json({ error: 'Session storage not configured' }, 503)
   }
 
-  const origin = new URL(c.req.url).origin
+  // OAUTH_CALLBACK_BASE_URL lets local dev override the callback origin because
+  // Miniflare strips the port under `wrangler dev --host`. In production the
+  // computed origin from c.req.url is correct and the override stays unset.
+  const origin = c.env.OAUTH_CALLBACK_BASE_URL ?? new URL(c.req.url).origin
   const redirectUri = `${origin}/api/admin/auth/callback`
 
   const { authorizeUrl } = await startOAuthFlow(

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -80,7 +80,7 @@ auth.get('/callback', async (c) => {
   }
 
   try {
-    const { sessionId } = await exchangeCodeForToken(
+    const { sessionId, session } = await exchangeCodeForToken(
       c.env.SESSION_KV,
       c.env.KEYCAST_URL,
       c.env.KEYCAST_CLIENT_ID,
@@ -88,12 +88,15 @@ auth.get('/callback', async (c) => {
       state,
     )
 
+    // Cookie maxAge matches KV session TTL (both derived from token expiry).
+    // Cap at 24 hours so sessions don't outlive a workday.
+    const maxAge = Math.min(session.expires_at - Date.now(), 86400 * 1000) / 1000
     setCookie(c, '__session', sessionId, {
       path: '/',
       httpOnly: true,
       secure: true,
       sameSite: 'Lax',
-      maxAge: 86400, // 24 hours
+      maxAge: Math.floor(maxAge),
     })
 
     return c.redirect('/?auth_success=true')

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -19,10 +19,16 @@ routes = [
 # INVITE_FAUCET_URL: base URL of the invite code faucet service (e.g. "https://faucet.example.com")
 # Set via wrangler secret put SENDGRID_API_KEY
 [vars]
+KEYCAST_URL = "https://login.divine.video"
+KEYCAST_CLIENT_ID = "divine-name-server"
 # FASTLY_STORE_ID = "your-store-id" # Set as secret in production
 # ALLOWED_MINTS = "https://8333.space:3338,https://mint.minibits.cash/Bitcoin"
 # NAME_PRICE_SATS = "1000"
 # INVITE_FAUCET_URL = "https://faucet.divine.video"
+
+[[kv_namespaces]]
+binding = "SESSION_KV"
+id = "f134d6b3b36b4890a0a272e6ca392bcd"
 
 [[d1_databases]]
 binding = "DB"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,9 @@ routes = [
 [vars]
 KEYCAST_URL = "https://login.divine.video"
 KEYCAST_CLIENT_ID = "divine-name-server"
+# Comma-separated hex pubkeys authorized for Keycast OAuth admin access.
+# CF Access users are authorized by the Access policy; this only applies to Keycast sessions.
+ADMIN_PUBKEYS = "81549bc0b5153b4b970fe4a3892ad185698b8b8b26ec69321a527d0644cd2898"
 # FASTLY_STORE_ID = "your-store-id" # Set as secret in production
 # ALLOWED_MINTS = "https://8333.space:3338,https://mint.minibits.cash/Bitcoin"
 # NAME_PRICE_SATS = "1000"


### PR DESCRIPTION
## Summary

Adds Keycast OAuth PKCE as an alternative admin-auth path alongside CF Access for `names.admin.divine.video`. Second Keycast adoption after divine-resurrection; mirrors that pattern closely.

- **Worker**: New OAuth routes (`/api/admin/auth/{start,callback,status,logout}`), cookie-based sessions (`__session`) with opaque random session IDs, session data in `SESSION_KV`. Admin middleware accepts CF Access JWT (edge-injected header) OR Keycast session cookie.
- **Frontend**: `AuthProvider` React context gates the app; Login page with "Sign in with Keycast"; email display and logout in the nav. Logout branches on `method` so CF Access users get bounced to `/cdn-cgi/access/logout`.
- **Authorization**: `ADMIN_PUBKEYS` env var checked against the session pubkey for the Keycast path. CF Access path trusts the Access policy (mirrors existing behavior; documented in `wrangler.toml`).
- **Config hardening**: `KEYCAST_URL` must be HTTPS outside localhost; `OAUTH_CALLBACK_BASE_URL` (local-dev override) gated to localhost variants; cookie `maxAge` clamped non-negative; null-pubkey UCAN extractions logged.

## ⚠️ Pre-deploy requirement

Before deploying to production, Cloudflare Access needs a **bypass policy** added for `/api/admin/auth/*` paths on the `names.admin.divine.video` Access application. Without it, the browser cannot reach `/api/admin/auth/start` to initiate Keycast login -- CF Access intercepts at the edge before the Worker's path-based exemption can match. The bypass keeps CF Access on every other admin path; Keycast login becomes possible only on the OAuth bootstrap paths, which have their own hostname guard + single-use state + PKCE + `ADMIN_PUBKEYS` enforcement.

I own the CF Access config change and will apply it at rollout time. Not blocking review.

## What changed

**Backend (Worker):**
| File | Change |
|------|--------|
| `src/auth/keycast-oauth.ts` | PKCE helpers, KV session store, UCAN parsing. Extracts email from UCAN `fct` array and pubkey from UCAN `aud` did:key (secp256k1 multicodec + base58). |
| `src/routes/auth.ts` | OAuth routes. Validates `KEYCAST_URL` is HTTPS outside localhost and that `OAUTH_CALLBACK_BASE_URL` (when set) points at a localhost variant. |
| `src/routes/admin.ts` | Middleware accepts CF Access JWT or `__session` cookie + `ADMIN_PUBKEYS` check. Localhost dev bypass now gated on `BYPASS_LOCAL_AUTH=true` env var (default off) so `wrangler dev` can exercise the real Keycast flow. |
| `src/index.ts` | Admin SPA served on `names.admin.divine.video` or `admin.localhost`. |
| `wrangler.toml` | `SESSION_KV` binding, `KEYCAST_URL`, `KEYCAST_CLIENT_ID`, `ADMIN_PUBKEYS` vars. |

**Frontend (React admin UI):**
| File | Change |
|------|--------|
| `admin-ui/src/context/AuthContext.tsx` | Session state + `method`-aware logout (CF Access users bounced to `/cdn-cgi/access/logout`). |
| `admin-ui/src/pages/Login.tsx` | "Sign in with Keycast" button; surfaces `?auth_error=<code>` from the OAuth callback redirect. |
| `admin-ui/src/components/Layout.tsx` | Email display + logout in nav. |
| `admin-ui/src/App.tsx` | Wrapped with `AuthProvider`. |

**Tests:** 234/234 pass (was 194 on main). New coverage for PKCE start, token exchange with stubbed Keycast response, session storage, UCAN email/pubkey extraction, OAuth start config validation, and the localhost dev bypass env gate.

## Local dev notes

For local end-to-end against a docker-based Keycast stack, set `BYPASS_LOCAL_AUTH=false` (default), point `KEYCAST_URL` at the local Keycast, set `OAUTH_CALLBACK_BASE_URL=http://admin.localhost:8787`, and run `wrangler dev --host admin.localhost`. The keycast side needs [divinevideo/keycast#114](https://github.com/divinevideo/keycast/pull/114) landed (or the equivalent patch applied locally) to accept `.localhost` subdomains as loopback. Full runbook in internal memory.

## Test plan

- [x] OAuth round-trip completes end-to-end against a real Keycast (verified locally against a docker Keycast stack at `admin.localhost:8787`)
- [x] `session.email` = real Keycast account email (from UCAN `fct` array, not the fallback literal)
- [x] `session.pubkey` = real user pubkey (from UCAN `aud` did:key, not `bunker_url`'s derived bunker pubkey)
- [x] Unauthorized pubkey gets 403 on Keycast path (authorization check in admin middleware unit-tested)
- [x] CF Access path still works (hostname-guard + JWT-presence behavior preserved; `should allow admin API requests from names.admin.divine.video with CF Access JWT` test passes)
- [x] Logout clears state (Keycast path clears `__session` cookie and KV entry; CF Access path redirects to `/cdn-cgi/access/logout`)
- [x] `234/234` unit tests, tsc clean (worker + admin-ui)
- [ ] Deploy and verify end-to-end on `names.admin.divine.video` after CF Access bypass policy is applied
- [ ] Confirm admin operations (reserve, assign, revoke) work through both auth paths in production

## Review notes

This PR went through an agent-run self-review (superpowers:code-reviewer) before requesting reviewers. Two merge-blockers and four hardening suggestions from that review were addressed in commits `b1f3b7d` and `a84b9c1`. Follow-up items filed separately: `ADMIN_EMAILS` parity for the CF Access path, JWKS verification of the CF Access JWT, Hono `Variables` type cleanup, route-level happy-path test for `/auth/status`. None block merge.
