### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug or regression
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the username flow, admin action, API request, or routing path needed to reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant environment details, logs, or payloads. Redact secrets and sensitive external names.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose a new feature or improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Explain why this work is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the intended behavior or implementation direction.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant username flows, admin UI behavior, or rollout notes. Redact secrets and sensitive external names.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+-
+
+## Motivation
+
+-
+
+## Related Issue
+
+- Closes #
+
+## Validation
+
+- [ ] `npm run test:once`
+- [ ] `npm run build:admin`
+- [ ] relevant local Wrangler validation if applicable
+- [ ] I could not run some validation locally, and I explained why below
+
+## Manual Test Plan / Notes
+
+-
+
+## Visuals / API Examples
+
+- [ ] No visual change
+- [ ] Screenshots, sample payloads, or logs attached if needed
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Worker code lives at the repo root and supporting scripts live under `scripts/`.
+- Admin UI code lives under `admin-ui/`.
+- Docs and rollout notes live in `README.md`, `docs/`, and related setup files.
+- Deployment and data configuration should be verified against `wrangler` config, migrations, and the documented admin UI build flow before changing production behavior.
+
+## Build, Test, and Validation Commands
+- `npm test`: Vitest watch mode.
+- `npm run test:once`: one-shot Vitest pass.
+- `npm run build:admin`: build the admin UI.
+- `npm run dev`: local Wrangler development.
+- `npm run deploy`: build admin UI and deploy the Worker. Use only when intentionally shipping changes.
+
+## Coding Style & Naming Conventions
+- Follow the existing TypeScript, Hono, Cloudflare Worker, and React/Vite admin UI patterns already established in the repo.
+- Keep username-claim flow, NIP-05 behavior, admin UI, and auth/deployment changes scoped. Do not mix unrelated cleanup or refactors in the same PR.
+- Verify routes, relay hints, auth flows, and environment-specific behavior against the current code and docs before changing them. Do not hardcode environment-specific domains or secrets in application code.
+
+## Security & Operational Notes
+- Never commit secrets, Cloudflare credentials, auth material, or screenshots/logs containing sensitive values.
+- Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.
+- Be explicit about any change that affects username ownership, admin permissions, auth, or NIP-05 resolution behavior.
+
+## Pull Request Guardrails
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR. Do not rely on fixing it later.
+- If a PR title is edited after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped. Do not include unrelated formatting churn, dependency noise, or drive-by refactors.
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue.
+- UI, admin, or externally visible API behavior changes should include screenshots, sample payloads, or an explicit note that there is no visual change.
+- PR descriptions must include a summary, motivation, linked issue, and manual validation plan.
+- Before requesting review, run the relevant checks for the files you changed, or note what you could not run.


### PR DESCRIPTION
## Summary
- add repo-local contributor and agent guardrails in AGENTS.md
- add semantic PR title enforcement plus PR and issue templates
- reinforce redaction of sensitive external names in public repo artifacts

## Motivation
- make repo-local contribution expectations explicit for humans and AI agents
- align this repo with the org standard without duplicating existing name-server docs

## Validation
- not run; docs and GitHub metadata changes only