### PR TITLE
fix: clear revoked_at on username reactivation

### DIFF
--- a/docs/superpowers/plans/2026-04-23-e2e-claim-nip05-tests.md
+++ b/docs/superpowers/plans/2026-04-23-e2e-claim-nip05-tests.md
@@ -1,0 +1,607 @@
+# E2E Claim → NIP-05 Resolution Test Coverage
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add route-level tests that exercise the full claim → NIP-05 resolution path, proving that a claimed username resolves correctly via `/.well-known/nostr.json` and that the `revoked_at` bug from PR #35 stays fixed.
+
+**Architecture:** Mount both the username route (`/api/username`) and the NIP-05 route (`/.well-known/nostr.json`) on a single test Hono app. Upgrade `createMockDB` in `username.test.ts` to track `revoked_at` mutations faithfully on the ON CONFLICT path (the same technique used by `createStatefulMockDB` in `queries.test.ts`). Each test scenario claims a name via HTTP POST, then queries NIP-05 via HTTP GET on the same app to verify resolution.
+
+**Tech Stack:** Vitest, Hono, existing mock infrastructure
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/routes/claim-nip05.e2e.test.ts` | End-to-end tests: claim → NIP-05 resolution |
+
+The new file keeps e2e tests separate from the existing unit/route tests in `username.test.ts`. It imports the existing `createMockDB` from `username.test.ts` would be an option, but since that function is not exported and modifying it would risk breaking existing tests, we'll define a self-contained mock DB in the new test file that correctly handles the two-step revoke+upsert flow.
+
+---
+
+### Task 1: Create e2e test scaffold with mock DB
+
+**Files:**
+- Create: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Create the test file with imports, mocks, and mock DB**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import username from './username'
+import nip05 from './nip05'
+
+vi.mock('../middleware/nip98', () => ({
+  verifyNip98Event: vi.fn()
+}))
+
+vi.mock('../utils/email', () => ({
+  sendReservationConfirmationEmail: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../utils/fastly-sync', () => ({
+  syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
+  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true })
+}))
+
+type MockUsername = {
+  id: number
+  name: string
+  username_display: string
+  username_canonical: string
+  pubkey: string | null
+  relays: string | null
+  status: string
+  recyclable: number
+  created_at: number
+  updated_at: number
+  claimed_at: number | null
+  revoked_at: number | null
+  reserved_reason: string | null
+  admin_notes: string | null
+  email: string | null
+  reservation_email: string | null
+  confirmation_token: string | null
+  reservation_expires_at: number | null
+  subscription_expires_at: number | null
+  claim_source: string | null
+  created_by: string | null
+  atproto_did: string | null
+  atproto_state: string | null
+}
+
+/**
+ * Stateful mock D1 that faithfully simulates the two-step claim flow:
+ *   Step 1: UPDATE ... SET status='revoked', revoked_at=? WHERE pubkey=? AND status='active'
+ *   Step 2: INSERT ... ON CONFLICT(username_canonical) DO UPDATE SET ... revoked_at = NULL
+ *
+ * The ON CONFLICT handler checks whether the SQL contains 'revoked_at = NULL'.
+ * If the fix from PR #35 is reverted, revoked_at will NOT be cleared and tests will fail.
+ */
+function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
+  const mockUsernames: MockUsername[] = initialUsernames.map((u, i) => ({
+    id: u.id ?? i + 1,
+    name: u.name ?? u.username_canonical ?? '',
+    username_display: u.username_display ?? u.name ?? u.username_canonical ?? '',
+    username_canonical: u.username_canonical ?? u.name ?? '',
+    pubkey: u.pubkey ?? null,
+    relays: u.relays ?? null,
+    status: u.status ?? 'active',
+    recyclable: u.recyclable ?? 1,
+    created_at: u.created_at ?? 1700000000,
+    updated_at: u.updated_at ?? 1700000000,
+    claimed_at: u.claimed_at ?? 1700000000,
+    revoked_at: u.revoked_at ?? null,
+    reserved_reason: u.reserved_reason ?? null,
+    admin_notes: u.admin_notes ?? null,
+    email: u.email ?? null,
+    reservation_email: u.reservation_email ?? null,
+    confirmation_token: u.confirmation_token ?? null,
+    reservation_expires_at: u.reservation_expires_at ?? null,
+    subscription_expires_at: u.subscription_expires_at ?? null,
+    claim_source: u.claim_source ?? null,
+    created_by: u.created_by ?? null,
+    atproto_did: u.atproto_did ?? null,
+    atproto_state: u.atproto_state ?? null,
+  }))
+
+  return {
+    _mockUsernames: mockUsernames,
+    prepare: (sql: string) => {
+      let boundParams: any[] = []
+      return {
+        bind: (...params: any[]) => {
+          boundParams = params
+          return {
+            first: async () => {
+              if (sql.includes('COUNT(*)') && sql.includes('usernames')) {
+                return { count: 0 }
+              }
+              if (sql.includes('reserved_words')) {
+                return null
+              }
+              if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
+                const lookupValue = boundParams[0] || boundParams[1]
+                return mockUsernames.find(u =>
+                  u.username_canonical === lookupValue || u.name === lookupValue
+                ) || null
+              }
+              if (sql.includes('pubkey = ?') && sql.includes('status')) {
+                const pubkey = boundParams[0]
+                return mockUsernames.find(u => u.pubkey === pubkey && u.status === 'active') || null
+              }
+              return null
+            },
+            all: async () => ({ results: [] }),
+            run: async () => {
+              // Step 1: Revoke active username for pubkey
+              if (sql.includes("SET status = 'revoked'") && sql.includes('WHERE pubkey = ?')) {
+                const revokedAt = boundParams[0]
+                const updatedAt = boundParams[1]
+                const pubkey = boundParams[2]
+                for (const u of mockUsernames) {
+                  if (u.pubkey === pubkey && u.status === 'active') {
+                    u.status = 'revoked'
+                    u.revoked_at = revokedAt
+                    u.updated_at = updatedAt
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              // Admin revoke: SET status = ?, recyclable = ?, revoked_at = ?
+              if (sql.includes('SET status = ?') && sql.includes('recyclable = ?') && sql.includes('revoked_at = ?')) {
+                const status = boundParams[0]
+                const recyclable = boundParams[1]
+                const revokedAt = boundParams[2]
+                const updatedAt = boundParams[3]
+                const canonical = boundParams[4]
+                const name = boundParams[5]
+                for (const u of mockUsernames) {
+                  if (u.username_canonical === canonical || u.name === name) {
+                    u.status = status
+                    u.recyclable = recyclable
+                    u.revoked_at = revokedAt
+                    u.updated_at = updatedAt
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              // Step 2: INSERT ... ON CONFLICT
+              if (sql.includes('INSERT INTO usernames') && sql.includes('ON CONFLICT')) {
+                const display = boundParams[1]
+                const canonical = boundParams[2]
+                const pubkey = boundParams[3]
+                const now = boundParams[boundParams.length - 1]
+
+                const existing = mockUsernames.find(u => u.username_canonical === canonical)
+                if (existing) {
+                  existing.name = canonical
+                  existing.username_display = display
+                  existing.pubkey = pubkey
+                  existing.status = 'active'
+                  existing.updated_at = now
+                  existing.claimed_at = now
+                  // Critical: only clear revoked_at if SQL contains the fix
+                  if (sql.includes('revoked_at = NULL')) {
+                    existing.revoked_at = null
+                  }
+                } else {
+                  mockUsernames.push({
+                    id: mockUsernames.length + 1,
+                    name: canonical,
+                    username_display: display,
+                    username_canonical: canonical,
+                    pubkey: pubkey,
+                    relays: boundParams[4] || null,
+                    status: 'active',
+                    recyclable: 1,
+                    created_at: now,
+                    updated_at: now,
+                    claimed_at: now,
+                    revoked_at: null,
+                    reserved_reason: null,
+                    admin_notes: null,
+                    email: null,
+                    reservation_email: null,
+                    confirmation_token: null,
+                    reservation_expires_at: null,
+                    subscription_expires_at: null,
+                    claim_source: 'self-service',
+                    created_by: null,
+                    atproto_did: null,
+                    atproto_state: null,
+                  })
+                }
+              }
+              return { success: true, meta: { changes: 1 } }
+            }
+          }
+        }
+      }
+    }
+  } as unknown as D1Database & { _mockUsernames: MockUsername[] }
+}
+
+function createTestApp() {
+  const app = new Hono<{ Bindings: { DB: D1Database } }>()
+  app.route('/api/username', username)
+  app.route('', nip05)
+  return app
+}
+
+const mockEnv = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+```
+
+- [ ] **Step 2: Run the test file to verify it loads without errors**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 0 tests found, no import/syntax errors.
+
+- [ ] **Step 3: Commit scaffold**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: scaffold e2e claim→NIP-05 test file with stateful mock DB"
+```
+
+---
+
+### Task 2: Claim a name, verify NIP-05 resolves
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Add inside a `describe('Claim → NIP-05 resolution (e2e)', () => { ... })` block:
+
+```typescript
+describe('Claim → NIP-05 resolution (e2e)', () => {
+  let verifyNip98Event: any
+
+  beforeEach(async () => {
+    const nip98Module = await import('../middleware/nip98')
+    verifyNip98Event = nip98Module.verifyNip98Event
+    vi.mocked(verifyNip98Event).mockResolvedValue('a'.repeat(64))
+  })
+
+  it('claim a name, then NIP-05 resolves to the pubkey', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    // Claim "alice"
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const claimRes = await app.fetch(claimReq, { DB: db }, mockEnv)
+    expect(claimRes.status).toBe(200)
+
+    // NIP-05 root domain: /.well-known/nostr.json?name=alice
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.alice).toBe(pubkey)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 1 test, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e claim→NIP-05 resolution for fresh name"
+```
+
+---
+
+### Task 3: Re-claim same name, verify revoked_at is null
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+  it('re-claim same name clears revoked_at and NIP-05 still resolves', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    // First claim
+    const claim1 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    await app.fetch(claim1, { DB: db }, mockEnv)
+
+    // Second claim — same pubkey, same name (mobile double-fire scenario)
+    const claim2 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const res2 = await app.fetch(claim2, { DB: db }, mockEnv)
+    expect(res2.status).toBe(200)
+
+    // DB record should have revoked_at = null
+    const record = db._mockUsernames.find(u => u.username_canonical === 'alice')
+    expect(record).toBeDefined()
+    expect(record!.status).toBe('active')
+    expect(record!.revoked_at).toBeNull()
+
+    // NIP-05 still resolves
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.alice).toBe(pubkey)
+  })
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 2 tests, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e re-claim same name clears revoked_at"
+```
+
+---
+
+### Task 4: Switch names, verify old name stops resolving
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+  it('switch names: old name stops resolving, new name resolves', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    // Claim "alice"
+    const claim1 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const res1 = await app.fetch(claim1, { DB: db }, mockEnv)
+    expect(res1.status).toBe(200)
+
+    // Claim "bob" (same pubkey — triggers Step 1 revoke of "alice")
+    const claim2 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'bob' })
+    })
+    const res2 = await app.fetch(claim2, { DB: db }, mockEnv)
+    expect(res2.status).toBe(200)
+
+    // "alice" should be revoked — NIP-05 returns empty
+    const nip05Alice = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const aliceRes = await app.fetch(nip05Alice, { DB: db }, mockEnv)
+    expect(aliceRes.status).toBe(200)
+    const aliceJson = await aliceRes.json() as any
+    expect(aliceJson.names).toEqual({})
+
+    // "bob" resolves
+    const nip05Bob = new Request('http://localhost/.well-known/nostr.json?name=bob')
+    const bobRes = await app.fetch(nip05Bob, { DB: db }, mockEnv)
+    expect(bobRes.status).toBe(200)
+    const bobJson = await bobRes.json() as any
+    expect(bobJson.names.bob).toBe(pubkey)
+  })
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 3 tests, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e name switch revokes old, resolves new"
+```
+
+---
+
+### Task 5: Claim a previously-revoked name
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+  it('claim a revoked name: NIP-05 resolves to new pubkey, revoked_at is null', async () => {
+    const app = createTestApp()
+    const revokedAt = 1700000500
+    const db = createE2EMockDB([{
+      name: 'charlie', username_canonical: 'charlie', username_display: 'charlie',
+      pubkey: 'b'.repeat(64), status: 'revoked', revoked_at: revokedAt, recyclable: 1,
+    }])
+    const newPubkey = 'c'.repeat(64)
+    vi.mocked((await import('../middleware/nip98')).verifyNip98Event).mockResolvedValue(newPubkey)
+
+    // Claim "charlie" with a different pubkey
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'charlie' })
+    })
+    const claimRes = await app.fetch(claimReq, { DB: db }, mockEnv)
+    expect(claimRes.status).toBe(200)
+
+    // DB record: revoked_at cleared, status active
+    const record = db._mockUsernames.find(u => u.username_canonical === 'charlie')
+    expect(record!.status).toBe('active')
+    expect(record!.revoked_at).toBeNull()
+    expect(record!.pubkey).toBe(newPubkey)
+
+    // NIP-05 resolves to new pubkey
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=charlie')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.charlie).toBe(newPubkey)
+  })
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 4 tests, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e claim revoked name clears revoked_at, resolves to new pubkey"
+```
+
+---
+
+### Task 6: Fastly KV sync receives correct data
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+  it('Fastly KV sync called with status:active after claim', async () => {
+    const { syncUsernameToFastly, deleteUsernameFromFastly } = await import('../utils/fastly-sync')
+    vi.mocked(syncUsernameToFastly).mockClear()
+    vi.mocked(deleteUsernameFromFastly).mockClear()
+
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+    const waitUntilPromises: Promise<any>[] = []
+
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'dave' })
+    })
+    await app.fetch(claimReq, { DB: db }, {
+      waitUntil: (p: Promise<any>) => { waitUntilPromises.push(p) },
+      passThroughOnException: () => {},
+      props: {}
+    })
+
+    expect(syncUsernameToFastly).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      'dave',
+      expect.objectContaining({
+        pubkey,
+        status: 'active',
+      })
+    )
+  })
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 5 tests, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e verify Fastly KV sync receives status:active"
+```
+
+---
+
+### Task 7: Subdomain NIP-05 resolution
+
+**Files:**
+- Modify: `src/routes/claim-nip05.e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+The NIP-05 route also handles subdomain-style lookups at `alice.divine.video/.well-known/nostr.json`. This is an important production path. Add a test that verifies it works after claiming.
+
+```typescript
+  it('subdomain NIP-05 resolves after claim', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    // Claim "eve"
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'eve' })
+    })
+    await app.fetch(claimReq, { DB: db }, mockEnv)
+
+    // Subdomain NIP-05: eve.divine.video/.well-known/nostr.json (no ?name param)
+    const nip05Req = new Request('http://eve.divine.video/.well-known/nostr.json')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names['_']).toBe(pubkey)
+  })
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd ~/code/divine-name-server && npx vitest run src/routes/claim-nip05.e2e.test.ts`
+Expected: 6 tests, PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/routes/claim-nip05.e2e.test.ts
+git commit -m "test: e2e subdomain NIP-05 resolution after claim"
+```
+
+---
+
+### Task 8: Run full test suite, verify no regressions
+
+**Files:**
+- None modified
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd ~/code/divine-name-server && npx vitest run`
+Expected: All existing tests pass. New e2e tests pass. 0 failures.
+
+- [ ] **Step 2: Verify test count increased**
+
+The test output should show 6 new tests in `claim-nip05.e2e.test.ts` on top of existing tests in `username.test.ts` and `queries.test.ts`.
+
+- [ ] **Step 3: Final commit if any cleanup needed**
+
+If any imports or formatting adjustments were needed, commit them:
+
+```bash
+git add -A
+git commit -m "test: finalize e2e claim→NIP-05 test suite"
+```

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, createReservation, reserveUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, type SearchParams } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -204,6 +204,48 @@ describe('claimUsername', () => {
     expect(insertSql).toContain("'self-service'")
     expect(insertSql).toContain('claim_source')
   })
