### PR TITLE
fix: check in FASTLY_STORE_ID as config var instead of secret

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,7 +11,9 @@ routes = [
 
 # Fastly KV sync (for divine-router edge)
 # Set via wrangler secret put FASTLY_API_TOKEN
-# Set via wrangler secret put FASTLY_STORE_ID
+# FASTLY_STORE_ID is a resource identifier checked in as a [vars] entry below.
+# If a secret of the same name exists, it shadows the var. After merging,
+# delete any secret override: npx wrangler secret delete FASTLY_STORE_ID
 
 # Payment/invite gate for public name reservations
 # ALLOWED_MINTS: comma-separated list of trusted Cashu mint URLs (e.g. "https://mint.example.com")
@@ -24,7 +26,7 @@ KEYCAST_CLIENT_ID = "divine-name-server"
 # Comma-separated hex pubkeys authorized for Keycast OAuth admin access.
 # CF Access users are authorized by the Access policy; this only applies to Keycast sessions.
 ADMIN_PUBKEYS = "81549bc0b5153b4b970fe4a3892ad185698b8b8b26ec69321a527d0644cd2898"
-# FASTLY_STORE_ID = "your-store-id" # Set as secret in production
+FASTLY_STORE_ID = "gclbp6suv4bjnqpctp2b7n"
 # ALLOWED_MINTS = "https://8333.space:3338,https://mint.minibits.cash/Bitcoin"
 # NAME_PRICE_SATS = "1000"
 # INVITE_FAUCET_URL = "https://faucet.divine.video"


### PR DESCRIPTION
## Summary

- Moves `FASTLY_STORE_ID` from a Cloudflare Workers secret to a checked-in `[vars]` entry in `wrangler.toml`
- The store ID (`gclbp6suv4bjnqpctp2b7n`, the `divine-names` KV store) is a resource identifier, not a credential -- same pattern as the D1 database ID already in this file
- Adds a post-merge instruction to delete the temporary secret so the var becomes authoritative

## Context

The `FASTLY_STORE_ID` secret was missing from the deployed worker as of May 6, causing every per-claim Fastly KV sync and hourly cron reconciliation to silently fail. This broke NIP-05 resolution on `*.divine.video` subdomains for any handle not previously written to Fastly KV. A temporary secret was set as an immediate fix; this PR makes it durable.

The CI workflow (`wrangler-action@v3`) doesn't inject this value, which is how it kept getting lost across deploys.

## Post-merge steps

1. CI auto-deploys on merge
2. Run `npx wrangler secret delete FASTLY_STORE_ID` to remove the temporary secret so the checked-in var is authoritative
3. Verify sync is working: pick a recent handle and check `https://<handle>.divine.video/.well-known/nostr.json?name=_`

Relates to #40. Context: #42.