### PR TITLE
feat: admin sort controls, stats endpoint, notes editing, and extended search

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -1,5 +1,6 @@
 import type {
   SearchResult,
+  SearchSort,
   UsernameLookupResponse,
   ReserveResponse,
   AssignResponse,
@@ -7,7 +8,8 @@ import type {
   ReservedWord,
   BulkReserveResponse,
   ApiResponse,
-  TagDetail
+  TagDetail,
+  UsernameStatsResponse
 } from '../types'
 
 const API_BASE = '/api/admin'
@@ -17,7 +19,8 @@ export async function searchUsernames(
   status?: string,
   page = 1,
   limit = 50,
-  tag?: string
+  tag?: string,
+  sort?: SearchSort
 ): Promise<SearchResult> {
   const params = new URLSearchParams({
     q: query,
@@ -31,6 +34,10 @@ export async function searchUsernames(
 
   if (tag) {
     params.set('tag', tag)
+  }
+
+  if (sort) {
+    params.set('sort', sort)
   }
 
   const response = await fetch(`${API_BASE}/usernames/search?${params}`)
@@ -236,6 +243,37 @@ export async function getAllTags(): Promise<{ tags: { tag: string; count: number
 
   if (!response.ok) {
     throw new Error(`Failed to fetch tags: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+// --- Stats ---
+
+export async function getUsernameStats(): Promise<UsernameStatsResponse> {
+  const response = await fetch(`${API_BASE}/usernames/stats`)
+
+  if (!response.ok) {
+    throw new Error(`Stats failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+// --- Notes ---
+
+export async function updateAdminNotes(
+  name: string,
+  adminNotes: string | null
+): Promise<ApiResponse & { admin_notes: string | null }> {
+  const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}/notes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ admin_notes: adminNotes }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Update notes failed: ${response.statusText}`)
   }
 
   return response.json()

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -265,7 +265,11 @@ export async function getUsernameStats(): Promise<UsernameStatsResponse> {
 export async function updateAdminNotes(
   name: string,
   adminNotes: string | null
-): Promise<ApiResponse & { admin_notes: string | null }> {
+): Promise<ApiResponse & {
+  admin_notes: string | null
+  admin_notes_updated_by?: string | null
+  admin_notes_updated_at?: number | null
+}> {
   const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}/notes`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/admin-ui/src/components/StatusBadge.tsx
+++ b/admin-ui/src/components/StatusBadge.tsx
@@ -1,7 +1,9 @@
-// ABOUTME: Displays color-coded status badges for username states (active, reserved, revoked, burned, recovered)
+// ABOUTME: Displays color-coded status badges for username states (active, reserved, revoked, burned, pending-confirmation, recovered)
 // ABOUTME: Provides visual distinction between different username lifecycle states using Tailwind classes
+import type { UsernameStatus } from '../types'
+
 interface StatusBadgeProps {
-  status: 'active' | 'reserved' | 'revoked' | 'burned'
+  status: UsernameStatus
   isRecovered?: boolean
 }
 
@@ -11,14 +13,18 @@ export default function StatusBadge({ status, isRecovered }: StatusBadgeProps) {
     reserved: 'bg-yellow-100 text-yellow-800',
     revoked: 'bg-gray-100 text-gray-800',
     burned: 'bg-red-100 text-red-800',
+    'pending-confirmation': 'bg-cyan-100 text-cyan-800',
     recovered: 'bg-purple-100 text-purple-800'
+  }
+  const labels: Record<string, string> = {
+    'pending-confirmation': 'pending confirmation',
   }
 
   const displayStatus = isRecovered ? 'recovered' : status
 
   return (
     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors[displayStatus] || colors[status]}`}>
-      {displayStatus}
+      {labels[displayStatus] || displayStatus}
     </span>
   )
 }

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -51,7 +51,9 @@ export default function Dashboard() {
   }, [query, status, currentPage, tagFilter, sort, performSearch])
 
   useEffect(() => {
-    getUsernameStats().then(data => setStats(data)).catch(() => {})
+    getUsernameStats()
+      .then(data => setStats(data))
+      .catch((err) => console.error('Failed to load username stats:', err))
   }, [])
 
   // Loads all distinct tags once at mount for the filter dropdown.
@@ -168,6 +170,7 @@ export default function Dashboard() {
               <option value="">All Statuses</option>
               <option value="active">Active</option>
               <option value="reserved">Reserved</option>
+              <option value="pending-confirmation">Pending Confirmation</option>
               <option value="recovered">Recovered (Vine)</option>
               <option value="revoked">Revoked</option>
               <option value="burned">Burned</option>

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -3,16 +3,25 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { searchUsernames, getAllTags } from '../api/client'
-import type { Username } from '../types'
+import { searchUsernames, getAllTags, getUsernameStats } from '../api/client'
+import type { SearchSort, Username, UsernameStats } from '../types'
 import StatusBadge from '../components/StatusBadge'
 import Pagination from '../components/Pagination'
+
+const SORT_OPTIONS: Array<{ value: SearchSort; label: string }> = [
+  { value: 'relevance', label: 'Best Match' },
+  { value: 'updated', label: 'Recently Updated' },
+  { value: 'newest', label: 'Newest' },
+  { value: 'oldest', label: 'Oldest' },
+]
 
 export default function Dashboard() {
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
   const [status, setStatus] = useState<string>('')
+  const [sort, setSort] = useState<SearchSort>('relevance')
   const [results, setResults] = useState<Username[]>([])
+  const [stats, setStats] = useState<UsernameStats | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [totalPages, setTotalPages] = useState(0)
   const [total, setTotal] = useState(0)
@@ -25,7 +34,7 @@ export default function Dashboard() {
     setLoading(true)
     setError(null)
     try {
-      const data = await searchUsernames(query, status || undefined, currentPage, 50, tagFilter || undefined)
+      const data = await searchUsernames(query, status || undefined, currentPage, 50, tagFilter || undefined, sort)
       setResults(data.results)
       setTotalPages(data.pagination.total_pages)
       setTotal(data.pagination.total)
@@ -35,11 +44,15 @@ export default function Dashboard() {
     } finally {
       setLoading(false)
     }
-  }, [query, status, currentPage, tagFilter])
+  }, [query, status, currentPage, tagFilter, sort])
 
   useEffect(() => {
     performSearch()
-  }, [query, status, currentPage, tagFilter, performSearch])
+  }, [query, status, currentPage, tagFilter, sort, performSearch])
+
+  useEffect(() => {
+    getUsernameStats().then(data => setStats(data)).catch(() => {})
+  }, [])
 
   // Loads all distinct tags once at mount for the filter dropdown.
   // This works as long as the tag vocabulary stays small and admin-curated (~20 values).
@@ -95,12 +108,33 @@ export default function Dashboard() {
       <div>
         <h2 className="text-2xl font-bold text-gray-900">Search Usernames</h2>
         <p className="mt-1 text-sm text-gray-600">
-          Search by username, pubkey, or email
+          Search by username, pubkey, email, tags, or internal notes
         </p>
       </div>
 
+      {stats && (
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {[
+            { label: 'All Names', value: stats.totals.all, tone: 'bg-slate-50 border-slate-200 text-slate-900' },
+            { label: 'Active', value: stats.totals.active, tone: 'bg-green-50 border-green-200 text-green-900' },
+            { label: 'Reserved', value: stats.totals.reserved, tone: 'bg-yellow-50 border-yellow-200 text-yellow-900' },
+            { label: 'Pending Confirm.', value: stats.totals.pending_confirmation, tone: 'bg-cyan-50 border-cyan-200 text-cyan-900' },
+            { label: 'With Notes', value: stats.metadata.with_notes, tone: 'bg-blue-50 border-blue-200 text-blue-900' },
+            { label: 'With Tags', value: stats.metadata.with_tags, tone: 'bg-indigo-50 border-indigo-200 text-indigo-900' },
+            { label: 'Untagged', value: stats.metadata.untagged, tone: 'bg-orange-50 border-orange-200 text-orange-900' },
+            { label: 'VIP', value: stats.metadata.vip, tone: 'bg-purple-50 border-purple-200 text-purple-900' },
+            { label: 'Updated 30d', value: stats.activity.updated_30d, tone: 'bg-emerald-50 border-emerald-200 text-emerald-900' },
+          ].map((card) => (
+            <div key={card.label} className={`rounded-lg border p-4 ${card.tone}`}>
+              <p className="text-xs font-semibold uppercase tracking-wider">{card.label}</p>
+              <p className="mt-2 text-2xl font-bold">{card.value.toLocaleString()}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="bg-white shadow rounded-lg p-6">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
           <div>
             <label htmlFor="search" className="block text-sm font-medium text-gray-700">
               Search Query
@@ -158,6 +192,25 @@ export default function Dashboard() {
                 <option key={t.tag} value={t.tag}>
                   {t.tag} ({t.count})
                 </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="sort" className="block text-sm font-medium text-gray-700">
+              Sort
+            </label>
+            <select
+              id="sort"
+              value={sort}
+              onChange={(e) => {
+                setSort(e.target.value as SearchSort)
+                setCurrentPage(1)
+              }}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm px-3 py-2 border"
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
               ))}
             </select>
           </div>

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows all metadata and provides actions like assign, revoke, burn
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTagFromUsername, getAllTags } from '../api/client'
+import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTagFromUsername, getAllTags, updateAdminNotes } from '../api/client'
 import type { Username, TagDetail } from '../types'
 import StatusBadge from '../components/StatusBadge'
 
@@ -31,6 +31,12 @@ export default function UsernameDetail() {
   const [allKnownTags, setAllKnownTags] = useState<{ tag: string; count: number }[]>([])
   const tagContainerRef = useRef<HTMLDivElement>(null)
 
+  // Notes states
+  const [draftNotes, setDraftNotes] = useState('')
+  const [notesSaving, setNotesSaving] = useState(false)
+  const [notesError, setNotesError] = useState<string | null>(null)
+  const [notesSuccess, setNotesSuccess] = useState<string | null>(null)
+
   useEffect(() => {
     loadUsername()
     getAllTags().then(data => setAllKnownTags(data.tags || [])).catch(() => {})
@@ -57,6 +63,7 @@ export default function UsernameDetail() {
         setUsername(result.username)
         setTags(result.username.tags || [])
         setTagDetails(result.username.tag_details || [])
+        setDraftNotes(result.username.admin_notes || '')
       } else {
         setError(result.error || 'Username not found')
       }
@@ -152,6 +159,30 @@ export default function UsernameDetail() {
     const date = new Date(detail.created_at * 1000).toLocaleDateString()
     const who = detail.created_by || 'unknown'
     return `Added by ${who} on ${date}`
+  }
+
+  const handleSaveNotes = async () => {
+    if (!name) return
+    setNotesSaving(true)
+    setNotesError(null)
+    setNotesSuccess(null)
+    try {
+      const result = await updateAdminNotes(name, draftNotes.trim() || null)
+      if (result.ok) {
+        const savedNotes = result.admin_notes || ''
+        setDraftNotes(savedNotes)
+        setNotesSuccess('Notes saved.')
+        if (username) {
+          setUsername({ ...username, admin_notes: result.admin_notes })
+        }
+      } else {
+        setNotesError(result.error || 'Save failed')
+      }
+    } catch (err) {
+      setNotesError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setNotesSaving(false)
+    }
   }
 
   const filteredSuggestions = allKnownTags
@@ -333,13 +364,6 @@ export default function UsernameDetail() {
             </div>
           )}
 
-          {username.admin_notes && (
-            <div>
-              <p className="text-sm font-medium text-gray-500">Admin Notes</p>
-              <p className="mt-1 text-sm text-gray-900">{username.admin_notes}</p>
-            </div>
-          )}
-
           <div>
             <p className="text-sm font-medium text-gray-500">Source</p>
             <p className="mt-1 text-sm text-gray-900">{username.claim_source}</p>
@@ -351,6 +375,41 @@ export default function UsernameDetail() {
               <p className="mt-1 text-sm text-gray-900">{username.created_by}</p>
             </div>
           )}
+        </div>
+      </div>
+
+      {/* Internal Notes Card */}
+      <div className="bg-white shadow rounded-lg overflow-hidden mb-6">
+        <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+          <h3 className="text-lg font-medium text-gray-900">Internal Notes</h3>
+        </div>
+        <div className="px-6 py-4 space-y-3">
+          <textarea
+            rows={4}
+            value={draftNotes}
+            onChange={(e) => {
+              setDraftNotes(e.target.value)
+              setNotesSuccess(null)
+            }}
+            placeholder="Add internal context for trust and safety, support, or outreach..."
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
+          />
+          {notesError && (
+            <p className="text-sm text-red-600">{notesError}</p>
+          )}
+          {notesSuccess && (
+            <p className="text-sm text-green-600">{notesSuccess}</p>
+          )}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleSaveNotes}
+              disabled={notesSaving}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50"
+            >
+              {notesSaving ? 'Saving...' : 'Save Notes'}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -6,6 +6,8 @@ import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTa
 import type { Username, TagDetail } from '../types'
 import StatusBadge from '../components/StatusBadge'
 
+const MAX_ADMIN_NOTES_LENGTH = 5000
+
 export default function UsernameDetail() {
   const { name } = useParams<{ name: string }>()
   const navigate = useNavigate()
@@ -173,7 +175,12 @@ export default function UsernameDetail() {
         setDraftNotes(savedNotes)
         setNotesSuccess('Notes saved.')
         if (username) {
-          setUsername({ ...username, admin_notes: result.admin_notes })
+          setUsername({
+            ...username,
+            admin_notes: result.admin_notes,
+            admin_notes_updated_by: result.admin_notes_updated_by || null,
+            admin_notes_updated_at: result.admin_notes_updated_at || null,
+          })
         }
       } else {
         setNotesError(result.error || 'Save failed')
@@ -237,15 +244,17 @@ export default function UsernameDetail() {
       </div>
 
       {/* Reserved banner with inline assign */}
-      {username.status === 'reserved' && !username.pubkey && (
+      {(username.status === 'reserved' || username.status === 'pending-confirmation') && !username.pubkey && (
         <div className="rounded-lg bg-amber-50 border border-amber-200 p-4 mb-6">
           <div className="flex items-start justify-between">
             <div>
               <p className="text-sm font-medium text-amber-800">
-                Reserved — no account yet
+                {username.status === 'pending-confirmation' ? 'Pending confirmation — no account yet' : 'Reserved — no account yet'}
               </p>
               <p className="mt-1 text-sm text-amber-700">
-                This name is held but not assigned to anyone. Assign a pubkey to activate it.
+                {username.status === 'pending-confirmation'
+                  ? 'This name is awaiting email confirmation and has not been assigned to anyone yet. Assign a pubkey to activate it immediately.'
+                  : 'This name is held but not assigned to anyone. Assign a pubkey to activate it.'}
                 {username.claim_source === 'vine-import' && ' Originally imported from Vine.'}
                 {username.claim_source === 'admin' && ' Manually reserved by an admin.'}
               </p>
@@ -392,8 +401,17 @@ export default function UsernameDetail() {
               setNotesSuccess(null)
             }}
             placeholder="Add internal context for trust and safety, support, or outreach..."
+            maxLength={MAX_ADMIN_NOTES_LENGTH}
             className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
           />
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>
+              {username.admin_notes_updated_at
+                ? `Last updated by ${username.admin_notes_updated_by || 'unknown'} on ${formatDate(username.admin_notes_updated_at)}`
+                : 'No edit history yet'}
+            </span>
+            <span>{draftNotes.length}/{MAX_ADMIN_NOTES_LENGTH}</span>
+          </div>
           {notesError && (
             <p className="text-sm text-red-600">{notesError}</p>
           )}
@@ -497,7 +515,7 @@ export default function UsernameDetail() {
         </div>
         <div className="px-6 py-4 space-y-4">
           {/* Assign Action — hidden for reserved+no-pubkey since the banner above handles it */}
-          {(username.status === 'revoked' || (username.status === 'reserved' && username.pubkey)) && (
+          {(username.status === 'revoked' || ((username.status === 'reserved' || username.status === 'pending-confirmation') && username.pubkey)) && (
             <div>
               {!showAssign ? (
                 <button
@@ -550,7 +568,7 @@ export default function UsernameDetail() {
           )}
 
           {/* Revoke Action */}
-          {(username.status === 'active' || username.status === 'reserved') && (
+          {(username.status === 'active' || username.status === 'reserved' || username.status === 'pending-confirmation') && (
             <div>
               {!showRevoke ? (
                 <button

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,5 +1,6 @@
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
 export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
+export type UsernameStatus = 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
 
 export interface TagDetail {
   tag: string
@@ -13,7 +14,7 @@ export interface Username {
   pubkey: string | null
   email: string | null
   relays: string | null
-  status: 'active' | 'reserved' | 'revoked' | 'burned'
+  status: UsernameStatus
   recyclable: number
   created_at: number
   updated_at: number
@@ -21,6 +22,8 @@ export interface Username {
   revoked_at: number | null
   reserved_reason: string | null
   admin_notes: string | null
+  admin_notes_updated_by?: string | null
+  admin_notes_updated_at?: number | null
   claim_source: ClaimSource
   created_by: string | null
   tags?: string[]

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,4 +1,5 @@
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
+export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
 
 export interface TagDetail {
   tag: string
@@ -85,3 +86,29 @@ export interface BulkReserveResponse extends ApiResponse {
   failed?: number
   results?: BulkReserveResult[]
 }
+
+export interface UsernameStats {
+  totals: {
+    all: number
+    active: number
+    reserved: number
+    revoked: number
+    burned: number
+    pending_confirmation: number
+  }
+  metadata: {
+    with_notes: number
+    with_tags: number
+    untagged: number
+    vip: number
+  }
+  activity: {
+    claimed_7d: number
+    claimed_30d: number
+    updated_7d: number
+    updated_30d: number
+  }
+  top_tags: Array<{ tag: string; count: number }>
+}
+
+export interface UsernameStatsResponse extends ApiResponse, UsernameStats {}

--- a/migrations/0010_add_admin_notes_audit_fields.sql
+++ b/migrations/0010_add_admin_notes_audit_fields.sql
@@ -1,0 +1,5 @@
+-- ABOUTME: Track who last edited admin notes and when for accountability.
+-- ABOUTME: Keeps lightweight audit metadata on the usernames row without a separate history table.
+
+ALTER TABLE usernames ADD COLUMN admin_notes_updated_by TEXT DEFAULT NULL;
+ALTER TABLE usernames ADD COLUMN admin_notes_updated_at INTEGER DEFAULT NULL;

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, type SearchParams, type Username } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -750,13 +750,20 @@ describe('updateAdminNotes', () => {
       { id: 1, name: 'alice', username_canonical: 'alice', status: 'active', created_at: 1000, updated_at: 1000 },
     ]
     const db = createFakeD1(recs)
-    const result = await updateAdminNotes(db, 'alice', 'Important creator')
-    expect(result).toBe(true)
+    const result = await updateAdminNotes(db, 'alice', 'Important creator', 'admin@divine.video')
+    expect(result?.admin_notes).toBe('Important creator')
+    expect(result?.admin_notes_updated_by).toBe('admin@divine.video')
+    expect(result?.admin_notes_updated_at).toBeTypeOf('number')
+
+    const updated = await getUsernameByName(db, 'alice')
+    expect(updated?.admin_notes).toBe('Important creator')
+    expect(updated?.admin_notes_updated_by).toBe('admin@divine.video')
+    expect(updated?.admin_notes_updated_at).toBeTypeOf('number')
   })
 
-  it('should return false for non-existent username', async () => {
+  it('should return null for non-existent username', async () => {
     const db = createFakeD1([])
-    const result = await updateAdminNotes(db, 'nobody', 'test')
-    expect(result).toBe(false)
+    const result = await updateAdminNotes(db, 'nobody', 'test', 'admin@divine.video')
+    expect(result).toBe(null)
   })
 })

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, type SearchParams, type Username } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -675,5 +675,88 @@ describe('username tags', () => {
     expect(tagMap.get(1)).toEqual(['vip'])
     expect(tagMap.get(2)).toEqual(['vine-legacy'])
     expect(tagMap.has(3)).toBe(false)
+  })
+})
+
+describe('search sort', () => {
+  it('should support oldest-first sorting', async () => {
+    const db = createFakeD1(mockRecords)
+    const result = await searchUsernames(db, { query: '', sort: 'oldest' })
+    expect(result.results[0].name).toBe('alice')
+    expect(result.results[result.results.length - 1].name).toBe('vineuser')
+  })
+
+  it('should support updated sorting', async () => {
+    const recs: MockRecord[] = [
+      { id: 1, name: 'old', username_canonical: 'old', status: 'active', created_at: 1000, updated_at: 9000 },
+      { id: 2, name: 'new', username_canonical: 'new', status: 'active', created_at: 9000, updated_at: 1000 },
+    ]
+    const db = createFakeD1(recs)
+    const result = await searchUsernames(db, { query: '', sort: 'updated' })
+    expect(result.results[0].name).toBe('old')
+  })
+})
+
+describe('search across notes and tags', () => {
+  it('should find usernames by admin_notes content', async () => {
+    const recs: MockRecord[] = [
+      { id: 1, name: 'alice', username_canonical: 'alice', status: 'active', admin_notes: 'VIP creator account', created_at: 1000, updated_at: 1000 },
+      { id: 2, name: 'bob', username_canonical: 'bob', status: 'active', created_at: 2000, updated_at: 2000 },
+    ]
+    const db = createFakeD1(recs)
+    const result = await searchUsernames(db, { query: 'VIP' })
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].name).toBe('alice')
+  })
+
+  it('should find usernames by tag content', async () => {
+    const recs: MockRecord[] = [
+      { id: 1, name: 'alice', username_canonical: 'alice', status: 'active', created_at: 1000, updated_at: 1000 },
+      { id: 2, name: 'bob', username_canonical: 'bob', status: 'active', created_at: 2000, updated_at: 2000 },
+    ]
+    const db = createFakeD1(recs)
+    await addTag(db, 1, 'creator', 'admin')
+    const result = await searchUsernames(db, { query: 'creator' })
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].name).toBe('alice')
+  })
+})
+
+describe('getUsernameStats', () => {
+  it('should return totals and metadata counts', async () => {
+    const recs: MockRecord[] = [
+      { id: 1, name: 'a', username_canonical: 'a', status: 'active', admin_notes: 'some note', created_at: 1000, updated_at: 1000 },
+      { id: 2, name: 'b', username_canonical: 'b', status: 'reserved', created_at: 2000, updated_at: 2000 },
+      { id: 3, name: 'c', username_canonical: 'c', status: 'pending-confirmation', created_at: 3000, updated_at: 3000 },
+    ]
+    const db = createFakeD1(recs)
+    await addTag(db, 1, 'vip', 'admin')
+    const stats = await getUsernameStats(db)
+    expect(stats.totals.all).toBe(3)
+    expect(stats.totals.active).toBe(1)
+    expect(stats.totals.reserved).toBe(1)
+    expect(stats.totals.pending_confirmation).toBe(1)
+    expect(stats.metadata.with_notes).toBe(1)
+    expect(stats.metadata.with_tags).toBe(1)
+    expect(stats.metadata.untagged).toBe(2)
+    expect(stats.metadata.vip).toBe(1)
+    expect(stats.top_tags).toContainEqual({ tag: 'vip', count: 1 })
+  })
+})
+
+describe('updateAdminNotes', () => {
+  it('should update admin_notes for an existing username', async () => {
+    const recs: MockRecord[] = [
+      { id: 1, name: 'alice', username_canonical: 'alice', status: 'active', created_at: 1000, updated_at: 1000 },
+    ]
+    const db = createFakeD1(recs)
+    const result = await updateAdminNotes(db, 'alice', 'Important creator')
+    expect(result).toBe(true)
+  })
+
+  it('should return false for non-existent username', async () => {
+    const db = createFakeD1([])
+    const result = await updateAdminNotes(db, 'nobody', 'test')
+    expect(result).toBe(false)
   })
 })

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -20,6 +20,8 @@ export interface Username {
   revoked_at: number | null
   reserved_reason: string | null
   admin_notes: string | null
+  admin_notes_updated_by: string | null
+  admin_notes_updated_at: number | null
   reservation_email: string | null
   confirmation_token: string | null
   reservation_expires_at: number | null
@@ -42,7 +44,7 @@ export interface ReservationToken {
 
 export interface SearchParams {
   query: string
-  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'recovered'
   tag?: string
   sort?: SearchSort
   page?: number
@@ -388,7 +390,7 @@ export async function deleteReservedWord(
 
 export async function exportUsernamesByStatus(
   db: D1Database,
-  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'recovered'
 ): Promise<Username[]> {
   if (status === 'recovered') {
     const result = await db.prepare(
@@ -667,45 +669,94 @@ export interface UsernameStats {
   top_tags: Array<{ tag: string; count: number }>
 }
 
-async function countQuery(db: D1Database, sql: string, ...params: unknown[]): Promise<number> {
-  const result = await db.prepare(sql).bind(...params).first<{ count: number }>()
-  return result?.count || 0
-}
-
 export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
   const now = Math.floor(Date.now() / 1000)
   const sevenDaysAgo = now - 7 * 24 * 60 * 60
   const thirtyDaysAgo = now - 30 * 24 * 60 * 60
 
-  const [
-    all, active, reserved, revoked, burned, pendingConfirmation,
-    withNotes, withTags, untagged, vip,
-    claimed7d, claimed30d, updated7d, updated30d,
-    topTagsResult,
-  ] = await Promise.all([
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'active'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'reserved'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'revoked'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'burned'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'pending-confirmation'),
-    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE admin_notes IS NOT NULL AND TRIM(admin_notes) != ''`),
-    countQuery(db, 'SELECT COUNT(DISTINCT username_id) AS count FROM username_tags'),
-    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE NOT EXISTS (SELECT 1 FROM username_tags WHERE username_tags.username_id = usernames.id)`),
-    countQuery(db, 'SELECT COUNT(DISTINCT username_id) AS count FROM username_tags WHERE tag = ?', 'vip'),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?', sevenDaysAgo),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?', thirtyDaysAgo),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?', sevenDaysAgo),
-    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?', thirtyDaysAgo),
+  const [summary, topTagsResult] = await Promise.all([
+    db.prepare(
+      `SELECT
+         COUNT(*) AS all_count,
+         SUM(CASE WHEN u.status = 'active' THEN 1 ELSE 0 END) AS active_count,
+         SUM(CASE WHEN u.status = 'reserved' THEN 1 ELSE 0 END) AS reserved_count,
+         SUM(CASE WHEN u.status = 'revoked' THEN 1 ELSE 0 END) AS revoked_count,
+         SUM(CASE WHEN u.status = 'burned' THEN 1 ELSE 0 END) AS burned_count,
+         SUM(CASE WHEN u.status = 'pending-confirmation' THEN 1 ELSE 0 END) AS pending_confirmation_count,
+         SUM(CASE WHEN u.admin_notes IS NOT NULL AND TRIM(u.admin_notes) != '' THEN 1 ELSE 0 END) AS with_notes_count,
+         SUM(CASE WHEN tagged.username_id IS NOT NULL THEN 1 ELSE 0 END) AS with_tags_count,
+         SUM(CASE WHEN tagged.username_id IS NULL THEN 1 ELSE 0 END) AS untagged_count,
+         SUM(CASE WHEN vip.username_id IS NOT NULL THEN 1 ELSE 0 END) AS vip_count,
+         SUM(CASE WHEN u.claimed_at IS NOT NULL AND u.claimed_at >= ? THEN 1 ELSE 0 END) AS claimed_7d_count,
+         SUM(CASE WHEN u.claimed_at IS NOT NULL AND u.claimed_at >= ? THEN 1 ELSE 0 END) AS claimed_30d_count,
+         SUM(CASE WHEN u.updated_at >= ? THEN 1 ELSE 0 END) AS updated_7d_count,
+         SUM(CASE WHEN u.updated_at >= ? THEN 1 ELSE 0 END) AS updated_30d_count
+       FROM usernames u
+       LEFT JOIN (
+         SELECT DISTINCT username_id FROM username_tags
+       ) tagged ON tagged.username_id = u.id
+       LEFT JOIN (
+         SELECT DISTINCT username_id FROM username_tags WHERE tag = 'vip'
+       ) vip ON vip.username_id = u.id`
+    ).bind(sevenDaysAgo, thirtyDaysAgo, sevenDaysAgo, thirtyDaysAgo).first<{
+      all_count: number
+      active_count: number
+      reserved_count: number
+      revoked_count: number
+      burned_count: number
+      pending_confirmation_count: number
+      with_notes_count: number
+      with_tags_count: number
+      untagged_count: number
+      vip_count: number
+      claimed_7d_count: number
+      claimed_30d_count: number
+      updated_7d_count: number
+      updated_30d_count: number
+    }>(),
     db.prepare(
       'SELECT tag, COUNT(*) AS count FROM username_tags GROUP BY tag ORDER BY count DESC, tag ASC LIMIT 10'
     ).bind().all<{ tag: string; count: number }>(),
   ])
 
+  const stats = summary || {
+    all_count: 0,
+    active_count: 0,
+    reserved_count: 0,
+    revoked_count: 0,
+    burned_count: 0,
+    pending_confirmation_count: 0,
+    with_notes_count: 0,
+    with_tags_count: 0,
+    untagged_count: 0,
+    vip_count: 0,
+    claimed_7d_count: 0,
+    claimed_30d_count: 0,
+    updated_7d_count: 0,
+    updated_30d_count: 0,
+  }
+
   return {
-    totals: { all, active, reserved, revoked, burned, pending_confirmation: pendingConfirmation },
-    metadata: { with_notes: withNotes, with_tags: withTags, untagged, vip },
-    activity: { claimed_7d: claimed7d, claimed_30d: claimed30d, updated_7d: updated7d, updated_30d: updated30d },
+    totals: {
+      all: stats.all_count,
+      active: stats.active_count,
+      reserved: stats.reserved_count,
+      revoked: stats.revoked_count,
+      burned: stats.burned_count,
+      pending_confirmation: stats.pending_confirmation_count,
+    },
+    metadata: {
+      with_notes: stats.with_notes_count,
+      with_tags: stats.with_tags_count,
+      untagged: stats.untagged_count,
+      vip: stats.vip_count,
+    },
+    activity: {
+      claimed_7d: stats.claimed_7d_count,
+      claimed_30d: stats.claimed_30d_count,
+      updated_7d: stats.updated_7d_count,
+      updated_30d: stats.updated_30d_count,
+    },
     top_tags: topTagsResult.results,
   }
 }
@@ -715,14 +766,20 @@ export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
 export async function updateAdminNotes(
   db: D1Database,
   name: string,
-  adminNotes: string | null
-): Promise<boolean> {
+  adminNotes: string | null,
+  updatedBy: string | null
+): Promise<Pick<Username, 'admin_notes' | 'admin_notes_updated_by' | 'admin_notes_updated_at'> | null> {
   const username = await getUsernameByName(db, name)
-  if (!username) return false
+  if (!username) return null
 
   const now = Math.floor(Date.now() / 1000)
   await db.prepare(
-    'UPDATE usernames SET admin_notes = ?, updated_at = ? WHERE id = ?'
-  ).bind(adminNotes, now, username.id).run()
-  return true
+    'UPDATE usernames SET admin_notes = ?, admin_notes_updated_by = ?, admin_notes_updated_at = ?, updated_at = ? WHERE id = ?'
+  ).bind(adminNotes, updatedBy, now, now, username.id).run()
+
+  return {
+    admin_notes: adminNotes,
+    admin_notes_updated_by: updatedBy,
+    admin_notes_updated_at: now,
+  }
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Provides type-safe D1 database operations
 
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
+export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
 
 export interface Username {
   id: number
@@ -43,6 +44,7 @@ export interface SearchParams {
   query: string
   status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered'
   tag?: string
+  sort?: SearchSort
   page?: number
   limit?: number
 }
@@ -229,7 +231,7 @@ export async function searchUsernames(
   db: D1Database,
   params: SearchParams
 ): Promise<SearchResult> {
-  const { query, status, page = 1, limit = 50 } = params
+  const { query, status, sort = 'relevance', page = 1, limit = 50 } = params
   const offset = (page - 1) * limit
 
   // Build WHERE clause
@@ -237,11 +239,11 @@ export async function searchUsernames(
   const queryParams: any[] = []
   const escapedQuery = query && query.length > 0 ? escapeLikePattern(query) : ''
 
-  // If query is empty, don't filter by name/pubkey/email
+  // Search across name, pubkey, email, admin_notes, and tags
   if (escapedQuery) {
     const searchPattern = `%${escapedQuery}%`
-    whereClause = `(name LIKE ? OR username_display LIKE ? OR username_canonical LIKE ? OR pubkey LIKE ? OR email LIKE ?)`
-    queryParams.push(searchPattern, searchPattern, searchPattern, searchPattern, searchPattern)
+    whereClause = `(name LIKE ? OR username_display LIKE ? OR username_canonical LIKE ? OR pubkey LIKE ? OR email LIKE ? OR admin_notes LIKE ? OR EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ?))`
+    queryParams.push(searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern)
   }
 
   // Add status filter if provided
@@ -286,19 +288,41 @@ export async function searchUsernames(
   const total = countResult?.count || 0
   const totalPages = Math.ceil(total / limit)
 
-  // Get paginated results
-  // When searching by name, score by match quality: exact > prefix > substring
+  // Build ORDER BY clause based on sort parameter
+  // Bind order: ...queryParams, ...orderParams, limit, offset
   let orderClause = 'created_at DESC'
   const orderParams: any[] = []
-  if (escapedQuery) {
+
+  if (sort === 'oldest') {
+    orderClause = 'created_at ASC'
+  } else if (sort === 'updated') {
+    orderClause = 'updated_at DESC, created_at DESC'
+  } else if (sort === 'newest') {
+    orderClause = 'created_at DESC'
+  } else if (escapedQuery) {
+    // sort === 'relevance' with a search query: rank by match quality
     const canonical = query!.toLowerCase()
     const prefixPattern = `${escapedQuery}%`
+    const containsPattern = `%${escapedQuery}%`
     orderClause = `CASE
       WHEN username_canonical = ? THEN 0
       WHEN username_canonical LIKE ? THEN 1
-      ELSE 2
-    END, created_at DESC`
-    orderParams.push(canonical, prefixPattern)
+      WHEN name LIKE ? OR username_display LIKE ? THEN 2
+      WHEN EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag = ?) THEN 3
+      WHEN EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ?) THEN 4
+      WHEN pubkey = ? OR email = ? THEN 5
+      WHEN pubkey LIKE ? OR email LIKE ? THEN 6
+      WHEN admin_notes LIKE ? THEN 7
+      ELSE 8
+    END, updated_at DESC, created_at DESC`
+    orderParams.push(
+      canonical, prefixPattern,
+      containsPattern, containsPattern,
+      canonical, containsPattern,
+      canonical, canonical,
+      containsPattern, containsPattern,
+      containsPattern
+    )
   }
 
   const results = await db.prepare(
@@ -615,4 +639,90 @@ export async function getAllTags(
     'SELECT tag, COUNT(*) as count FROM username_tags GROUP BY tag ORDER BY tag'
   ).bind().all<{ tag: string; count: number }>()
   return result.results
+}
+
+// --- Stats ---
+
+export interface UsernameStats {
+  totals: {
+    all: number
+    active: number
+    reserved: number
+    revoked: number
+    burned: number
+    pending_confirmation: number
+  }
+  metadata: {
+    with_notes: number
+    with_tags: number
+    untagged: number
+    vip: number
+  }
+  activity: {
+    claimed_7d: number
+    claimed_30d: number
+    updated_7d: number
+    updated_30d: number
+  }
+  top_tags: Array<{ tag: string; count: number }>
+}
+
+async function countQuery(db: D1Database, sql: string, ...params: unknown[]): Promise<number> {
+  const result = await db.prepare(sql).bind(...params).first<{ count: number }>()
+  return result?.count || 0
+}
+
+export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
+  const now = Math.floor(Date.now() / 1000)
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60
+  const thirtyDaysAgo = now - 30 * 24 * 60 * 60
+
+  const [
+    all, active, reserved, revoked, burned, pendingConfirmation,
+    withNotes, withTags, untagged, vip,
+    claimed7d, claimed30d, updated7d, updated30d,
+    topTagsResult,
+  ] = await Promise.all([
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'active'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'reserved'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'revoked'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'burned'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE status = ?', 'pending-confirmation'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE admin_notes IS NOT NULL AND TRIM(admin_notes) != ''`),
+    countQuery(db, 'SELECT COUNT(DISTINCT username_id) AS count FROM username_tags'),
+    countQuery(db, `SELECT COUNT(*) AS count FROM usernames WHERE NOT EXISTS (SELECT 1 FROM username_tags WHERE username_tags.username_id = usernames.id)`),
+    countQuery(db, 'SELECT COUNT(DISTINCT username_id) AS count FROM username_tags WHERE tag = ?', 'vip'),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?', sevenDaysAgo),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE claimed_at IS NOT NULL AND claimed_at >= ?', thirtyDaysAgo),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?', sevenDaysAgo),
+    countQuery(db, 'SELECT COUNT(*) AS count FROM usernames WHERE updated_at >= ?', thirtyDaysAgo),
+    db.prepare(
+      'SELECT tag, COUNT(*) AS count FROM username_tags GROUP BY tag ORDER BY count DESC, tag ASC LIMIT 10'
+    ).bind().all<{ tag: string; count: number }>(),
+  ])
+
+  return {
+    totals: { all, active, reserved, revoked, burned, pending_confirmation: pendingConfirmation },
+    metadata: { with_notes: withNotes, with_tags: withTags, untagged, vip },
+    activity: { claimed_7d: claimed7d, claimed_30d: claimed30d, updated_7d: updated7d, updated_30d: updated30d },
+    top_tags: topTagsResult.results,
+  }
+}
+
+// --- Admin notes ---
+
+export async function updateAdminNotes(
+  db: D1Database,
+  name: string,
+  adminNotes: string | null
+): Promise<boolean> {
+  const username = await getUsernameByName(db, name)
+  if (!username) return false
+
+  const now = Math.floor(Date.now() / 1000)
+  await db.prepare(
+    'UPDATE usernames SET admin_notes = ?, updated_at = ? WHERE id = ?'
+  ).bind(adminNotes, now, username.id).run()
+  return true
 }

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -101,6 +101,29 @@ export function createFakeD1(records: MockRecord[]) {
                 return { count: new Set(tags.map(t => t.username_id)).size }
               }
 
+              // Consolidated stats summary query
+              if (sql.includes('all_count') && sql.includes('pending_confirmation_count')) {
+                const [sevenDaysAgo, thirtyDaysAgo, updatedSevenDaysAgo, updatedThirtyDaysAgo] = boundParams
+                const taggedIds = new Set(tags.map(t => t.username_id))
+                const vipIds = new Set(tags.filter(t => t.tag === 'vip').map(t => t.username_id))
+                return {
+                  all_count: records.length,
+                  active_count: records.filter(u => u.status === 'active').length,
+                  reserved_count: records.filter(u => u.status === 'reserved').length,
+                  revoked_count: records.filter(u => u.status === 'revoked').length,
+                  burned_count: records.filter(u => u.status === 'burned').length,
+                  pending_confirmation_count: records.filter(u => u.status === 'pending-confirmation').length,
+                  with_notes_count: records.filter(u => typeof u.admin_notes === 'string' && u.admin_notes.trim().length > 0).length,
+                  with_tags_count: records.filter(u => u.id != null && taggedIds.has(u.id)).length,
+                  untagged_count: records.filter(u => u.id == null || !taggedIds.has(u.id)).length,
+                  vip_count: records.filter(u => u.id != null && vipIds.has(u.id)).length,
+                  claimed_7d_count: records.filter(u => typeof u.claimed_at === 'number' && u.claimed_at >= sevenDaysAgo).length,
+                  claimed_30d_count: records.filter(u => typeof u.claimed_at === 'number' && u.claimed_at >= thirtyDaysAgo).length,
+                  updated_7d_count: records.filter(u => (u.updated_at || 0) >= updatedSevenDaysAgo).length,
+                  updated_30d_count: records.filter(u => (u.updated_at || 0) >= updatedThirtyDaysAgo).length,
+                }
+              }
+
               // COUNT query
               if (sql.includes('COUNT(*)')) {
                 // Search COUNT (has LIKE patterns) — handle first to avoid matching stats patterns
@@ -240,10 +263,12 @@ export function createFakeD1(records: MockRecord[]) {
             run: async () => {
               // Admin notes UPDATE
               if (sql.includes('UPDATE usernames') && sql.includes('admin_notes = ?')) {
-                const [adminNotes, updatedAt, id] = boundParams
+                const [adminNotes, updatedBy, updatedAtNotes, updatedAt, id] = boundParams
                 const rec = records.find(r => r.id === id)
                 if (rec) {
                   rec.admin_notes = adminNotes
+                  rec.admin_notes_updated_by = updatedBy
+                  rec.admin_notes_updated_at = updatedAtNotes
                   rec.updated_at = updatedAt
                 }
                 return { success: true, meta: { changes: rec ? 1 : 0 } }

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -39,17 +39,23 @@ export function createFakeD1(records: MockRecord[]) {
         return boundParams.find((p) => typeof p === 'string' && statuses.includes(p)) || null
       }
 
-      // Filter records by search term (matches name, display, canonical, pubkey, email)
+      // Filter records by search term (matches name, display, canonical, pubkey, email, admin_notes, tags)
       function applySearch(data: MockRecord[]): MockRecord[] {
         const term = extractSearchTerm()
         if (!term || term.length === 0) return data
         return data.filter(
-          (u) =>
-            u.name?.includes(term) ||
-            u.username_display?.includes(term) ||
-            u.username_canonical?.includes(term) ||
-            u.pubkey?.includes(term) ||
-            u.email?.includes(term)
+          (u) => {
+            const userTags = tags.filter(t => t.username_id === u.id).map(t => t.tag)
+            return (
+              u.name?.includes(term) ||
+              u.username_display?.includes(term) ||
+              u.username_canonical?.includes(term) ||
+              u.pubkey?.includes(term) ||
+              u.email?.includes(term) ||
+              u.admin_notes?.includes(term) ||
+              userTags.some(t => t.includes(term))
+            )
+          }
         )
       }
 
@@ -86,10 +92,49 @@ export function createFakeD1(records: MockRecord[]) {
           boundParams = params
           return {
             first: async () => {
+              // Stats COUNT queries on username_tags (not search queries with EXISTS subqueries)
+              if (sql.includes('COUNT(DISTINCT username_id)') && sql.includes('FROM username_tags')) {
+                if (sql.includes('tag = ?')) {
+                  const tagVal = boundParams[0]
+                  return { count: new Set(tags.filter(t => t.tag === tagVal).map(t => t.username_id)).size }
+                }
+                return { count: new Set(tags.map(t => t.username_id)).size }
+              }
+
               // COUNT query
               if (sql.includes('COUNT(*)')) {
+                // Search COUNT (has LIKE patterns) — handle first to avoid matching stats patterns
+                if (sql.includes('LIKE')) {
+                  let filtered = [...records]
+                  filtered = applySearch(filtered)
+                  if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
+                    filtered = applyRecoveredFilter(filtered)
+                  } else {
+                    filtered = applyStatusFilter(filtered)
+                  }
+                  return { count: filtered.length }
+                }
+                // Stats: admin_notes presence
+                if (sql.includes('admin_notes IS NOT NULL')) {
+                  return { count: records.filter(u => typeof u.admin_notes === 'string' && u.admin_notes.trim().length > 0).length }
+                }
+                // Stats: untagged
+                if (sql.includes('NOT EXISTS') && sql.includes('username_tags')) {
+                  return { count: records.filter(u => !tags.some(t => t.username_id === u.id)).length }
+                }
+                // Stats: claimed_at window
+                if (sql.includes('claimed_at IS NOT NULL') && sql.includes('claimed_at >= ?')) {
+                  const since = boundParams[0]
+                  return { count: records.filter(u => typeof u.claimed_at === 'number' && u.claimed_at >= since).length }
+                }
+                // Stats: updated_at window
+                if (sql.includes('updated_at >= ?')) {
+                  const since = boundParams[0]
+                  return { count: records.filter(u => (u.updated_at || 0) >= since).length }
+                }
+
+                // Non-search COUNT (status filter only, no LIKE)
                 let filtered = [...records]
-                if (sql.includes('LIKE')) filtered = applySearch(filtered)
                 if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
                   filtered = applyRecoveredFilter(filtered)
                 } else {
@@ -119,8 +164,8 @@ export function createFakeD1(records: MockRecord[]) {
             },
 
             all: async () => {
-              // Tag queries
-              if (sql.includes('username_tags')) {
+              // Tag queries (but not search queries that reference tags in EXISTS subqueries)
+              if (sql.includes('username_tags') && !sql.includes('FROM usernames')) {
                 // SELECT tag FROM username_tags WHERE username_id = ?
                 if (sql.includes('WHERE username_id = ?') && !sql.includes('IN (')) {
                   const uid = boundParams[0]
@@ -137,7 +182,14 @@ export function createFakeD1(records: MockRecord[]) {
                   for (const t of tags) {
                     counts.set(t.tag, (counts.get(t.tag) || 0) + 1)
                   }
-                  return { results: Array.from(counts.entries()).map(([tag, count]) => ({ tag, count })).sort((a, b) => a.tag.localeCompare(b.tag)) }
+                  const entries = Array.from(counts.entries()).map(([tag, count]) => ({ tag, count }))
+                  // Respect ORDER BY count DESC if present
+                  if (sql.includes('count DESC')) {
+                    entries.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+                  } else {
+                    entries.sort((a, b) => a.tag.localeCompare(b.tag))
+                  }
+                  return { results: entries }
                 }
                 return { results: [] }
               }
@@ -156,9 +208,13 @@ export function createFakeD1(records: MockRecord[]) {
                 filtered = applyStatusFilter(filtered)
               }
 
-              // Tag filter via EXISTS subquery
-              if (sql.includes('username_tags') && sql.includes('EXISTS')) {
-                const tagParam = boundParams.find(p => typeof p === 'string' && !p.includes('%'))
+              // Tag filter via exact-match EXISTS subquery in WHERE clause (AND ut.tag = ?)
+              // The ORDER BY CASE also uses ut.tag = ? for relevance ranking — distinguish
+              // by checking for the pattern in the WHERE clause (before ORDER BY)
+              const whereClause = sql.split('ORDER BY')[0]
+              if (whereClause.includes('ut.tag = ?')) {
+                // The exact tag param is the last non-% string before limit/offset
+                const tagParam = boundParams.find(p => typeof p === 'string' && !p.includes('%') && !['active', 'reserved', 'revoked', 'burned', 'pending-confirmation'].includes(p))
                 if (tagParam) {
                   const taggedIds = new Set(tags.filter(t => t.tag === tagParam).map(t => t.username_id))
                   filtered = filtered.filter(u => u.id != null && taggedIds.has(u.id))
@@ -167,14 +223,31 @@ export function createFakeD1(records: MockRecord[]) {
 
               const { limit, offset } = extractPagination()
 
+              // Respect sort order from SQL
+              if (sql.includes('created_at ASC')) {
+                filtered.sort((a, b) => (a.created_at || 0) - (b.created_at || 0))
+              } else if (sql.includes('updated_at DESC')) {
+                filtered.sort((a, b) => (b.updated_at || 0) - (a.updated_at || 0))
+              } else {
+                filtered.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+              }
+
               return {
-                results: filtered
-                  .sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
-                  .slice(offset, offset + limit),
+                results: filtered.slice(offset, offset + limit),
               }
             },
 
             run: async () => {
+              // Admin notes UPDATE
+              if (sql.includes('UPDATE usernames') && sql.includes('admin_notes = ?')) {
+                const [adminNotes, updatedAt, id] = boundParams
+                const rec = records.find(r => r.id === id)
+                if (rec) {
+                  rec.admin_notes = adminNotes
+                  rec.updated_at = updatedAt
+                }
+                return { success: true, meta: { changes: rec ? 1 : 0 } }
+              }
               // Tag INSERT
               if (sql.includes('INSERT') && sql.includes('username_tags')) {
                 const [username_id, tag, created_at, created_by] = boundParams

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { Hono } from 'hono'
 import admin from './admin'
+import { getUsernameByName } from '../db/queries'
 
 // Mock the email utility so tests don't hit SendGrid
 vi.mock('../utils/email', () => ({
@@ -66,6 +67,27 @@ describe('Admin Search Endpoint', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(true)
     expect(json.results).toBeDefined()
+  })
+
+  it('should allow pending-confirmation as a status filter', async () => {
+    const app = createTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'pendinguser', username_display: 'pendinguser', username_canonical: 'pendinguser',
+        pubkey: null, email: 'pending@example.com', relays: null, status: 'pending-confirmation',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: null,
+        revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    const req = new Request('http://localhost/admin/usernames/search?q=&status=pending-confirmation')
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.results).toHaveLength(1)
+    expect(json.results[0].status).toBe('pending-confirmation')
   })
 
   it('should return 400 if query is too long', async () => {
@@ -995,18 +1017,26 @@ describe('Admin Notes Endpoint', () => {
 
   it('should update admin notes for existing username', async () => {
     const app = createTestApp()
+    const db = createMockDB()
 
     const req = new Request('http://localhost/admin/username/testuser/notes', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'VIP creator account' }),
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.ok).toBe(true)
     expect(json.admin_notes).toBe('VIP creator account')
+    expect(json.admin_notes_updated_by).toBe('dev@local')
+    expect(json.admin_notes_updated_at).toBeTypeOf('number')
+
+    const username = await getUsernameByName(db, 'testuser')
+    expect(username?.admin_notes).toBe('VIP creator account')
+    expect(username?.admin_notes_updated_by).toBe('dev@local')
+    expect(username?.admin_notes_updated_at).toBeTypeOf('number')
   })
 
   it('should return 404 for non-existent username', async () => {
@@ -1020,5 +1050,64 @@ describe('Admin Notes Endpoint', () => {
     const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(404)
+  })
+
+  it('should reject non-string admin_notes payloads', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/testuser/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ admin_notes: { nope: true } }),
+    })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('string or null')
+  })
+
+  it('should reject admin_notes that exceed the max length', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/testuser/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ admin_notes: 'a'.repeat(5001) }),
+    })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('5000')
+  })
+})
+
+describe('Admin Export Endpoint', () => {
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
+    app.route('/admin', admin)
+    return app
+  }
+
+  it('should allow exporting pending-confirmation usernames', async () => {
+    const app = createTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'pendinguser', username_display: 'pendinguser', username_canonical: 'pendinguser',
+        pubkey: null, email: 'pending@example.com', relays: null, status: 'pending-confirmation',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: null,
+        revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    const req = new Request('http://localhost/admin/export/csv?status=pending-confirmation')
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/csv')
+    const csv = await res.text()
+    expect(csv).toContain('pending-confirmation')
+    expect(csv).toContain('pendinguser')
   })
 })

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -108,6 +108,18 @@ describe('Admin Search Endpoint', () => {
     expect(json.error).toContain('Invalid status parameter')
   })
 
+  it('should return 400 if sort parameter is invalid', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/usernames/search?q=test&sort=weird')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.ok).toBe(false)
+    expect(json.error).toContain('Invalid sort parameter')
+  })
+
   it('should return 400 if page is negative', async () => {
     const app = createTestApp()
 
@@ -947,5 +959,66 @@ describe('Admin Tag Endpoints', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(false)
     expect(json.error).toContain('50')
+  })
+})
+
+describe('Admin Stats Endpoint', () => {
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    app.route('/admin', admin)
+    return app
+  }
+
+  it('should return stats', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/usernames/stats')
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.totals).toBeDefined()
+    expect(json.totals.pending_confirmation).toBeDefined()
+    expect(json.metadata).toBeDefined()
+    expect(json.activity).toBeDefined()
+    expect(json.top_tags).toBeDefined()
+  })
+})
+
+describe('Admin Notes Endpoint', () => {
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    app.route('/admin', admin)
+    return app
+  }
+
+  it('should update admin notes for existing username', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/testuser/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ admin_notes: 'VIP creator account' }),
+    })
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.admin_notes).toBe('VIP creator account')
+  })
+
+  it('should return 404 for non-existent username', async () => {
+    const app = createTestApp()
+
+    const req = new Request('http://localhost/admin/username/doesnotexist/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ admin_notes: 'test' }),
+    })
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(404)
   })
 })

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -112,7 +112,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&sort=weird')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -973,7 +973,7 @@ describe('Admin Stats Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/stats')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -1001,7 +1001,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'VIP creator account' }),
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -1017,7 +1017,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'test' }),
     })
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
 
     expect(res.status).toBe(404)
   })

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -11,6 +11,10 @@ import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
+const MAX_ADMIN_NOTES_LENGTH = 5000
+const VALID_ADMIN_STATUSES = ['active', 'reserved', 'revoked', 'burned', 'pending-confirmation', 'recovered'] as const
+type AdminStatusFilter = (typeof VALID_ADMIN_STATUSES)[number]
+
 /** Convert a 64-char hex pubkey to npub bech32 format */
 function hexToNpub(hex: string): string {
   try {
@@ -118,7 +122,7 @@ admin.use('*', async (c, next) => {
 admin.get('/usernames/search', async (c) => {
   try {
     const query = c.req.query('q')
-    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
+    const status = c.req.query('status') as AdminStatusFilter | undefined
     const sort = c.req.query('sort') as SearchSort | undefined
     const pageStr = c.req.query('page') || '1'
     const limitStr = c.req.query('limit') || '50'
@@ -133,8 +137,7 @@ admin.get('/usernames/search', async (c) => {
     }
 
     // Validate status parameter
-    const validStatuses = ['active', 'reserved', 'revoked', 'burned', 'recovered']
-    if (status && !validStatuses.includes(status)) {
+    if (status && !VALID_ADMIN_STATUSES.includes(status)) {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
     }
 
@@ -221,15 +224,26 @@ admin.post('/username/:name/notes', async (c) => {
     }
 
     const body = await c.req.json<{ admin_notes?: string | null }>()
+    if (body.admin_notes !== undefined && body.admin_notes !== null && typeof body.admin_notes !== 'string') {
+      return c.json({ ok: false, error: 'admin_notes must be a string or null' }, 400)
+    }
+
     const adminNotes = body.admin_notes !== undefined ? body.admin_notes : null
     const trimmed = typeof adminNotes === 'string' && adminNotes.trim() ? adminNotes.trim() : null
 
-    const updated = await updateAdminNotes(c.env.DB, name, trimmed)
+    if (trimmed && trimmed.length > MAX_ADMIN_NOTES_LENGTH) {
+      return c.json({ ok: false, error: `admin_notes must be ${MAX_ADMIN_NOTES_LENGTH} characters or less` }, 400)
+    }
+
+    const updatedBy = (c.get('adminEmail' as never) as string) || null
+    const updated = await updateAdminNotes(c.env.DB, name, trimmed, updatedBy)
     if (!updated) {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
 
-    return c.json({ ok: true, admin_notes: trimmed })
+    console.log(`Admin notes updated for "${name}" by ${updatedBy || 'unknown'} (${trimmed?.length || 0} chars)`)
+
+    return c.json({ ok: true, ...updated })
   } catch (error) {
     console.error('Update notes error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
@@ -639,11 +653,10 @@ admin.post('/username/assign-bulk', async (c) => {
 
 admin.get('/export/csv', async (c) => {
   try {
-    const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
+    const status = c.req.query('status') as AdminStatusFilter | undefined
 
     // Validate status parameter
-    const validStatuses = ['active', 'reserved', 'revoked', 'burned', 'recovered']
-    if (status && !validStatuses.includes(status)) {
+    if (status && !VALID_ADMIN_STATUSES.includes(status)) {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
     }
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,7 +5,7 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -119,6 +119,7 @@ admin.get('/usernames/search', async (c) => {
   try {
     const query = c.req.query('q')
     const status = c.req.query('status') as 'active' | 'reserved' | 'revoked' | 'burned' | 'recovered' | undefined
+    const sort = c.req.query('sort') as SearchSort | undefined
     const pageStr = c.req.query('page') || '1'
     const limitStr = c.req.query('limit') || '50'
 
@@ -135,6 +136,12 @@ admin.get('/usernames/search', async (c) => {
     const validStatuses = ['active', 'reserved', 'revoked', 'burned', 'recovered']
     if (status && !validStatuses.includes(status)) {
       return c.json({ ok: false, error: 'Invalid status parameter' }, 400)
+    }
+
+    // Validate sort parameter
+    const validSorts: SearchSort[] = ['relevance', 'newest', 'oldest', 'updated']
+    if (sort && !validSorts.includes(sort)) {
+      return c.json({ ok: false, error: 'Invalid sort parameter' }, 400)
     }
 
     // Validate page parameter
@@ -154,7 +161,7 @@ admin.get('/usernames/search', async (c) => {
 
     const tagRaw = c.req.query('tag')
     const tag = tagRaw && tagRaw.length <= 50 ? tagRaw : undefined
-    const result = await searchUsernames(c.env.DB, { query, status, tag, page, limit: cappedLimit })
+    const result = await searchUsernames(c.env.DB, { query, status, tag, sort, page, limit: cappedLimit })
 
     // Batch-load tags for result set
     const ids = result.results.map((r: any) => r.id).filter(Boolean)
@@ -171,6 +178,16 @@ admin.get('/usernames/search', async (c) => {
     })
   } catch (error) {
     console.error('Search error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.get('/usernames/stats', async (c) => {
+  try {
+    const stats = await getUsernameStats(c.env.DB)
+    return c.json({ ok: true, ...stats })
+  } catch (error) {
+    console.error('Username stats error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })
@@ -192,6 +209,29 @@ admin.get('/username/:name', async (c) => {
     return c.json({ ok: true, username: { ...username, tags, tag_details: tagDetails } })
   } catch (error) {
     console.error('Username lookup error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.post('/username/:name/notes', async (c) => {
+  try {
+    const name = c.req.param('name')
+    if (!name) {
+      return c.json({ ok: false, error: 'Name parameter is required' }, 400)
+    }
+
+    const body = await c.req.json<{ admin_notes?: string | null }>()
+    const adminNotes = body.admin_notes !== undefined ? body.admin_notes : null
+    const trimmed = typeof adminNotes === 'string' && adminNotes.trim() ? adminNotes.trim() : null
+
+    const updated = await updateAdminNotes(c.env.DB, name, trimmed)
+    if (!updated) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    return c.json({ ok: true, admin_notes: trimmed })
+  } catch (error) {
+    console.error('Update notes error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })


### PR DESCRIPTION
## Summary

- **Sort controls**: `relevance`/`newest`/`oldest`/`updated` dropdown on dashboard and `sort` query param on search API
- **Stats endpoint**: `GET /usernames/stats` with totals, metadata coverage, activity windows, and top tags — rendered as stat cards on the dashboard
- **Notes editing**: Editable `admin_notes` textarea on the username detail page via `POST /username/:name/notes`
- **Extended search**: Free-text search now matches `admin_notes` and tags (via EXISTS subquery), not just name/pubkey/email
- **Deeper relevance ranking**: 9-tier CASE expression (exact name > prefix > substring > exact tag > tag substring > exact pubkey/email > pubkey/email substring > notes match > rest)
- **Rebased onto current `main`** and reconciled with the newer admin auth changes
- **Follow-up fix**: stats now expose `pending_confirmation`, and the notes editor normalizes the saved value back into the textarea

Closes #33
Carries forward features from #21 (closed) that weren't covered by #27.

## Test plan
- [x] `npm run test:once` passes on the rebased branch: 263 tests across 11 files
- [x] `npm run build:admin` passes on the rebased branch
- [x] Added coverage for sort validation, stats endpoint, notes update, `admin_notes` search, tag search, and pending-confirmation stats handling
- [ ] Visual: sort dropdown changes result order
- [ ] Visual: stat cards render on dashboard
- [ ] Visual: notes textarea saves and persists on detail page