+
+  it('should clear revoked_at in ON CONFLICT clause', async () => {
+    const sqlStatements: string[] = []
+    const mockDB = {
+      prepare: (sql: string) => {
+        sqlStatements.push(sql)
+        return {
+          bind: (..._params: any[]) => ({
+            run: async () => ({ success: true }),
+          }),
+        }
+      },
+    } as unknown as D1Database
+
+    await claimUsername(mockDB, 'TestUser', 'testuser', 'abc123', null)
+
+    const insertSql = sqlStatements[1]
+    expect(insertSql).toContain('ON CONFLICT')
+    expect(insertSql).toContain('revoked_at = NULL')
+  })
+})
+
+describe('assignUsername', () => {
+  it('should clear revoked_at in ON CONFLICT clause', async () => {
+    const sqlStatements: string[] = []
+    const mockDB = {
+      prepare: (sql: string) => {
+        sqlStatements.push(sql)
+        return {
+          bind: (..._params: any[]) => ({
+            run: async () => ({ success: true }),
+          }),
+        }
+      },
+    } as unknown as D1Database
+
+    await assignUsername(mockDB, 'TestUser', 'testuser', 'abc123', 'admin', 'matt@divine.video')
+
+    const insertSql = sqlStatements[1]
+    expect(insertSql).toContain('ON CONFLICT')
+    expect(insertSql).toContain('revoked_at = NULL')
+  })
 })
 
 describe('reserveUsername', () => {
@@ -230,6 +272,25 @@ describe('reserveUsername', () => {
     expect(allParams).toContain('matt@divine.video')
     expect(allParams).toContain('admin')
   })
+
+  it('should clear revoked_at in ON CONFLICT clause', async () => {
+    const sqlStatements: string[] = []
+    const mockDB = {
+      prepare: (sql: string) => {
+        sqlStatements.push(sql)
+        return {
+          bind: (..._params: any[]) => ({
+            run: async () => ({ success: true }),
+          }),
+        }
+      },
+    } as unknown as D1Database
+
+    await reserveUsername(mockDB, 'TestName', 'testname', 'brand protection', 'admin', 'matt@divine.video')
+
+    expect(sqlStatements[0]).toContain('ON CONFLICT')
+    expect(sqlStatements[0]).toContain('revoked_at = NULL')
+  })
 })
 
 describe('createReservation', () => {
@@ -251,6 +312,266 @@ describe('createReservation', () => {
     const insertSql = sqlStatements[0]
     expect(insertSql).toContain("'public-reservation'")
     expect(insertSql).toContain('claim_source')
+  })
+
+  it('should clear revoked_at in ON CONFLICT clause', async () => {
+    const sqlStatements: string[] = []
+    const mockDB = {
+      prepare: (sql: string) => {
+        sqlStatements.push(sql)
+        return {
+          bind: (..._params: any[]) => ({
+            run: async () => ({ success: true }),
+          }),
+        }
+      },
+    } as unknown as D1Database
+
+    await createReservation(mockDB, 'TestUser', 'testuser', 'test@example.com', 'token123', 9999999999)
+
+    const insertSql = sqlStatements[0]
+    expect(insertSql).toContain('ON CONFLICT')
+    expect(insertSql).toContain('revoked_at = NULL')
+  })
+})
+
+// Stateful mock that faithfully tracks revoked_at through the revoke-then-upsert flow.
+// Reproduces the ericartell bug: claimUsername on a name the same pubkey already owns
+// should NOT leave revoked_at set.
+function createStatefulMockDB(initialRecords: Partial<Username>[] = []) {
+  const records: Partial<Username>[] = [...initialRecords]
+
+  return {
+    _records: records,
+    prepare: (sql: string) => {
+      let boundParams: any[] = []
+      return {
+        bind: (...params: any[]) => {
+          boundParams = params
+          return {
+            first: async <T>(): Promise<T | null> => {
+              if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
+                const lookupValues = boundParams.filter(p => typeof p === 'string')
+                return (records.find(r =>
+                  lookupValues.includes(r.username_canonical as string) ||
+                  lookupValues.includes(r.name as string)
+                ) as T) || null
+              }
+              if (sql.includes('pubkey = ?') && sql.includes('status = ?')) {
+                const pubkey = boundParams[0]
+                const status = boundParams[1]
+                return (records.find(r => r.pubkey === pubkey && r.status === status) as T) || null
+              }
+              return null
+            },
+            all: async () => ({ results: records }),
+            run: async () => {
+              // UPDATE ... SET status = 'revoked', revoked_at = ? ... WHERE pubkey = ? AND status = 'active'
+              if (sql.includes("SET status = 'revoked'") && sql.includes('WHERE pubkey = ?')) {
+                const revokedAt = boundParams[0]
+                const updatedAt = boundParams[1]
+                const pubkey = boundParams[2]
+                for (const r of records) {
+                  if (r.pubkey === pubkey && r.status === 'active') {
+                    r.status = 'revoked'
+                    r.revoked_at = revokedAt
+                    r.updated_at = updatedAt
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              // UPDATE ... SET status = ?, recyclable = ?, revoked_at = ? ... WHERE username_canonical = ?
+              if (sql.includes('SET status = ?') && sql.includes('recyclable = ?') && sql.includes('revoked_at = ?')) {
+                const status = boundParams[0]
+                const recyclable = boundParams[1]
+                const revokedAt = boundParams[2]
+                const updatedAt = boundParams[3]
+                const canonical = boundParams[4]
+                const name = boundParams[5]
+                for (const r of records) {
+                  if (r.username_canonical === canonical || r.name === name) {
+                    r.status = status
+                    r.recyclable = recyclable
+                    r.revoked_at = revokedAt
+                    r.updated_at = updatedAt
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              // INSERT ... ON CONFLICT DO UPDATE (claimUsername / assignUsername / reserveUsername / createReservation)
+              if (sql.includes('INSERT INTO usernames') && sql.includes('ON CONFLICT')) {
+                const canonical = boundParams[2]
+                const existing = records.find(r => r.username_canonical === canonical)
+
+                if (existing) {
+                  // ON CONFLICT path: apply the SET clauses
+                  if (sql.includes("status = 'active'")) {
+                    existing.status = 'active'
+                    existing.pubkey = boundParams[3]
+                    existing.claimed_at = boundParams[boundParams.length - 1]
+                  } else if (sql.includes("status = 'reserved'")) {
+                    existing.status = 'reserved'
+                  } else if (sql.includes("status = 'pending-confirmation'")) {
+                    existing.status = 'pending-confirmation' as any
+                  }
+                  existing.updated_at = boundParams[boundParams.length - 2] || Math.floor(Date.now() / 1000)
+                  // The critical part: does the SQL clear revoked_at?
+                  if (sql.includes('revoked_at = NULL')) {
+                    existing.revoked_at = null
+                  }
+                  // If sql does NOT include 'revoked_at = NULL', revoked_at stays as-is (the bug)
+                } else {
+                  // Fresh INSERT
+                  records.push({
+                    id: records.length + 1,
+                    name: boundParams[0],
+                    username_display: boundParams[1],
+                    username_canonical: boundParams[2],
+                    pubkey: boundParams[3] || null,
+                    status: 'active',
+                    revoked_at: null,
+                    created_at: Math.floor(Date.now() / 1000),
+                    updated_at: Math.floor(Date.now() / 1000),
+                    claimed_at: Math.floor(Date.now() / 1000),
+                  })
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              return { success: true, meta: { changes: 0 } }
+            },
+          }
+        },
+      }
+    },
+  } as unknown as D1Database & { _records: Partial<Username>[] }
+}
+
+describe('revoked_at clearing (ericartell bug)', () => {
+  it('claimUsername: re-claiming same name should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'ericartell', username_display: 'EricArtell', username_canonical: 'ericartell',
+      pubkey: 'aaa111', status: 'active', revoked_at: null,
+      created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+    }])
+
+    // Same pubkey re-claims the same name (e.g., updating relays)
+    await claimUsername(db, 'EricArtell', 'ericartell', 'aaa111', ['wss://relay.divine.video'])
+
+    const record = db._records.find(r => r.username_canonical === 'ericartell')!
+    expect(record.status).toBe('active')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('claimUsername: claiming a previously-revoked name should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'oldname', username_display: 'oldname', username_canonical: 'oldname',
+      pubkey: 'bbb222', status: 'revoked', revoked_at: 1700000000,
+      created_at: 1699000000, updated_at: 1700000000,
+    }])
+
+    // New user claims the revoked name
+    await claimUsername(db, 'oldname', 'oldname', 'ccc333', null)
+
+    const record = db._records.find(r => r.username_canonical === 'oldname')!
+    expect(record.status).toBe('active')
+    expect(record.pubkey).toBe('ccc333')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('claimUsername: claiming a reserved Vine import name should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'vinestar', username_display: 'VineStar', username_canonical: 'vinestar',
+      pubkey: null, status: 'revoked', revoked_at: 1690000000,
+      reserved_reason: 'Imported from Vine account', claim_source: 'vine-import',
+      created_at: 1680000000, updated_at: 1690000000,
+    }])
+
+    await claimUsername(db, 'VineStar', 'vinestar', 'newowner999', ['wss://relay.divine.video'])
+
+    const record = db._records.find(r => r.username_canonical === 'vinestar')!
+    expect(record.status).toBe('active')
+    expect(record.pubkey).toBe('newowner999')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('claimUsername: switching names should revoke old and activate new cleanly', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'firstname', username_display: 'FirstName', username_canonical: 'firstname',
+      pubkey: 'user123', status: 'active', revoked_at: null,
+      created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+    }])
+
+    // User claims a different name -- old one gets revoked, new one is fresh INSERT
+    await claimUsername(db, 'SecondName', 'secondname', 'user123', null)
+
+    const oldRecord = db._records.find(r => r.username_canonical === 'firstname')!
+    expect(oldRecord.status).toBe('revoked')
+    expect(oldRecord.revoked_at).not.toBeNull()
+
+    const newRecord = db._records.find(r => r.username_canonical === 'secondname')!
+    expect(newRecord.status).toBe('active')
+    expect(newRecord.revoked_at).toBeNull()
+  })
+
+  it('assignUsername: assigning over a revoked record should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'adminassign', username_display: 'AdminAssign', username_canonical: 'adminassign',
+      pubkey: null, status: 'revoked', revoked_at: 1700000000,
+      created_at: 1699000000, updated_at: 1700000000,
+    }])
+
+    await assignUsername(db, 'AdminAssign', 'adminassign', 'assigned123', 'admin', 'matt@divine.video')
+
+    const record = db._records.find(r => r.username_canonical === 'adminassign')!
+    expect(record.status).toBe('active')
+    expect(record.pubkey).toBe('assigned123')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('reserveUsername: re-reserving a revoked name should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'brandname', username_display: 'BrandName', username_canonical: 'brandname',
+      pubkey: 'old999', status: 'revoked', revoked_at: 1700000000,
+      created_at: 1699000000, updated_at: 1700000000,
+    }])
+
+    await reserveUsername(db, 'BrandName', 'brandname', 'brand protection', 'admin', 'matt@divine.video')
+
+    const record = db._records.find(r => r.username_canonical === 'brandname')!
+    expect(record.status).toBe('reserved')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('createReservation: reserving over a revoked name should clear revoked_at', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'expiredres', username_display: 'ExpiredRes', username_canonical: 'expiredres',
+      pubkey: null, status: 'revoked', revoked_at: 1700000000,
+      created_at: 1699000000, updated_at: 1700000000,
+    }])
+
+    await createReservation(db, 'ExpiredRes', 'expiredres', 'user@example.com', 'token123', 9999999999)
+
+    const record = db._records.find(r => r.username_canonical === 'expiredres')!
+    expect(record.status).toBe('pending-confirmation')
+    expect(record.revoked_at).toBeNull()
+  })
+
+  it('revokeUsername: should set revoked_at when revoking', async () => {
+    const db = createStatefulMockDB([{
+      id: 1, name: 'tobanned', username_display: 'ToBanned', username_canonical: 'tobanned',
+      pubkey: 'user999', status: 'active', revoked_at: null,
+      created_at: 1700000000, updated_at: 1700000000,
+    }])
+
+    await revokeUsername(db, 'tobanned', false)
+
+    const record = db._records.find(r => r.username_canonical === 'tobanned')!
+    expect(record.status).toBe('revoked')
+    expect(record.revoked_at).not.toBeNull()
+    expect(typeof record.revoked_at).toBe('number')
   })
 })
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -123,6 +123,7 @@ export async function claimUsername(
        status = 'active',
        claim_source = 'self-service',
        created_by = NULL,
+       revoked_at = NULL,
        updated_at = excluded.updated_at,
        claimed_at = excluded.claimed_at`
   ).bind(nameCanonical, nameDisplay, nameCanonical, pubkey, relaysJson, now, now, now).run()
@@ -158,6 +159,7 @@ export async function reserveUsername(
        reserved_reason = excluded.reserved_reason,
        claim_source = excluded.claim_source,
        created_by = excluded.created_by,
+       revoked_at = NULL,
        updated_at = excluded.updated_at`
   ).bind(nameCanonical, nameDisplay, nameCanonical, reason, claimSource, createdBy, now, now).run()
 }
@@ -212,6 +214,7 @@ export async function assignUsername(
        status = 'active',
        claim_source = excluded.claim_source,
        created_by = excluded.created_by,
+       revoked_at = NULL,
        updated_at = excluded.updated_at,
        claimed_at = excluded.claimed_at`
   ).bind(nameCanonical, nameDisplay, nameCanonical, pubkey, claimSource, createdBy, now, now, now).run()
@@ -415,6 +418,7 @@ export async function createReservation(
        status = 'pending-confirmation',
        claim_source = 'public-reservation',
        created_by = NULL,
+       revoked_at = NULL,
        reservation_email = excluded.reservation_email,
        confirmation_token = excluded.confirmation_token,
        reservation_expires_at = excluded.reservation_expires_at,

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -1,0 +1,454 @@
+// ABOUTME: End-to-end tests for the claim → NIP-05 resolution path
+// ABOUTME: Mounts both username and nip05 routes on a single Hono app
+// ABOUTME: Exercises the two-step SQL flow (revoke old name, upsert new name)
+// ABOUTME: The revoked_at = NULL clause in Step 2 is the fix from PR #35
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import username from './username'
+import nip05 from './nip05'
+
+// Mock NIP-98 middleware
+vi.mock('../middleware/nip98', () => ({
+  verifyNip98Event: vi.fn()
+}))
+
+// Mock email utility to avoid real SendGrid calls in tests
+vi.mock('../utils/email', () => ({
+  sendReservationConfirmationEmail: vi.fn().mockResolvedValue(undefined)
+}))
+
+// Mock Fastly sync utilities
+vi.mock('../utils/fastly-sync', () => ({
+  syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
+  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true })
+}))
+
+type MockUsername = {
+  id: number
+  name: string
+  username_display: string | null
+  username_canonical: string | null
+  pubkey: string | null
+  relays: string | null
+  status: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
+  recyclable: number
+  created_at: number
+  updated_at: number
+  claimed_at: number | null
+  revoked_at: number | null
+  reserved_reason: string | null
+  admin_notes: string | null
+  email: string | null
+  reservation_email: string | null
+  confirmation_token: string | null
+  reservation_expires_at: number | null
+  subscription_expires_at: number | null
+  claim_source: string
+  created_by: string | null
+  atproto_did: string | null
+  atproto_state: 'pending' | 'ready' | 'failed' | 'disabled' | null
+}
+
+/**
+ * Stateful mock D1 database that faithfully simulates the two-step SQL flow
+ * used by claimUsername in db/queries.ts.
+ *
+ * Step 1: UPDATE ... SET status='revoked', revoked_at=? WHERE pubkey=? AND status='active'
+ * Step 2: INSERT INTO usernames ... ON CONFLICT(username_canonical) DO UPDATE SET ... revoked_at = NULL
+ *
+ * The check for 'revoked_at = NULL' in Step 2 is intentional: if the fix from PR #35
+ * is ever reverted, the revoked_at column will not be cleared and the re-claim test
+ * will fail, alerting us to the regression.
+ */
+function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
+  const now = Math.floor(Date.now() / 1000)
+
+  const mockUsernames: MockUsername[] = initialUsernames.map((u, i) => ({
+    id: i + 1,
+    name: u.username_canonical || '',
+    username_display: u.username_display ?? u.username_canonical ?? null,
+    username_canonical: u.username_canonical ?? null,
+    pubkey: u.pubkey ?? null,
+    relays: u.relays ?? null,
+    status: u.status ?? 'active',
+    recyclable: u.recyclable ?? 1,
+    created_at: u.created_at ?? now,
+    updated_at: u.updated_at ?? now,
+    claimed_at: u.claimed_at ?? null,
+    revoked_at: u.revoked_at ?? null,
+    reserved_reason: u.reserved_reason ?? null,
+    admin_notes: u.admin_notes ?? null,
+    email: u.email ?? null,
+    reservation_email: u.reservation_email ?? null,
+    confirmation_token: u.confirmation_token ?? null,
+    reservation_expires_at: u.reservation_expires_at ?? null,
+    subscription_expires_at: u.subscription_expires_at ?? null,
+    claim_source: u.claim_source ?? 'self-service',
+    created_by: u.created_by ?? null,
+    atproto_did: u.atproto_did ?? null,
+    atproto_state: u.atproto_state ?? null,
+  }))
+
+  return {
+    prepare: (sql: string) => {
+      let boundParams: any[] = []
+
+      return {
+        bind: (...params: any[]) => {
+          boundParams = params
+          return {
+            first: async () => {
+              // COUNT queries always return 0 for count-based checks
+              if (sql.includes('COUNT(*)') && sql.includes('usernames')) {
+                return { count: 0 }
+              }
+              if (sql.includes('COUNT(*)') && sql.includes('reservation_tokens')) {
+                return { count: 0 }
+              }
+
+              // Reserved words: never reserved by default
+              if (sql.includes('reserved_words')) {
+                return null
+              }
+
+              // Username lookup by canonical name or legacy name column
+              if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
+                const lookupValue = boundParams[0]
+                const found = mockUsernames.find(
+                  u => u.username_canonical === lookupValue || u.name === lookupValue
+                )
+                return found ?? null
+              }
+
+              // Username lookup by pubkey + status='active'
+              if (sql.includes('pubkey = ?') && sql.includes('status = ?')) {
+                const pubkey = boundParams[0]
+                const status = boundParams[1]
+                return mockUsernames.find(u => u.pubkey === pubkey && u.status === status) ?? null
+              }
+
+              return null
+            },
+
+            all: async () => {
+              return { results: [] }
+            },
+
+            run: async () => {
+              const ts = Math.floor(Date.now() / 1000)
+
+              // -------------------------------------------------------------------
+              // Step 1: Revoke active username for pubkey
+              // UPDATE usernames SET status='revoked', revoked_at=?, updated_at=?
+              //   WHERE pubkey=? AND status='active'
+              // Bound: [revoked_at, updated_at, pubkey]
+              // -------------------------------------------------------------------
+              if (sql.includes("SET status = 'revoked'") && sql.includes('WHERE pubkey = ?')) {
+                const pubkey = boundParams[2]
+                const record = mockUsernames.find(u => u.pubkey === pubkey && u.status === 'active')
+                if (record) {
+                  record.status = 'revoked'
+                  record.revoked_at = boundParams[0]
+                  record.updated_at = boundParams[1]
+                }
+                return { success: true, meta: { changes: record ? 1 : 0 } }
+              }
+
+              // -------------------------------------------------------------------
+              // Admin revoke: SET status=?, recyclable=?, revoked_at=?, updated_at=?
+              //   WHERE username_canonical=? OR name=?
+              // Bound: [status, recyclable, revoked_at, updated_at, canonical, name]
+              // -------------------------------------------------------------------
+              if (sql.includes('SET status = ?') && sql.includes('recyclable = ?') && sql.includes('revoked_at = ?')) {
+                const status = boundParams[0] as MockUsername['status']
+                const recyclable = boundParams[1]
+                const revokedAt = boundParams[2]
+                const updatedAt = boundParams[3]
+                const canonical = boundParams[4]
+                const name = boundParams[5]
+                const record = mockUsernames.find(
+                  u => u.username_canonical === canonical || u.name === name
+                )
+                if (record) {
+                  record.status = status
+                  record.recyclable = recyclable
+                  record.revoked_at = revokedAt
+                  record.updated_at = updatedAt
+                }
+                return { success: true, meta: { changes: record ? 1 : 0 } }
+              }
+
+              // -------------------------------------------------------------------
+              // Step 2: INSERT ON CONFLICT upsert
+              // INSERT INTO usernames (name, username_display, username_canonical, pubkey, ...)
+              //   VALUES (?, ?, ?, ?, ?, 'active', 'self-service', ?, ?, ?)
+              //   ON CONFLICT(username_canonical) DO UPDATE SET ... revoked_at = NULL
+              // Bound: [name(0), display(1), canonical(2), pubkey(3), relays(4), now(5), now(6), now(7)]
+              // -------------------------------------------------------------------
+              if (sql.includes('INSERT INTO usernames') && sql.includes('ON CONFLICT')) {
+                const name = boundParams[0]
+                const display = boundParams[1]
+                const canonical = boundParams[2]
+                const pubkey = boundParams[3]
+                const relays = boundParams[4] ?? null
+                const claimedAt = boundParams[7] ?? ts
+
+                const existingIdx = mockUsernames.findIndex(u => u.username_canonical === canonical)
+
+                if (existingIdx >= 0) {
+                  // ON CONFLICT path: update the existing record
+                  const existing = mockUsernames[existingIdx]
+                  existing.name = name
+                  existing.username_display = display
+                  existing.pubkey = pubkey
+                  existing.relays = relays
+                  existing.status = 'active'
+                  existing.claim_source = 'self-service'
+                  existing.created_by = null
+                  existing.updated_at = ts
+                  existing.claimed_at = claimedAt
+                  // Only clear revoked_at if the SQL explicitly sets it to NULL.
+                  // This is the fix from PR #35. If it is ever reverted, this
+                  // conditional will leave revoked_at set and the re-claim test fails.
+                  if (sql.includes('revoked_at = NULL')) {
+                    existing.revoked_at = null
+                  }
+                } else {
+                  // Fresh insert
+                  mockUsernames.push({
+                    id: mockUsernames.length + 1,
+                    name,
+                    username_display: display,
+                    username_canonical: canonical,
+                    pubkey,
+                    relays,
+                    status: 'active',
+                    recyclable: 1,
+                    created_at: ts,
+                    updated_at: ts,
+                    claimed_at: claimedAt,
+                    revoked_at: null,
+                    reserved_reason: null,
+                    admin_notes: null,
+                    email: null,
+                    reservation_email: null,
+                    confirmation_token: null,
+                    reservation_expires_at: null,
+                    subscription_expires_at: null,
+                    claim_source: 'self-service',
+                    created_by: null,
+                    atproto_did: null,
+                    atproto_state: null,
+                  })
+                }
+
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              return { success: true, meta: { changes: 0 } }
+            }
+          }
+        }
+      }
+    },
+
+    // Expose the live array so tests can assert on DB state
+    _mockUsernames: mockUsernames,
+  } as unknown as D1Database & { _mockUsernames: MockUsername[] }
+}
+
+function createTestApp() {
+  const app = new Hono<{ Bindings: { DB: D1Database } }>()
+  app.route('/api/username', username)
+  app.route('', nip05)
+  return app
+}
+
+const mockEnv = {
+  waitUntil: () => {},
+  passThroughOnException: () => {},
+  props: {}
+}
+
+describe('Claim → NIP-05 resolution (e2e)', () => {
+  beforeEach(async () => {
+    const nip98Module = await import('../middleware/nip98')
+    vi.mocked(nip98Module.verifyNip98Event).mockResolvedValue('a'.repeat(64))
+  })
+
+  // Task 2
+  it('claim a name, then NIP-05 resolves to the pubkey', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const claimRes = await app.fetch(claimReq, { DB: db }, mockEnv)
+    expect(claimRes.status).toBe(200)
+
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.alice).toBe(pubkey)
+  })
+
+  // Task 3
+  it('re-claim same name clears revoked_at and NIP-05 still resolves', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    const claim1 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    await app.fetch(claim1, { DB: db }, mockEnv)
+
+    const claim2 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const res2 = await app.fetch(claim2, { DB: db }, mockEnv)
+    expect(res2.status).toBe(200)
+
+    const record = db._mockUsernames.find(u => u.username_canonical === 'alice')
+    expect(record).toBeDefined()
+    expect(record!.status).toBe('active')
+    expect(record!.revoked_at).toBeNull()
+
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.alice).toBe(pubkey)
+  })
+
+  // Task 4
+  it('switch names: old name stops resolving, new name resolves', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    const claim1 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const res1 = await app.fetch(claim1, { DB: db }, mockEnv)
+    expect(res1.status).toBe(200)
+
+    const claim2 = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'bob' })
+    })
+    const res2 = await app.fetch(claim2, { DB: db }, mockEnv)
+    expect(res2.status).toBe(200)
+
+    const nip05Alice = new Request('http://localhost/.well-known/nostr.json?name=alice')
+    const aliceRes = await app.fetch(nip05Alice, { DB: db }, mockEnv)
+    expect(aliceRes.status).toBe(200)
+    const aliceJson = await aliceRes.json() as any
+    expect(aliceJson.names).toEqual({})
+
+    const nip05Bob = new Request('http://localhost/.well-known/nostr.json?name=bob')
+    const bobRes = await app.fetch(nip05Bob, { DB: db }, mockEnv)
+    expect(bobRes.status).toBe(200)
+    const bobJson = await bobRes.json() as any
+    expect(bobJson.names.bob).toBe(pubkey)
+  })
+
+  // Task 5
+  it('claim a revoked name: NIP-05 resolves to new pubkey, revoked_at is null', async () => {
+    const app = createTestApp()
+    const revokedAt = 1700000500
+    const db = createE2EMockDB([{
+      name: 'charlie', username_canonical: 'charlie', username_display: 'charlie',
+      pubkey: 'b'.repeat(64), status: 'revoked', revoked_at: revokedAt, recyclable: 1,
+    }])
+    const newPubkey = 'c'.repeat(64)
+    vi.mocked((await import('../middleware/nip98')).verifyNip98Event).mockResolvedValue(newPubkey)
+
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'charlie' })
+    })
+    const claimRes = await app.fetch(claimReq, { DB: db }, mockEnv)
+    expect(claimRes.status).toBe(200)
+
+    const record = db._mockUsernames.find(u => u.username_canonical === 'charlie')
+    expect(record!.status).toBe('active')
+    expect(record!.revoked_at).toBeNull()
+    expect(record!.pubkey).toBe(newPubkey)
+
+    const nip05Req = new Request('http://localhost/.well-known/nostr.json?name=charlie')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names.charlie).toBe(newPubkey)
+  })
+
+  // Task 6
+  it('Fastly KV sync called with status:active after claim', async () => {
+    const { syncUsernameToFastly, deleteUsernameFromFastly } = await import('../utils/fastly-sync')
+    vi.mocked(syncUsernameToFastly).mockClear()
+    vi.mocked(deleteUsernameFromFastly).mockClear()
+
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+    const waitUntilPromises: Promise<any>[] = []
+
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'dave' })
+    })
+    await app.fetch(claimReq, { DB: db }, {
+      waitUntil: (p: Promise<any>) => { waitUntilPromises.push(p) },
+      passThroughOnException: () => {},
+      props: {}
+    })
+
+    // Flush waitUntil promises so Fastly sync mock gets called
+    await Promise.all(waitUntilPromises)
+
+    expect(syncUsernameToFastly).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      'dave',
+      expect.objectContaining({
+        pubkey,
+        status: 'active',
+      })
+    )
+  })
+
+  // Task 7
+  it('subdomain NIP-05 resolves after claim', async () => {
+    const app = createTestApp()
+    const db = createE2EMockDB()
+    const pubkey = 'a'.repeat(64)
+
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'eve' })
+    })
+    await app.fetch(claimReq, { DB: db }, mockEnv)
+
+    const nip05Req = new Request('http://eve.divine.video/.well-known/nostr.json')
+    const nip05Res = await app.fetch(nip05Req, { DB: db }, mockEnv)
+    expect(nip05Res.status).toBe(200)
+    const json = await nip05Res.json() as any
+    expect(json.names['_']).toBe(pubkey)
+  })
+})

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -114,9 +114,8 @@ function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
 
               // Username lookup by canonical name or legacy name column
               if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
-                const lookupValue = boundParams[0]
                 const found = mockUsernames.find(
-                  u => u.username_canonical === lookupValue || u.name === lookupValue
+                  u => u.username_canonical === boundParams[0] || u.name === boundParams[1]
                 )
                 return found ?? null
               }
@@ -184,7 +183,7 @@ function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
               // INSERT INTO usernames (name, username_display, username_canonical, pubkey, ...)
               //   VALUES (?, ?, ?, ?, ?, 'active', 'self-service', ?, ?, ?)
               //   ON CONFLICT(username_canonical) DO UPDATE SET ... revoked_at = NULL
-              // Bound: [name(0), display(1), canonical(2), pubkey(3), relays(4), now(5), now(6), now(7)]
+              // Bound: [canonical(0), display(1), canonical(2), pubkey(3), relays(4), now(5), now(6), now(7)]
               // -------------------------------------------------------------------
               if (sql.includes('INSERT INTO usernames') && sql.includes('ON CONFLICT')) {
                 const name = boundParams[0]


### PR DESCRIPTION
## Summary

- All four `ON CONFLICT(username_canonical)` upsert paths now include `revoked_at = NULL`: `claimUsername`, `assignUsername`, `reserveUsername`, `createReservation`
- 12 new unit/integration tests: 4 SQL-level assertions + 8 stateful integration tests covering the exact failure scenarios
- 6 new e2e tests: claim → NIP-05 resolution, re-claim revoked_at clearing, name switching, claiming revoked names, Fastly KV sync, subdomain NIP-05

Closes #36

## Root cause

`claimUsername` uses a two-step SQL pattern:

1. `UPDATE ... SET status = 'revoked', revoked_at = <now> WHERE pubkey = ? AND status = 'active'`
2. `INSERT ... ON CONFLICT DO UPDATE SET status = 'active', ...`

When Step 2 hits ON CONFLICT (record already exists for that canonical name), it re-activates the record but never cleared `revoked_at`. The record ends up with contradictory state: `status = 'active'` + `revoked_at = <timestamp>`.

Same pattern exists in `assignUsername`, `reserveUsername`, and `createReservation`.

## Impact

- NIP-05 resolution can fail (Fastly KV sync may not fire or may write stale state)
- Admin UI shows strikethrough on active records (confusing operators)
- `revoked_at` timestamp is disinformation — it reflects the claim time, not an actual revocation

## Evidence: ericartell

Admin UI showed `created_at = 6:55:23 PM`, `claimed_at = updated_at = revoked_at = 6:57:57 PM`, `status = active`. This is consistent with two profile saves ~2.5 minutes apart — the mobile profile editor fires `claimUsername` on every save regardless of whether the username changed. The second save hit ON CONFLICT, Step 1 set `revoked_at`, Step 2 didn't clear it.

Bug has been present since initial implementation (62c3efe, Nov 2025). Only triggers on the ON CONFLICT path — fresh INSERTs are unaffected, which is why most users never hit it.

## Test plan

- [x] `npx vitest run` — 212 tests pass (41 in queries.test.ts, 6 in claim-nip05.e2e.test.ts)
- [x] `npx tsc --noEmit` — clean
- [ ] After deploy: re-trigger ericartell claim (or admin re-assign) to clear stale `revoked_at`
- [ ] Verify NIP-05 resolves: `curl https://divine.video/.well-known/nostr.json?name=ericartell`

## Follow-up considerations

- Mobile profile editor calls `claimUsername` on every profile save even when the username hasn't changed — unnecessary API calls that amplified this bug's blast radius
- Existing records with dirty `revoked_at` will need a one-time data cleanup (SQL: `UPDATE usernames SET revoked_at = NULL WHERE status = 'active' AND revoked_at IS NOT NULL`)