### PR TITLE
fix: Fastly KV sync scaling + NIP-05 status + write-path verification

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -9,6 +9,8 @@ import type {
   ApiResponse,
   TagDetail,
   FastlySyncPageResponse,
+  Nip05StatusResponse,
+  ResyncResponse,
 } from '../types'
 
 const API_BASE = '/api/admin'
@@ -237,6 +239,30 @@ export async function getAllTags(): Promise<{ tags: { tag: string; count: number
 
   if (!response.ok) {
     throw new Error(`Failed to fetch tags: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+// --- NIP-05 / Fastly KV Status ---
+
+export async function getNip05Status(name: string): Promise<Nip05StatusResponse> {
+  const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}/nip05-status`)
+
+  if (!response.ok) {
+    throw new Error(`NIP-05 status check failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+export async function resyncToFastly(name: string): Promise<ResyncResponse> {
+  const response = await fetch(`${API_BASE}/username/${encodeURIComponent(name)}/sync-to-fastly`, {
+    method: 'POST',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Re-sync failed: ${response.statusText}`)
   }
 
   return response.json()

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -273,11 +273,13 @@ export async function resyncToFastly(name: string): Promise<ResyncResponse> {
 export async function syncFastlyPage(
   cursor?: string | null,
   limit = 500,
-  dryRun = false
+  dryRun = false,
+  signal?: AbortSignal
 ): Promise<FastlySyncPageResponse> {
   const response = await fetch(`${API_BASE}/sync/fastly`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    signal,
     body: JSON.stringify({
       limit,
       cursor: cursor ?? undefined,

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -7,7 +7,8 @@ import type {
   ReservedWord,
   BulkReserveResponse,
   ApiResponse,
-  TagDetail
+  TagDetail,
+  FastlySyncPageResponse,
 } from '../types'
 
 const API_BASE = '/api/admin'
@@ -236,6 +237,30 @@ export async function getAllTags(): Promise<{ tags: { tag: string; count: number
 
   if (!response.ok) {
     throw new Error(`Failed to fetch tags: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+
+// --- Fastly KV Sync ---
+
+export async function syncFastlyPage(
+  cursor?: string | null,
+  limit = 500,
+  dryRun = false
+): Promise<FastlySyncPageResponse> {
+  const response = await fetch(`${API_BASE}/sync/fastly`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      limit,
+      cursor: cursor ?? undefined,
+      dry_run: dryRun,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Fastly sync failed: ${response.statusText}`)
   }
 
   return response.json()

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -38,9 +38,9 @@ export default function Dashboard() {
     let totalFailed = 0
 
     try {
-      // Dry run first to get total count
+      // Dry run first page to get total count
       const dryRun = await syncFastlyPage(null, 500, true)
-      let estimatedTotal = (dryRun.syncable ?? 0) + (dryRun.remaining ?? 0)
+      const estimatedTotal = dryRun.total ?? 0
       setSyncProgress(p => ({ ...p, total: estimatedTotal }))
 
       // Now sync for real

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
 // ABOUTME: Main admin dashboard page for searching and viewing usernames
 // ABOUTME: Supports search by username/pubkey/email with status filtering and pagination
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { searchUsernames, getAllTags } from '../api/client'
+import { searchUsernames, getAllTags, syncFastlyPage } from '../api/client'
 import type { Username } from '../types'
 import StatusBadge from '../components/StatusBadge'
 import Pagination from '../components/Pagination'
@@ -20,6 +20,46 @@ export default function Dashboard() {
   const [error, setError] = useState<string | null>(null)
   const [tagFilter, setTagFilter] = useState<string>('')
   const [availableTags, setAvailableTags] = useState<{ tag: string; count: number }[]>([])
+
+  // Fastly KV sync state
+  const [syncState, setSyncState] = useState<'idle' | 'confirm' | 'running' | 'done' | 'error'>('idle')
+  const [syncProgress, setSyncProgress] = useState({ synced: 0, failed: 0, total: 0 })
+  const [syncError, setSyncError] = useState<string | null>(null)
+  const cancelRef = useRef(false)
+
+  const startFastlySync = async () => {
+    setSyncState('running')
+    setSyncError(null)
+    setSyncProgress({ synced: 0, failed: 0, total: 0 })
+    cancelRef.current = false
+
+    let cursor: string | null = null
+    let totalSynced = 0
+    let totalFailed = 0
+
+    try {
+      // Dry run first to get total count
+      const dryRun = await syncFastlyPage(null, 500, true)
+      let estimatedTotal = (dryRun.syncable ?? 0) + (dryRun.remaining ?? 0)
+      setSyncProgress(p => ({ ...p, total: estimatedTotal }))
+
+      // Now sync for real
+      while (!cancelRef.current) {
+        const result = await syncFastlyPage(cursor, 500, false)
+        totalSynced += result.synced ?? 0
+        totalFailed += result.failed ?? 0
+        setSyncProgress({ synced: totalSynced, failed: totalFailed, total: estimatedTotal })
+
+        cursor = result.cursor ?? null
+        if (!cursor) break
+      }
+
+      setSyncState(cancelRef.current ? 'idle' : 'done')
+    } catch (err) {
+      setSyncError(err instanceof Error ? err.message : 'Unknown error')
+      setSyncState('error')
+    }
+  }
 
   const performSearch = useCallback(async () => {
     setLoading(true)
@@ -227,6 +267,86 @@ export default function Dashboard() {
               </svg>
               Burned
             </a>
+          </div>
+        </div>
+
+        {/* Fastly KV Sync */}
+        <div className="mt-4 pt-4 border-t border-gray-200">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-gray-700">Fastly KV Sync:</p>
+            <div className="flex items-center gap-2">
+              {syncState === 'idle' && (
+                <button
+                  onClick={() => setSyncState('confirm')}
+                  className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
+                >
+                  Sync to Fastly KV
+                </button>
+              )}
+              {syncState === 'confirm' && (
+                <>
+                  <span className="text-xs text-gray-600">Sync all active usernames to Fastly KV?</span>
+                  <button
+                    onClick={startFastlySync}
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+                  >
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setSyncState('idle')}
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  >
+                    Cancel
+                  </button>
+                </>
+              )}
+              {syncState === 'running' && (
+                <>
+                  <div className="flex-1 min-w-[200px]">
+                    <div className="flex items-center justify-between text-xs text-gray-600 mb-1">
+                      <span>Syncing... {syncProgress.synced.toLocaleString()}{syncProgress.total > 0 ? ` / ${syncProgress.total.toLocaleString()}` : ''}</span>
+                      {syncProgress.total > 0 && <span>{Math.round((syncProgress.synced / syncProgress.total) * 100)}%</span>}
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-1.5">
+                      <div
+                        className="bg-indigo-600 h-1.5 rounded-full transition-all"
+                        style={{ width: syncProgress.total > 0 ? `${Math.min(100, (syncProgress.synced / syncProgress.total) * 100)}%` : '0%' }}
+                      />
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => { cancelRef.current = true }}
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  >
+                    Stop
+                  </button>
+                </>
+              )}
+              {syncState === 'done' && (
+                <>
+                  <span className="text-xs text-green-700">
+                    Complete: {syncProgress.synced.toLocaleString()} synced{syncProgress.failed > 0 ? `, ${syncProgress.failed} failed` : ''}
+                  </span>
+                  <button
+                    onClick={() => setSyncState('idle')}
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  >
+                    Dismiss
+                  </button>
+                </>
+              )}
+              {syncState === 'error' && (
+                <>
+                  <span className="text-xs text-red-700">Error: {syncError}</span>
+                  <button
+                    onClick={() => setSyncState('idle')}
+                    className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  >
+                    Dismiss
+                  </button>
+                </>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ export default function Dashboard() {
   const [syncProgress, setSyncProgress] = useState({ synced: 0, failed: 0, total: 0 })
   const [syncError, setSyncError] = useState<string | null>(null)
   const cancelRef = useRef(false)
+  const abortRef = useRef<AbortController | null>(null)
 
   const startFastlySync = async () => {
     setSyncState('running')
@@ -38,14 +39,16 @@ export default function Dashboard() {
     let totalFailed = 0
 
     try {
+      abortRef.current = new AbortController()
+
       // Dry run first page to get total count
-      const dryRun = await syncFastlyPage(null, 500, true)
-      const estimatedTotal = dryRun.total ?? 0
+      const dryRun = await syncFastlyPage(null, 500, true, abortRef.current.signal)
+      const estimatedTotal = dryRun.total_active ?? 0
       setSyncProgress(p => ({ ...p, total: estimatedTotal }))
 
       // Now sync for real
       while (!cancelRef.current) {
-        const result = await syncFastlyPage(cursor, 500, false)
+        const result = await syncFastlyPage(cursor, 500, false, abortRef.current.signal)
         totalSynced += result.synced ?? 0
         totalFailed += result.failed ?? 0
         setSyncProgress({ synced: totalSynced, failed: totalFailed, total: estimatedTotal })
@@ -56,8 +59,14 @@ export default function Dashboard() {
 
       setSyncState(cancelRef.current ? 'idle' : 'done')
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        setSyncState('idle')
+        return
+      }
       setSyncError(err instanceof Error ? err.message : 'Unknown error')
       setSyncState('error')
+    } finally {
+      abortRef.current = null
     }
   }
 
@@ -315,7 +324,10 @@ export default function Dashboard() {
                     </div>
                   </div>
                   <button
-                    onClick={() => { cancelRef.current = true }}
+                    onClick={() => {
+                      cancelRef.current = true
+                      abortRef.current?.abort()
+                    }}
                     className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
                   >
                     Stop

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -2,8 +2,8 @@
 // ABOUTME: Shows all metadata and provides actions like assign, revoke, burn
 import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTagFromUsername, getAllTags } from '../api/client'
-import type { Username, TagDetail } from '../types'
+import { getUsername, assignUsername, revokeUsername, addTagToUsername, removeTagFromUsername, getAllTags, getNip05Status, resyncToFastly } from '../api/client'
+import type { Username, TagDetail, Nip05StatusResponse } from '../types'
 import StatusBadge from '../components/StatusBadge'
 
 export default function UsernameDetail() {
@@ -23,6 +23,12 @@ export default function UsernameDetail() {
   const [burnOnRevoke, setBurnOnRevoke] = useState(false)
   const [revokeLoading, setRevokeLoading] = useState(false)
 
+  // NIP-05 / Fastly sync states
+  const [nip05Status, setNip05Status] = useState<Nip05StatusResponse | null>(null)
+  const [nip05Loading, setNip05Loading] = useState(false)
+  const [syncLoading, setSyncLoading] = useState(false)
+  const [syncResult, setSyncResult] = useState<string | null>(null)
+
   // Tag states
   const [tags, setTags] = useState<string[]>([])
   const [tagDetails, setTagDetails] = useState<TagDetail[]>([])
@@ -31,8 +37,41 @@ export default function UsernameDetail() {
   const [allKnownTags, setAllKnownTags] = useState<{ tag: string; count: number }[]>([])
   const tagContainerRef = useRef<HTMLDivElement>(null)
 
+  const loadNip05Status = async () => {
+    if (!name) return
+    setNip05Loading(true)
+    try {
+      const result = await getNip05Status(name)
+      setNip05Status(result)
+    } catch {
+      setNip05Status(null)
+    } finally {
+      setNip05Loading(false)
+    }
+  }
+
+  const handleResync = async () => {
+    if (!name) return
+    setSyncLoading(true)
+    setSyncResult(null)
+    try {
+      const result = await resyncToFastly(name)
+      if (result.ok && result.success) {
+        setSyncResult(result.verified ? 'Synced and verified' : 'Synced (verification pending)')
+      } else {
+        setSyncResult(result.error || 'Sync failed')
+      }
+      loadNip05Status()
+    } catch (err) {
+      setSyncResult(err instanceof Error ? err.message : 'Sync failed')
+    } finally {
+      setSyncLoading(false)
+    }
+  }
+
   useEffect(() => {
     loadUsername()
+    loadNip05Status()
     getAllTags().then(data => setAllKnownTags(data.tags || [])).catch(() => {})
   }, [name])
 
@@ -351,6 +390,47 @@ export default function UsernameDetail() {
               <p className="mt-1 text-sm text-gray-900">{username.created_by}</p>
             </div>
           )}
+
+          <div>
+            <p className="text-sm font-medium text-gray-500">Fastly KV Status</p>
+            <div className="mt-1 flex items-center gap-2">
+              {nip05Loading ? (
+                <span className="text-sm text-gray-400">Checking...</span>
+              ) : !nip05Status ? (
+                <span className="text-sm text-gray-400">Unable to check</span>
+              ) : nip05Status.status === 'synced' ? (
+                <span className="inline-flex items-center gap-1 text-sm text-green-700">
+                  <span className="w-2 h-2 rounded-full bg-green-500" />
+                  Synced
+                </span>
+              ) : nip05Status.status === 'missing' ? (
+                <span className="inline-flex items-center gap-1 text-sm text-amber-700">
+                  <span className="w-2 h-2 rounded-full bg-amber-500" />
+                  Missing from Fastly
+                </span>
+              ) : nip05Status.status === 'mismatch' ? (
+                <span className="inline-flex items-center gap-1 text-sm text-red-700">
+                  <span className="w-2 h-2 rounded-full bg-red-500" />
+                  Mismatch
+                </span>
+              ) : nip05Status.status === 'not_applicable' ? (
+                <span className="text-sm text-gray-400">N/A — {nip05Status.reason}</span>
+              ) : nip05Status.status === 'error' ? (
+                <span className="inline-flex items-center gap-1 text-sm text-red-600">
+                  <span className="w-2 h-2 rounded-full bg-red-400" />
+                  Error: {nip05Status.detail}
+                </span>
+              ) : null}
+              <button
+                onClick={loadNip05Status}
+                disabled={nip05Loading}
+                className="text-xs text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                title="Refresh status"
+              >
+                Refresh
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -486,6 +566,24 @@ export default function UsernameDetail() {
                     </button>
                   </div>
                 </form>
+              )}
+            </div>
+          )}
+
+          {/* Re-sync to Fastly */}
+          {username.status === 'active' && username.pubkey && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleResync}
+                disabled={syncLoading}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md shadow-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+              >
+                {syncLoading ? 'Syncing...' : 'Re-sync to Fastly'}
+              </button>
+              {syncResult && (
+                <span className={`text-sm ${syncResult.startsWith('Synced') ? 'text-green-600' : 'text-red-600'}`}>
+                  {syncResult}
+                </span>
               )}
             </div>
           )}

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -59,7 +59,11 @@ export default function UsernameDetail() {
     try {
       const result = await resyncToFastly(name)
       if (result.ok && result.success) {
-        setSyncResult(result.verified ? 'Synced and verified' : (result.error || 'Synced, verification failed'))
+        if (result.action === 'deleted') {
+          setSyncResult('Deleted from Fastly')
+        } else {
+          setSyncResult(result.verified ? 'Synced and verified' : (result.error || 'Synced, verification failed'))
+        }
       } else {
         setSyncResult(result.error || 'Sync failed')
       }
@@ -648,7 +652,7 @@ export default function UsernameDetail() {
           )}
 
           {/* Re-sync to Fastly */}
-          {username.status === 'active' && username.pubkey && (
+          {(username.status === 'active' || username.status === 'revoked' || username.status === 'burned') && (
             <div className="flex items-center gap-3">
               <button
                 onClick={handleResync}

--- a/admin-ui/src/pages/UsernameDetail.tsx
+++ b/admin-ui/src/pages/UsernameDetail.tsx
@@ -57,7 +57,7 @@ export default function UsernameDetail() {
     try {
       const result = await resyncToFastly(name)
       if (result.ok && result.success) {
-        setSyncResult(result.verified ? 'Synced and verified' : 'Synced (verification pending)')
+        setSyncResult(result.verified ? 'Synced and verified' : (result.error || 'Synced, verification failed'))
       } else {
         setSyncResult(result.error || 'Sync failed')
       }

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -121,6 +121,7 @@ export interface FastlySyncPageResponse extends ApiResponse {
   synced?: number
   deleted?: number
   failed?: number
+  remaining?: number
   cursor?: string | null
   errors?: string[]
   dry_run?: boolean

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -88,11 +88,13 @@ export interface BulkReserveResponse extends ApiResponse {
 
 export interface FastlySyncPageResponse extends ApiResponse {
   synced?: number
+  deleted?: number
   failed?: number
   cursor?: string | null
   remaining?: number
   errors?: string[]
   dry_run?: boolean
+  total?: number
   syncable?: number
   skipped?: number
   page_size?: number

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -100,6 +100,9 @@ export interface Nip05StatusResponse extends ApiResponse {
   db?: {
     pubkey: string
     status: string
+    relays: string[]
+    atproto_did?: string | null
+    atproto_state?: string | null
   }
 }
 
@@ -107,6 +110,7 @@ export interface ResyncResponse extends ApiResponse {
   action?: 'synced' | 'deleted'
   success?: boolean
   verified?: boolean
+  error?: string
 }
 
 export interface FastlySyncPageResponse extends ApiResponse {
@@ -114,10 +118,9 @@ export interface FastlySyncPageResponse extends ApiResponse {
   deleted?: number
   failed?: number
   cursor?: string | null
-  remaining?: number
   errors?: string[]
   dry_run?: boolean
-  total?: number
+  total_active?: number
   syncable?: number
   skipped?: number
   page_size?: number

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -85,3 +85,15 @@ export interface BulkReserveResponse extends ApiResponse {
   failed?: number
   results?: BulkReserveResult[]
 }
+
+export interface FastlySyncPageResponse extends ApiResponse {
+  synced?: number
+  failed?: number
+  cursor?: string | null
+  remaining?: number
+  errors?: string[]
+  dry_run?: boolean
+  syncable?: number
+  skipped?: number
+  page_size?: number
+}

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -86,6 +86,29 @@ export interface BulkReserveResponse extends ApiResponse {
   results?: BulkReserveResult[]
 }
 
+export interface Nip05StatusResponse extends ApiResponse {
+  status?: 'synced' | 'mismatch' | 'missing' | 'not_applicable' | 'error'
+  reason?: string
+  detail?: string
+  fastly?: {
+    pubkey: string
+    status: string
+    relays: string[]
+    atproto_did?: string | null
+    atproto_state?: string | null
+  }
+  db?: {
+    pubkey: string
+    status: string
+  }
+}
+
+export interface ResyncResponse extends ApiResponse {
+  action?: 'synced' | 'deleted'
+  success?: boolean
+  verified?: boolean
+}
+
 export interface FastlySyncPageResponse extends ApiResponse {
   synced?: number
   deleted?: number

--- a/docs/superpowers/plans/2026-05-06-cron-sync-scaling.md
+++ b/docs/superpowers/plans/2026-05-06-cron-sync-scaling.md
@@ -1,0 +1,1224 @@
+# Fastly KV Cron Sync Scaling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the timing-out full-table Fastly KV sync with delta cron + concurrent batch processing + paginated admin full-sync endpoint + CLI backfill script + admin UI button.
+
+**Architecture:** Delta sync (2-hour window) for the hourly cron, `syncBatch` utility with bounded concurrency (10 parallel Fastly API calls), cursor-paginated admin endpoint for full syncs, shell script for CLI backfill, React button for admin UI.
+
+**Tech Stack:** Cloudflare Workers (Hono), D1, Fastly KV API, Vitest, React (admin-ui), shell/curl
+
+**Branch:** `fix/cron-sync-scaling` (already has WIP delta sync commit)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/utils/fastly-sync.ts` | Modify | Add `syncBatch` with bounded concurrency |
+| `src/utils/fastly-sync.test.ts` | Create | Tests for `syncBatch` |
+| `src/db/queries.ts` | Modify | Add `getActiveUsernamesPaginated` query |
+| `src/db/queries.test.ts` | Modify | Add tests for new query |
+| `src/index.ts` | Modify | Refactor cron handler to use `syncBatch` |
+| `src/index.test.ts` | Create | Tests for scheduled handler |
+| `src/routes/admin.ts` | Modify | Refactor `/sync/fastly` to paginated |
+| `src/routes/admin.test.ts` | Modify | Add tests for paginated sync endpoint |
+| `migrations/0010_add_updated_at_index.sql` | Create | Index on `updated_at` |
+| `scripts/backfill-fastly-kv.sh` | Create | CLI backfill script |
+| `admin-ui/src/api/client.ts` | Modify | Add `syncFastlyPage` API function |
+| `admin-ui/src/types/index.ts` | Modify | Add `FastlySyncPageResponse` type |
+| `admin-ui/src/pages/Dashboard.tsx` | Modify | Add Sync to Fastly button + progress |
+
+---
+
+### Task 1: `syncBatch` — concurrent sync utility
+
+**Files:**
+- Create: `src/utils/fastly-sync.test.ts`
+- Modify: `src/utils/fastly-sync.ts`
+
+- [ ] **Step 1: Write tests for `syncBatch`**
+
+Create `src/utils/fastly-sync.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock global fetch
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import { syncBatch, type SyncItem, type FastlyEnv } from './fastly-sync'
+
+const env: FastlyEnv = {
+  FASTLY_API_TOKEN: 'test-token',
+  FASTLY_STORE_ID: 'test-store-id',
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('syncBatch', () => {
+  it('should sync active users and delete revoked users', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => '' })
+
+    const items: SyncItem[] = [
+      { username: 'alice', action: 'sync', data: { pubkey: 'abc123', relays: [], status: 'active' } },
+      { username: 'bob', action: 'delete' },
+    ]
+
+    const result = await syncBatch(env, items)
+
+    expect(result.synced).toBe(1)
+    expect(result.deleted).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(result.errors).toEqual([])
+  })
+
+  it('should handle partial failures without aborting', async () => {
+    let callCount = 0
+    mockFetch.mockImplementation(async () => {
+      callCount++
+      if (callCount <= 3) {
+        // First item: all 3 retries fail
+        return { ok: false, status: 500, text: async () => 'server error' }
+      }
+      // Second item succeeds
+      return { ok: true, status: 200, text: async () => '' }
+    })
+
+    const items: SyncItem[] = [
+      { username: 'failing', action: 'sync', data: { pubkey: 'aaa', relays: [], status: 'active' } },
+      { username: 'passing', action: 'sync', data: { pubkey: 'bbb', relays: [], status: 'active' } },
+    ]
+
+    const result = await syncBatch(env, items)
+
+    expect(result.synced).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.errors.length).toBe(1)
+    expect(result.errors[0]).toContain('failing')
+  })
+
+  it('should respect concurrency limit', async () => {
+    let concurrent = 0
+    let maxConcurrent = 0
+
+    mockFetch.mockImplementation(async () => {
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await new Promise(r => setTimeout(r, 10))
+      concurrent--
+      return { ok: true, status: 200, text: async () => '' }
+    })
+
+    const items: SyncItem[] = Array.from({ length: 20 }, (_, i) => ({
+      username: `user${i}`,
+      action: 'sync' as const,
+      data: { pubkey: `pk${i}`, relays: [], status: 'active' as const },
+    }))
+
+    await syncBatch(env, items, { concurrency: 3 })
+
+    expect(maxConcurrent).toBeLessThanOrEqual(3)
+    expect(maxConcurrent).toBeGreaterThan(1)
+  })
+
+  it('should return zeros for empty items array', async () => {
+    const result = await syncBatch(env, [])
+
+    expect(result.synced).toBe(0)
+    expect(result.deleted).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('should skip sync when Fastly config is missing', async () => {
+    const result = await syncBatch({ FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }, [
+      { username: 'alice', action: 'sync', data: { pubkey: 'abc', relays: [], status: 'active' } },
+    ])
+
+    expect(result.failed).toBe(1)
+    expect(result.errors[0]).toContain('alice')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/utils/fastly-sync.test.ts`
+Expected: FAIL — `syncBatch` is not exported from `./fastly-sync`
+
+- [ ] **Step 3: Add `SyncItem` type and `syncBatch` to `fastly-sync.ts`**
+
+Add to `src/utils/fastly-sync.ts` after existing exports:
+
+```typescript
+export interface SyncItem {
+  username: string
+  action: 'sync' | 'delete'
+  data?: UsernameKVData
+}
+
+export interface SyncBatchResult {
+  synced: number
+  deleted: number
+  failed: number
+  errors: string[]
+}
+
+export async function syncBatch(
+  env: FastlyEnv,
+  items: SyncItem[],
+  options?: { concurrency?: number }
+): Promise<SyncBatchResult> {
+  const concurrency = options?.concurrency ?? 10
+  const result: SyncBatchResult = { synced: 0, deleted: 0, failed: 0, errors: [] }
+
+  if (items.length === 0) return result
+
+  const queue = [...items]
+  const inflight = new Set<Promise<void>>()
+
+  const processItem = async (item: SyncItem): Promise<void> => {
+    if (item.action === 'sync' && item.data) {
+      const res = await syncUsernameToFastly(env, item.username, item.data)
+      if (res.success) result.synced++
+      else {
+        result.failed++
+        result.errors.push(`${item.username}: ${res.error}`)
+      }
+    } else if (item.action === 'delete') {
+      const res = await deleteUsernameFromFastly(env, item.username)
+      if (res.success) result.deleted++
+      else {
+        result.failed++
+        result.errors.push(`${item.username}: ${res.error}`)
+      }
+    }
+  }
+
+  while (queue.length > 0 || inflight.size > 0) {
+    while (queue.length > 0 && inflight.size < concurrency) {
+      const item = queue.shift()!
+      const promise = processItem(item).then(() => {
+        inflight.delete(promise)
+      })
+      inflight.add(promise)
+    }
+    if (inflight.size > 0) {
+      await Promise.race(inflight)
+    }
+  }
+
+  return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/utils/fastly-sync.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/fastly-sync.ts src/utils/fastly-sync.test.ts
+git commit -m "feat: add syncBatch with bounded concurrency for Fastly KV sync"
+```
+
+---
+
+### Task 2: D1 migration — `updated_at` index
+
+**Files:**
+- Create: `migrations/0010_add_updated_at_index.sql`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `migrations/0010_add_updated_at_index.sql`:
+
+```sql
+-- Index for delta sync query (getUsernamesUpdatedSince)
+CREATE INDEX IF NOT EXISTS idx_usernames_updated_at ON usernames (updated_at);
+```
+
+- [ ] **Step 2: Test the migration locally**
+
+Run: `npx wrangler d1 execute divine-name-server-db --local --file migrations/0010_add_updated_at_index.sql`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add migrations/0010_add_updated_at_index.sql
+git commit -m "migration: add updated_at index for delta sync query"
+```
+
+---
+
+### Task 3: Paginated query — `getActiveUsernamesPaginated`
+
+**Files:**
+- Modify: `src/db/queries.ts`
+- Modify: `src/db/queries.test.ts`
+
+- [ ] **Step 1: Write tests for the paginated query**
+
+Read the existing test file at `src/db/queries.test.ts` to understand its mock DB pattern. Then add tests at the end of the file:
+
+```typescript
+describe('getActiveUsernamesPaginated', () => {
+  it('should return first page when cursor is null', async () => {
+    // Insert 3 active users with pubkeys
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('alice', 'alice', 'pk1', 'active', 'self-service', 1000, 1000),
+              ('bob', 'bob', 'pk2', 'active', 'self-service', 1001, 1001),
+              ('carol', 'carol', 'pk3', 'active', 'self-service', 1002, 1002)`
+    ).run()
+
+    const results = await getActiveUsernamesPaginated(db, null, 2)
+
+    expect(results.length).toBe(2)
+    expect(results[0].username_canonical).toBe('alice')
+    expect(results[1].username_canonical).toBe('bob')
+  })
+
+  it('should return next page using cursor', async () => {
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('alice', 'alice', 'pk1', 'active', 'self-service', 1000, 1000),
+              ('bob', 'bob', 'pk2', 'active', 'self-service', 1001, 1001),
+              ('carol', 'carol', 'pk3', 'active', 'self-service', 1002, 1002)`
+    ).run()
+
+    const firstPage = await getActiveUsernamesPaginated(db, null, 2)
+    const lastId = firstPage[firstPage.length - 1].id
+    const secondPage = await getActiveUsernamesPaginated(db, lastId, 2)
+
+    expect(secondPage.length).toBe(1)
+    expect(secondPage[0].username_canonical).toBe('carol')
+  })
+
+  it('should return empty array when cursor is past last record', async () => {
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('alice', 'alice', 'pk1', 'active', 'self-service', 1000, 1000)`
+    ).run()
+
+    const results = await getActiveUsernamesPaginated(db, 9999, 10)
+
+    expect(results.length).toBe(0)
+  })
+
+  it('should only return active usernames', async () => {
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('active1', 'active1', 'pk1', 'active', 'self-service', 1000, 1000),
+              ('revoked1', 'revoked1', 'pk2', 'revoked', 'self-service', 1001, 1001),
+              ('active2', 'active2', 'pk3', 'active', 'self-service', 1002, 1002)`
+    ).run()
+
+    const results = await getActiveUsernamesPaginated(db, null, 10)
+
+    expect(results.length).toBe(2)
+    expect(results.every(r => r.status === 'active')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/db/queries.test.ts`
+Expected: FAIL — `getActiveUsernamesPaginated` is not exported
+
+- [ ] **Step 3: Implement `getActiveUsernamesPaginated`**
+
+Add to `src/db/queries.ts` after `getAllActiveUsernames`:
+
+```typescript
+export async function getActiveUsernamesPaginated(
+  db: D1Database,
+  afterId: number | null,
+  limit: number
+): Promise<Username[]> {
+  if (afterId !== null) {
+    const result = await db.prepare(
+      'SELECT * FROM usernames WHERE status = ? AND id > ? ORDER BY id LIMIT ?'
+    ).bind('active', afterId, limit).all<Username>()
+    return result.results
+  }
+  const result = await db.prepare(
+    'SELECT * FROM usernames WHERE status = ? ORDER BY id LIMIT ?'
+  ).bind('active', limit).all<Username>()
+  return result.results
+}
+```
+
+- [ ] **Step 4: Import `getActiveUsernamesPaginated` in the test file**
+
+Add to the import in `src/db/queries.test.ts`:
+
+```typescript
+import { ..., getActiveUsernamesPaginated } from './queries'
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/db/queries.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/db/queries.ts src/db/queries.test.ts
+git commit -m "feat: add getActiveUsernamesPaginated for cursor-based full sync"
+```
+
+---
+
+### Task 4: Refactor cron handler to use `syncBatch`
+
+**Files:**
+- Modify: `src/index.ts`
+- Create: `src/index.test.ts`
+
+- [ ] **Step 1: Write tests for the scheduled handler**
+
+Create `src/index.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./db/queries', () => ({
+  expireStaleReservations: vi.fn().mockResolvedValue(0),
+  getUsernamesUpdatedSince: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('./utils/fastly-sync', () => ({
+  syncBatch: vi.fn().mockResolvedValue({ synced: 0, deleted: 0, failed: 0, errors: [] }),
+  parseRelayHints: vi.fn((r: string | null) => r ? JSON.parse(r) : []),
+}))
+
+import { expireStaleReservations, getUsernamesUpdatedSince } from './db/queries'
+import { syncBatch, parseRelayHints } from './utils/fastly-sync'
+
+// Import the default export to get the scheduled handler
+import worker from './index'
+
+const mockEnv = {
+  DB: {} as D1Database,
+  ASSETS: {} as Fetcher,
+  FASTLY_API_TOKEN: 'test-token',
+  FASTLY_STORE_ID: 'test-store',
+}
+
+const mockCtx = {
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+}
+
+describe('scheduled handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should expire stale reservations before syncing', async () => {
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    expect(expireStaleReservations).toHaveBeenCalledWith(mockEnv.DB)
+  })
+
+  it('should query for recently changed usernames with 2-hour window', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    const calledWith = vi.mocked(getUsernamesUpdatedSince).mock.calls[0][1]
+    const expectedMin = now - (2 * 60 * 60) - 5
+    const expectedMax = now - (2 * 60 * 60) + 5
+    expect(calledWith).toBeGreaterThanOrEqual(expectedMin)
+    expect(calledWith).toBeLessThanOrEqual(expectedMax)
+  })
+
+  it('should call syncBatch with active users mapped to sync items', async () => {
+    vi.mocked(getUsernamesUpdatedSince).mockResolvedValue([
+      {
+        id: 1, name: 'alice', username_display: 'Alice', username_canonical: 'alice',
+        pubkey: 'pk1', relays: '["wss://relay.example.com"]', status: 'active',
+        email: null, recyclable: 0, created_at: 1000, updated_at: 2000,
+        claimed_at: 1000, revoked_at: null, reserved_reason: null,
+        admin_notes: null, reservation_email: null, confirmation_token: null,
+        reservation_expires_at: null, subscription_expires_at: null,
+        claim_source: 'self-service', created_by: null,
+        atproto_did: null, atproto_state: null,
+      },
+    ] as any)
+
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      mockEnv,
+      [{ username: 'alice', action: 'sync', data: expect.objectContaining({ pubkey: 'pk1' }) }],
+      { concurrency: 10 }
+    )
+  })
+
+  it('should map revoked users to delete items', async () => {
+    vi.mocked(getUsernamesUpdatedSince).mockResolvedValue([
+      {
+        id: 2, name: 'bob', username_display: 'Bob', username_canonical: 'bob',
+        pubkey: 'pk2', relays: null, status: 'revoked',
+        email: null, recyclable: 1, created_at: 1000, updated_at: 2000,
+        claimed_at: 1000, revoked_at: 2000, reserved_reason: null,
+        admin_notes: null, reservation_email: null, confirmation_token: null,
+        reservation_expires_at: null, subscription_expires_at: null,
+        claim_source: 'self-service', created_by: null,
+        atproto_did: null, atproto_state: null,
+      },
+    ] as any)
+
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      mockEnv,
+      [{ username: 'bob', action: 'delete', data: undefined }],
+      { concurrency: 10 }
+    )
+  })
+
+  it('should filter out active users without pubkeys', async () => {
+    vi.mocked(getUsernamesUpdatedSince).mockResolvedValue([
+      {
+        id: 3, name: 'nopubkey', username_display: 'NoPubkey', username_canonical: 'nopubkey',
+        pubkey: null, relays: null, status: 'active',
+        email: null, recyclable: 0, created_at: 1000, updated_at: 2000,
+        claimed_at: null, revoked_at: null, reserved_reason: 'Reserved',
+        admin_notes: null, reservation_email: null, confirmation_token: null,
+        reservation_expires_at: null, subscription_expires_at: null,
+        claim_source: 'admin', created_by: null,
+        atproto_did: null, atproto_state: null,
+      },
+    ] as any)
+
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    expect(syncBatch).toHaveBeenCalledWith(mockEnv, [], { concurrency: 10 })
+  })
+
+  it('should handle empty change set without calling syncBatch with items', async () => {
+    vi.mocked(getUsernamesUpdatedSince).mockResolvedValue([])
+
+    await worker.scheduled({} as ScheduledEvent, mockEnv, mockCtx as any)
+
+    expect(syncBatch).toHaveBeenCalledWith(mockEnv, [], { concurrency: 10 })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/index.test.ts`
+Expected: FAIL — scheduled handler doesn't use `syncBatch` yet (current code uses inline loop)
+
+- [ ] **Step 3: Refactor the scheduled handler in `src/index.ts`**
+
+Replace the entire `scheduled` method. Update imports at the top:
+
+```typescript
+import { getUsernamesUpdatedSince, expireStaleReservations } from './db/queries'
+import { syncBatch, parseRelayHints, type SyncItem } from './utils/fastly-sync'
+```
+
+Replace the scheduled handler body:
+
+```typescript
+async scheduled(event: ScheduledEvent, env: Bindings, ctx: ExecutionContext) {
+  const expired = await expireStaleReservations(env.DB)
+  if (expired > 0) {
+    console.log(`Cron: expired ${expired} stale pending-confirmation reservations`)
+  }
+
+  const twoHoursAgo = Math.floor(Date.now() / 1000) - (2 * 60 * 60)
+  const changed = await getUsernamesUpdatedSince(env.DB, twoHoursAgo)
+
+  const syncable = changed.filter(u =>
+    (u.status === 'active' && u.pubkey) || u.status === 'revoked' || u.status === 'burned'
+  )
+
+  const items: SyncItem[] = syncable.map(u => ({
+    username: u.username_canonical || u.name,
+    action: (u.status === 'active') ? 'sync' as const : 'delete' as const,
+    data: (u.status === 'active') ? {
+      pubkey: u.pubkey!,
+      relays: parseRelayHints(u.relays),
+      status: 'active' as const,
+      atproto_did: u.atproto_did,
+      atproto_state: u.atproto_state,
+    } : undefined,
+  }))
+
+  const results = await syncBatch(env, items, { concurrency: 10 })
+  console.log(`Cron delta sync: ${changed.length} changed, ${results.synced} synced, ${results.deleted} deleted, ${results.failed} failed`)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/index.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Run all tests to check for regressions**
+
+Run: `npx vitest run`
+Expected: All existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.ts src/index.test.ts
+git commit -m "feat: refactor cron handler to use syncBatch with concurrency"
+```
+
+---
+
+### Task 5: Paginated admin sync endpoint
+
+**Files:**
+- Modify: `src/routes/admin.ts`
+- Modify: `src/routes/admin.test.ts`
+
+- [ ] **Step 1: Read the existing admin test file**
+
+Read `src/routes/admin.test.ts` to understand its mock patterns, DB setup, and how auth bypass works. Note the `BYPASS_LOCAL_AUTH: 'true'` pattern for test bindings.
+
+- [ ] **Step 2: Write tests for paginated sync endpoint**
+
+Add to `src/routes/admin.test.ts`:
+
+```typescript
+describe('POST /sync/fastly (paginated)', () => {
+  it('should return first page of users with cursor', async () => {
+    // Seed 3 active users with pubkeys
+    for (let i = 1; i <= 3; i++) {
+      await db.prepare(
+        `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+         VALUES (?, ?, ?, 'active', 'self-service', ?, ?)`
+      ).bind(`user${i}`, `user${i}`, `pk${i}`, 1000 + i, 1000 + i).run()
+    }
+
+    const req = new Request('https://names.admin.divine.video/api/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 2, dry_run: true }),
+    })
+
+    const res = await app.fetch(req, testEnv, testCtx)
+    const data = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(data.ok).toBe(true)
+    expect(data.synced).toBe(2)
+    expect(data.cursor).toBeTruthy()
+    expect(data.remaining).toBe(1)
+  })
+
+  it('should return null cursor on last page', async () => {
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('only', 'only', 'pk1', 'active', 'self-service', 1000, 1000)`
+    ).run()
+
+    const req = new Request('https://names.admin.divine.video/api/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 10, dry_run: true }),
+    })
+
+    const res = await app.fetch(req, testEnv, testCtx)
+    const data = await res.json()
+
+    expect(data.ok).toBe(true)
+    expect(data.cursor).toBeNull()
+    expect(data.remaining).toBe(0)
+  })
+
+  it('should not call Fastly API in dry_run mode', async () => {
+    await db.prepare(
+      `INSERT INTO usernames (name, username_canonical, pubkey, status, claim_source, created_at, updated_at)
+       VALUES ('alice', 'alice', 'pk1', 'active', 'self-service', 1000, 1000)`
+    ).run()
+
+    const req = new Request('https://names.admin.divine.video/api/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dry_run: true }),
+    })
+
+    const res = await app.fetch(req, testEnv, testCtx)
+    const data = await res.json()
+
+    expect(data.ok).toBe(true)
+    expect(data.synced).toBe(1)
+    const { syncBatch } = await import('../utils/fastly-sync')
+    expect(vi.mocked(syncBatch)).not.toHaveBeenCalled()
+  })
+
+  it('should return 400 when Fastly config is missing', async () => {
+    const envNoFastly = { ...testEnv, FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }
+    const req = new Request('https://names.admin.divine.video/api/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    const res = await app.fetch(req, envNoFastly, testCtx)
+    const data = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(data.ok).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npx vitest run src/routes/admin.test.ts`
+Expected: Tests fail — endpoint still uses old non-paginated logic
+
+- [ ] **Step 4: Refactor the `/sync/fastly` endpoint in `src/routes/admin.ts`**
+
+Update the import at the top of `src/routes/admin.ts`:
+
+```typescript
+import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, type SyncItem } from '../utils/fastly-sync'
+```
+
+Add the `getActiveUsernamesPaginated` import:
+
+```typescript
+import { ..., getActiveUsernamesPaginated } from '../db/queries'
+```
+
+Replace the existing `/sync/fastly` endpoint (around line 660):
+
+```typescript
+admin.post('/sync/fastly', async (c) => {
+  try {
+    if (!c.env.FASTLY_API_TOKEN || !c.env.FASTLY_STORE_ID) {
+      return c.json({ ok: false, error: 'Fastly credentials not configured' }, 400)
+    }
+
+    const body = await c.req.json<{
+      limit?: number
+      cursor?: string | null
+      dry_run?: boolean
+    }>().catch(() => ({}))
+
+    const limit = Math.min(body.limit ?? 500, 1000)
+    const afterId = body.cursor ? parseInt(body.cursor, 10) : null
+    const dryRun = body.dry_run ?? false
+
+    if (afterId !== null && isNaN(afterId)) {
+      return c.json({ ok: false, error: 'Invalid cursor' }, 400)
+    }
+
+    const page = await getActiveUsernamesPaginated(c.env.DB, afterId, limit)
+
+    const withPubkey = page.filter(u => u.pubkey)
+    const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
+
+    // Count remaining for progress reporting
+    let remaining = 0
+    if (nextCursor) {
+      const countResult = await c.env.DB.prepare(
+        'SELECT COUNT(*) as count FROM usernames WHERE status = ? AND id > ?'
+      ).bind('active', parseInt(nextCursor, 10)).first<{ count: number }>()
+      remaining = countResult?.count ?? 0
+    }
+
+    if (dryRun) {
+      return c.json({
+        ok: true,
+        synced: withPubkey.length,
+        deleted: 0,
+        failed: 0,
+        cursor: nextCursor,
+        remaining,
+        dry_run: true,
+      })
+    }
+
+    const items: SyncItem[] = withPubkey.map(u => ({
+      username: u.username_canonical || u.name,
+      action: 'sync' as const,
+      data: {
+        pubkey: u.pubkey!,
+        relays: u.relays ? (() => { try { return JSON.parse(u.relays!) } catch { return [] } })() : [],
+        status: 'active' as const,
+        atproto_did: u.atproto_did || null,
+        atproto_state: u.atproto_state || null,
+      },
+    }))
+
+    const results = await syncBatch(c.env, items, { concurrency: 10 })
+
+    return c.json({
+      ok: true,
+      synced: results.synced,
+      deleted: results.deleted,
+      failed: results.failed,
+      cursor: nextCursor,
+      remaining,
+      errors: results.errors.length > 0 ? results.errors.slice(0, 20) : undefined,
+    })
+  } catch (error) {
+    console.error('Fastly sync error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+```
+
+- [ ] **Step 5: Add `syncBatch` to the Fastly sync mock**
+
+In `src/routes/admin.test.ts`, update the mock for `../utils/fastly-sync`:
+
+```typescript
+vi.mock('../utils/fastly-sync', () => ({
+  syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
+  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true }),
+  bulkSyncToFastly: vi.fn().mockResolvedValue({ success: 0, failed: 0, errors: [] }),
+  syncBatch: vi.fn().mockResolvedValue({ synced: 0, deleted: 0, failed: 0, errors: [] }),
+}))
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run src/routes/admin.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 7: Run all tests**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/routes/admin.ts src/routes/admin.test.ts src/db/queries.ts
+git commit -m "feat: paginated Fastly KV full-sync endpoint with dry-run support"
+```
+
+---
+
+### Task 6: CLI backfill script
+
+**Files:**
+- Create: `scripts/backfill-fastly-kv.sh`
+
+- [ ] **Step 1: Create the backfill script**
+
+Create `scripts/backfill-fastly-kv.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backfill Fastly KV store by paging through the admin sync API.
+# Usage:
+#   ./scripts/backfill-fastly-kv.sh --dry-run
+#   ./scripts/backfill-fastly-kv.sh --apply
+#   ./scripts/backfill-fastly-kv.sh --apply --limit=1000
+#
+# Environment:
+#   ADMIN_TOKEN  - CF Access service token or Keycast session JWT (required)
+#   API_BASE     - Admin API base URL (default: https://names.admin.divine.video)
+
+API_BASE="${API_BASE:-https://names.admin.divine.video}"
+LIMIT=500
+MODE=""
+CURSOR="null"
+TOTAL_SYNCED=0
+TOTAL_FAILED=0
+PAGE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  MODE="dry_run" ;;
+    --apply)    MODE="apply" ;;
+    --limit=*)  LIMIT="${arg#*=}" ;;
+    *)          echo "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+if [ -z "$MODE" ]; then
+  echo "Usage: $0 --dry-run | --apply [--limit=N]"
+  echo ""
+  echo "  --dry-run   Report what would be synced without writing to Fastly"
+  echo "  --apply     Sync for real"
+  echo "  --limit=N   Users per page (default: 500, max: 1000)"
+  exit 1
+fi
+
+if [ -z "${ADMIN_TOKEN:-}" ]; then
+  echo "Error: ADMIN_TOKEN environment variable is required"
+  echo "Set it to a CF Access service token or Keycast session JWT"
+  exit 1
+fi
+
+DRY_RUN="false"
+if [ "$MODE" = "dry_run" ]; then
+  DRY_RUN="true"
+  echo "=== DRY RUN MODE (no writes to Fastly) ==="
+else
+  echo "=== APPLY MODE (writing to Fastly KV) ==="
+fi
+echo "API: $API_BASE"
+echo "Limit: $LIMIT per page"
+echo ""
+
+while true; do
+  PAGE=$((PAGE + 1))
+
+  if [ "$CURSOR" = "null" ]; then
+    BODY=$(printf '{"limit":%s,"dry_run":%s}' "$LIMIT" "$DRY_RUN")
+  else
+    BODY=$(printf '{"limit":%s,"cursor":"%s","dry_run":%s}' "$LIMIT" "$CURSOR" "$DRY_RUN")
+  fi
+
+  RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -H "Cookie: __session=${ADMIN_TOKEN}" \
+    -H "Cf-Access-Jwt-Assertion: ${ADMIN_TOKEN}" \
+    -d "$BODY" \
+    "${API_BASE}/api/admin/sync/fastly")
+
+  HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+  BODY_RESPONSE=$(echo "$RESPONSE" | sed '$d')
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo "Error: HTTP $HTTP_CODE"
+    echo "$BODY_RESPONSE"
+    exit 1
+  fi
+
+  OK=$(echo "$BODY_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ok', False))" 2>/dev/null || echo "False")
+  if [ "$OK" != "True" ]; then
+    echo "Error: API returned ok=false"
+    echo "$BODY_RESPONSE"
+    exit 1
+  fi
+
+  SYNCED=$(echo "$BODY_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('synced', 0))")
+  FAILED=$(echo "$BODY_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('failed', 0))")
+  REMAINING=$(echo "$BODY_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('remaining', 0))")
+  CURSOR=$(echo "$BODY_RESPONSE" | python3 -c "import sys,json; c=json.load(sys.stdin).get('cursor'); print(c if c else 'null')")
+
+  TOTAL_SYNCED=$((TOTAL_SYNCED + SYNCED))
+  TOTAL_FAILED=$((TOTAL_FAILED + FAILED))
+
+  ESTIMATED_PAGES="?"
+  if [ "$PAGE" -eq 1 ] && [ "$REMAINING" -gt 0 ]; then
+    ESTIMATED_PAGES=$(( (REMAINING + SYNCED + LIMIT - 1) / LIMIT ))
+  fi
+
+  echo "Page ${PAGE}: ${SYNCED} synced, ${FAILED} failed, ${REMAINING} remaining"
+
+  if [ "$CURSOR" = "null" ]; then
+    break
+  fi
+done
+
+echo ""
+echo "=== COMPLETE ==="
+echo "Pages:  $PAGE"
+echo "Synced: $TOTAL_SYNCED"
+echo "Failed: $TOTAL_FAILED"
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x scripts/backfill-fastly-kv.sh`
+
+- [ ] **Step 3: Verify the script parses correctly**
+
+Run: `bash -n scripts/backfill-fastly-kv.sh`
+Expected: No output (syntax OK)
+
+Run: `./scripts/backfill-fastly-kv.sh`
+Expected: Usage message printed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/backfill-fastly-kv.sh
+git commit -m "feat: add CLI backfill script for Fastly KV sync"
+```
+
+---
+
+### Task 7: Admin UI — Sync to Fastly button
+
+**Files:**
+- Modify: `admin-ui/src/types/index.ts`
+- Modify: `admin-ui/src/api/client.ts`
+- Modify: `admin-ui/src/pages/Dashboard.tsx`
+
+- [ ] **Step 1: Add the response type**
+
+Add to `admin-ui/src/types/index.ts`:
+
+```typescript
+export interface FastlySyncPageResponse extends ApiResponse {
+  synced: number
+  deleted: number
+  failed: number
+  cursor: string | null
+  remaining: number
+  dry_run?: boolean
+  errors?: string[]
+}
+```
+
+- [ ] **Step 2: Add the API client function**
+
+Add to `admin-ui/src/api/client.ts`:
+
+```typescript
+import type {
+  // ... existing imports ...
+  FastlySyncPageResponse
+} from '../types'
+
+export async function syncFastlyPage(
+  options: { limit?: number; cursor?: string | null; dry_run?: boolean } = {}
+): Promise<FastlySyncPageResponse> {
+  const response = await fetch(`${API_BASE}/sync/fastly`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      limit: options.limit ?? 500,
+      cursor: options.cursor ?? undefined,
+      dry_run: options.dry_run ?? false,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Sync failed: ${response.statusText}`)
+  }
+
+  return response.json()
+}
+```
+
+- [ ] **Step 3: Add the sync button to Dashboard.tsx**
+
+Add the import at the top of `admin-ui/src/pages/Dashboard.tsx`:
+
+```typescript
+import { searchUsernames, getAllTags, syncFastlyPage } from '../api/client'
+```
+
+Add state variables inside the `Dashboard` component, after the existing state declarations:
+
+```typescript
+const [syncInProgress, setSyncInProgress] = useState(false)
+const [syncProgress, setSyncProgress] = useState<{ synced: number; total: number; failed: number } | null>(null)
+const [syncError, setSyncError] = useState<string | null>(null)
+const [syncCancelled, setSyncCancelled] = useState(false)
+```
+
+Add the sync handler function inside the component, after `performSearch`:
+
+```typescript
+const handleSyncFastly = useCallback(async () => {
+  if (!window.confirm('This will sync all active usernames to Fastly KV. This may take several minutes. Continue?')) {
+    return
+  }
+
+  setSyncInProgress(true)
+  setSyncProgress(null)
+  setSyncError(null)
+  setSyncCancelled(false)
+
+  let cursor: string | null = null
+  let totalSynced = 0
+  let totalFailed = 0
+  let cancelled = false
+
+  try {
+    // First call to get total count
+    const dryRun = await syncFastlyPage({ limit: 1, dry_run: true })
+    const estimatedTotal = (dryRun.remaining ?? 0) + (dryRun.synced ?? 0)
+
+    while (!cancelled) {
+      const result = await syncFastlyPage({ cursor, limit: 500 })
+      totalSynced += result.synced
+      totalFailed += result.failed
+      setSyncProgress({ synced: totalSynced, total: estimatedTotal, failed: totalFailed })
+
+      if (!result.cursor) break
+      cursor = result.cursor
+
+      // Check cancellation via ref trick
+      if (syncCancelled) {
+        cancelled = true
+      }
+    }
+
+    if (cancelled) {
+      setSyncError(`Sync cancelled. ${totalSynced} synced, ${totalFailed} failed so far.`)
+    }
+  } catch (err) {
+    setSyncError(err instanceof Error ? err.message : 'Sync failed')
+  } finally {
+    setSyncInProgress(false)
+  }
+}, [syncCancelled])
+```
+
+Add the UI after the CSV Export section (after the closing `</div>` of the CSV section, before the `{error &&` block). In `Dashboard.tsx`, insert after line 231:
+
+```tsx
+{/* Fastly KV Sync */}
+<div className="mt-4 pt-4 border-t border-gray-200">
+  <div className="flex items-center gap-4">
+    <div>
+      <p className="text-sm font-medium text-gray-700">Fastly KV Sync</p>
+      <p className="text-xs text-gray-500">Sync all active usernames to Fastly edge for NIP-05 resolution</p>
+    </div>
+    {!syncInProgress ? (
+      <button
+        type="button"
+        onClick={handleSyncFastly}
+        className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-blue-100 text-blue-700 hover:bg-blue-200"
+      >
+        Sync to Fastly KV
+      </button>
+    ) : (
+      <button
+        type="button"
+        onClick={() => setSyncCancelled(true)}
+        className="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-red-100 text-red-700 hover:bg-red-200"
+      >
+        Cancel
+      </button>
+    )}
+  </div>
+  {syncProgress && (
+    <div className="mt-2">
+      <div className="flex items-center gap-2 text-sm text-gray-600">
+        <div className="flex-1 bg-gray-200 rounded-full h-2">
+          <div
+            className="bg-blue-600 h-2 rounded-full transition-all"
+            style={{ width: `${syncProgress.total > 0 ? Math.min(100, (syncProgress.synced / syncProgress.total) * 100) : 0}%` }}
+          />
+        </div>
+        <span className="whitespace-nowrap">
+          {syncProgress.synced.toLocaleString()} / {syncProgress.total.toLocaleString()}
+          {syncProgress.failed > 0 && <span className="text-red-600"> ({syncProgress.failed} failed)</span>}
+        </span>
+      </div>
+    </div>
+  )}
+  {syncError && (
+    <p className="mt-2 text-sm text-red-600">{syncError}</p>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Build admin UI to verify no compile errors**
+
+Run: `cd admin-ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-ui/src/types/index.ts admin-ui/src/api/client.ts admin-ui/src/pages/Dashboard.tsx
+git commit -m "feat: add Sync to Fastly KV button in admin dashboard"
+```
+
+---
+
+### Task 8: Clean up and remove dead code
+
+**Files:**
+- Modify: `src/utils/fastly-sync.ts`
+- Modify: `src/routes/admin.ts`
+
+- [ ] **Step 1: Check if `bulkSyncToFastly` is still used anywhere**
+
+Run: `grep -rn 'bulkSyncToFastly' src/`
+
+If it's only imported in `admin.ts` and used nowhere (replaced by `syncBatch`), remove it.
+
+- [ ] **Step 2: Remove `bulkSyncToFastly` from `fastly-sync.ts` if unused**
+
+Delete the `bulkSyncToFastly` function from `src/utils/fastly-sync.ts` (lines 137-154).
+
+- [ ] **Step 3: Remove `bulkSyncToFastly` import from `admin.ts` if unused**
+
+Update the import in `src/routes/admin.ts` to remove `bulkSyncToFastly`.
+
+- [ ] **Step 4: Remove `getAllActiveUsernames` import from `admin.ts` if no longer used**
+
+Check: `grep -n 'getAllActiveUsernames' src/routes/admin.ts`
+
+If still used by another endpoint (e.g., export), keep it. If only the old sync endpoint used it, remove the import.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 6: Type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/fastly-sync.ts src/routes/admin.ts
+git commit -m "chore: remove unused bulkSyncToFastly after syncBatch migration"
+```
+
+---
+
+### Task 9: Final integration test and PR update
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 2: Type check the entire project**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Build admin UI**
+
+Run: `cd admin-ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 4: Squash the WIP commit into the feature commits**
+
+The first commit on this branch was a WIP. Squash it into the relevant feature commit:
+
+Run: `git log --oneline` to see all commits on the branch, then interactive rebase to squash the WIP into the first feature commit.
+
+- [ ] **Step 5: Push and update PR #44**
+
+Push the branch and update the PR description to reflect the completed implementation.
+
+```bash
+git push --force-with-lease origin fix/cron-sync-scaling
+```
+
+Update PR body via `gh pr edit 44` with the final summary covering all 5 components.

--- a/docs/superpowers/specs/2026-05-06-cron-sync-scaling-design.md
+++ b/docs/superpowers/specs/2026-05-06-cron-sync-scaling-design.md
@@ -1,0 +1,245 @@
+# Fastly KV Cron Sync Scaling
+
+**Date:** 2026-05-06
+**PR:** #44 (`fix/cron-sync-scaling`)
+**Related:** #40 (Fastly KV sync broken), #43 (FASTLY_STORE_ID fix)
+
+## Problem
+
+The hourly cron reconciliation syncs D1 usernames to Fastly KV for edge NIP-05
+resolution. It fetches all ~131K active users and syncs them one-by-one. This
+times out on every run.
+
+Inline syncs (on claim/assign/revoke) work individually, but there is no
+working reconciliation path to catch missed writes or recover from outages.
+
+### Growth data (May 2026)
+
+| Metric | Value |
+|--------|-------|
+| Total active usernames | 131,682 |
+| Claims in May (6 days) | 41,086 (~7K/day) |
+| Typical hourly updates | 10-34 |
+| Peak daily spike (May 2) | 34,876 (bulk import) |
+
+The delta sync (2-hour window) handles steady state easily. Spike days and
+full backfills require concurrency and pagination.
+
+## Design
+
+### 1. Concurrent sync utility
+
+**File:** `src/utils/fastly-sync.ts`
+
+Add `syncBatch`: processes an array of username records with bounded
+concurrency (default 10 in-flight Fastly API calls).
+
+```typescript
+interface SyncItem {
+  username: string
+  action: 'sync' | 'delete'
+  data?: UsernameKVData
+}
+
+interface SyncBatchResult {
+  synced: number
+  deleted: number
+  failed: number
+  errors: string[]
+}
+
+async function syncBatch(
+  env: FastlyEnv,
+  items: SyncItem[],
+  options?: { concurrency?: number }
+): Promise<SyncBatchResult>
+```
+
+Implementation: simple promise pool. Maintains a set of in-flight promises,
+starts a new one each time one resolves, capped at `concurrency`. No new
+dependencies.
+
+Existing `syncUsernameToFastly` and `deleteUsernameFromFastly` are unchanged.
+`syncBatch` composes them.
+
+**Tests:**
+- Verify concurrency limit is respected (mock fetch with delay, assert no more
+  than N concurrent calls)
+- Verify mixed active/revoked items route to PUT vs DELETE correctly
+- Verify partial failures don't abort the batch (all items processed)
+- Verify error array contains failed usernames with error messages
+
+### 2. Delta cron handler
+
+**File:** `src/index.ts`
+
+Replace the sequential loop in the scheduled handler with `syncBatch`:
+
+```typescript
+async scheduled(event, env, ctx) {
+  const expired = await expireStaleReservations(env.DB)
+  if (expired > 0) console.log(`Cron: expired ${expired} stale reservations`)
+
+  const twoHoursAgo = Math.floor(Date.now() / 1000) - (2 * 60 * 60)
+  const changed = await getUsernamesUpdatedSince(env.DB, twoHoursAgo)
+
+  // Filter out active users without pubkeys (reserved names, not syncable)
+  const syncable = changed.filter(u =>
+    (u.status === 'active' && u.pubkey) || u.status === 'revoked' || u.status === 'burned'
+  )
+
+  const items = syncable.map(u => ({
+    username: u.username_canonical || u.name,
+    action: (u.status === 'active') ? 'sync' as const : 'delete' as const,
+    data: (u.status === 'active') ? {
+      pubkey: u.pubkey!,
+      relays: parseRelayHints(u.relays),
+      status: 'active',
+      atproto_did: u.atproto_did,
+      atproto_state: u.atproto_state,
+    } : undefined,
+  }))
+
+  const results = await syncBatch(env, items, { concurrency: 10 })
+  console.log(`Cron delta sync: ${changed.length} changed, ${results.synced} synced, ${results.deleted} deleted, ${results.failed} failed`)
+}
+```
+
+**Migration:** `0010_add_updated_at_index.sql`
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_usernames_updated_at ON usernames (updated_at);
+```
+
+Without this index, `getUsernamesUpdatedSince` scans all 131K+ rows.
+
+**Tests:**
+- Scheduled handler calls `syncBatch` with correctly mapped items
+- 2-hour window calculation is correct
+- `expireStaleReservations` runs before sync
+- Handler completes without error when no changes exist (empty array)
+
+### 3. Paginated full-sync API
+
+**File:** `src/routes/admin.ts`
+
+Refactor `POST /api/admin/sync/fastly` to accept pagination:
+
+**Request body:**
+```json
+{
+  "limit": 500,
+  "cursor": "12847",
+  "dry_run": false
+}
+```
+
+All fields optional. Defaults: `limit=500`, `cursor=null` (start from
+beginning), `dry_run=false`.
+
+**Response:**
+```json
+{
+  "ok": true,
+  "synced": 487,
+  "deleted": 3,
+  "failed": 2,
+  "cursor": "13347",
+  "remaining": 130692,
+  "errors": ["someuser: Fastly API error: 429"]
+}
+```
+
+`cursor` is null when the sync is complete (no more pages).
+
+**New query:** `src/db/queries.ts`
+
+```typescript
+async function getActiveUsernamesPaginated(
+  db: D1Database,
+  afterId: number | null,
+  limit: number
+): Promise<Username[]>
+```
+
+Query: `SELECT * FROM usernames WHERE status = 'active' AND id > ? ORDER BY id LIMIT ?`
+
+When `afterId` is null, omit the `id > ?` clause (first page).
+
+Each page uses `syncBatch` with concurrency 10. In dry-run mode, the query
+runs but `syncBatch` is skipped; the response reports what would be synced
+(count of users with pubkeys vs without).
+
+**Tests:**
+- First page (no cursor): returns users from id=1, includes cursor for next page
+- Middle page: returns users after cursor, correct remaining count
+- Last page: returns remaining users, cursor is null
+- Dry-run: returns counts, zero Fastly API calls made
+- Auth middleware protects the endpoint (unauthenticated request rejected)
+- Error handling: Fastly config missing returns 400
+
+### 4. CLI backfill script
+
+**File:** `scripts/backfill-fastly-kv.sh`
+
+Shell script that loops through the paginated admin API.
+
+**Usage:**
+```bash
+# Dry run -- report what would sync
+./scripts/backfill-fastly-kv.sh --dry-run
+
+# Apply -- sync for real
+./scripts/backfill-fastly-kv.sh --apply
+
+# Custom page size
+./scripts/backfill-fastly-kv.sh --apply --limit=1000
+```
+
+**Requirements:**
+- `ADMIN_TOKEN` env var (CF Access service token or Keycast session JWT)
+- `API_BASE` env var (defaults to `https://names.admin.divine.video`)
+
+**Behavior:**
+- Pages through `POST /api/admin/sync/fastly` until cursor is null
+- Prints progress per page: `Page 12/~263: 5987 synced, 0 failed, 125695 remaining`
+- Stops on any page returning `ok: false` (prints error, exits non-zero)
+- On completion, prints totals
+
+**Testing:** Manual. Run `--dry-run` against staging, verify counts match D1
+active user count. Then `--apply` against staging, spot-check Fastly KV
+entries.
+
+### 5. Admin UI button
+
+**File:** `admin-ui/src/` (component TBD based on existing UI structure)
+
+Add "Sync to Fastly KV" button on the admin dashboard:
+
+1. Click triggers a confirmation dialog: "This will sync all active usernames
+   to Fastly KV. This may take several minutes. Continue?"
+2. On confirm, UI loops calling the paginated endpoint
+3. Progress bar shows: `Syncing... 5,987 / 131,682 (4%)`
+4. On completion: "Sync complete. 131,400 synced, 12 failed."
+5. On error: show error message, stop syncing
+6. Cancel button stops the loop after the current page completes
+
+**Testing:** Manual verification on staging. Click button, watch progress
+complete, spot-check Fastly KV.
+
+## Migration plan
+
+1. Merge PR #43 first (FASTLY_STORE_ID as var) -- inline syncs start working
+2. Deploy PR #44 (this work) -- delta cron + paginated API + script
+3. Run migration `0010_add_updated_at_index.sql` on production D1
+4. Run `scripts/backfill-fastly-kv.sh --dry-run` to verify counts
+5. Run `scripts/backfill-fastly-kv.sh --apply` to backfill Fastly KV
+6. Verify: spot-check NIP-05 resolution on several `*.divine.video` subdomains
+7. Monitor next cron tick in worker logs -- should show small delta count
+
+## Out of scope
+
+- Fastly KV bulk API (doesn't exist -- single PUT/DELETE per key)
+- CF Queues or Durable Objects (unnecessary complexity for this use case)
+- Bidirectional sync (Fastly KV is write-only from name-server's perspective)
+- Changing the cron frequency (hourly is fine with delta sync)

--- a/migrations/0010_add_updated_at_index.sql
+++ b/migrations/0010_add_updated_at_index.sql
@@ -1,0 +1,2 @@
+-- Index for delta sync query (getUsernamesUpdatedSince)
+CREATE INDEX IF NOT EXISTS idx_usernames_updated_at ON usernames (updated_at);

--- a/migrations/0011_add_fastly_sync_queue.sql
+++ b/migrations/0011_add_fastly_sync_queue.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS fastly_sync_queue (
+  username_canonical TEXT PRIMARY KEY,
+  action TEXT NOT NULL CHECK(action IN ('sync', 'delete')),
+  payload_json TEXT,
+  queued_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  last_attempt_at INTEGER,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_fastly_sync_queue_updated_at ON fastly_sync_queue (updated_at);

--- a/scripts/backfill-fastly-kv.sh
+++ b/scripts/backfill-fastly-kv.sh
@@ -81,7 +81,7 @@ while true; do
   if [[ "$DRY_RUN" == "true" ]]; then
     syncable=$(echo "$body" | jq -r '.syncable')
     skipped=$(echo "$body" | jq -r '.skipped')
-    remaining=$(echo "$body" | jq -r '.remaining')
+    remaining=$(echo "$body" | jq -r '.remaining // 0')
     cursor=$(echo "$body" | jq -r '.cursor // "null"')
     total_synced=$((total_synced + syncable))
     total_skipped=$((total_skipped + skipped))
@@ -89,7 +89,7 @@ while true; do
   else
     synced=$(echo "$body" | jq -r '.synced')
     failed=$(echo "$body" | jq -r '.failed')
-    remaining=$(echo "$body" | jq -r '.remaining')
+    remaining=$(echo "$body" | jq -r '.remaining // 0')
     cursor=$(echo "$body" | jq -r '.cursor // "null"')
     total_synced=$((total_synced + synced))
     total_failed=$((total_failed + failed))

--- a/scripts/backfill-fastly-kv.sh
+++ b/scripts/backfill-fastly-kv.sh
@@ -59,7 +59,7 @@ while true; do
   response=$(curl -s -w "\n%{http_code}" \
     -X POST "$API_BASE/api/admin/sync/fastly" \
     -H "Content-Type: application/json" \
-    -H "Cookie: session=$ADMIN_TOKEN" \
+    -H "Cookie: __session=$ADMIN_TOKEN" \
     -d "$payload")
 
   http_code=$(echo "$response" | tail -1)

--- a/scripts/backfill-fastly-kv.sh
+++ b/scripts/backfill-fastly-kv.sh
@@ -30,7 +30,8 @@ if [[ -z "$MODE" ]]; then
 fi
 
 if [[ -z "${ADMIN_TOKEN:-}" ]]; then
-  echo "Error: ADMIN_TOKEN env var required (CF Access service token or Keycast session JWT)"
+  echo "Error: ADMIN_TOKEN env var required"
+  echo "  Extract from browser: copy the 'session' cookie value from names.admin.divine.video"
   exit 1
 fi
 

--- a/scripts/backfill-fastly-kv.sh
+++ b/scripts/backfill-fastly-kv.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backfill Fastly KV Store from D1 via the paginated admin sync endpoint.
+# Usage:
+#   ./scripts/backfill-fastly-kv.sh --dry-run          # report what would sync
+#   ./scripts/backfill-fastly-kv.sh --apply             # sync for real
+#   ./scripts/backfill-fastly-kv.sh --apply --limit=1000
+
+API_BASE="${API_BASE:-https://names.admin.divine.video}"
+LIMIT=500
+MODE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  MODE="dry_run" ;;
+    --apply)    MODE="apply" ;;
+    --limit=*)  LIMIT="${arg#--limit=}" ;;
+    *)          echo "Unknown arg: $arg"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage: $0 --dry-run | --apply [--limit=N]"
+  echo ""
+  echo "  --dry-run   Report what would be synced (no Fastly writes)"
+  echo "  --apply     Sync active usernames to Fastly KV"
+  echo "  --limit=N   Page size (default 500, max 1000)"
+  exit 1
+fi
+
+if [[ -z "${ADMIN_TOKEN:-}" ]]; then
+  echo "Error: ADMIN_TOKEN env var required (CF Access service token or Keycast session JWT)"
+  exit 1
+fi
+
+DRY_RUN="false"
+[[ "$MODE" == "dry_run" ]] && DRY_RUN="true"
+
+cursor="null"
+page=0
+total_synced=0
+total_failed=0
+total_skipped=0
+
+echo "Backfill Fastly KV — mode=$MODE limit=$LIMIT base=$API_BASE"
+echo ""
+
+while true; do
+  page=$((page + 1))
+
+  if [[ "$cursor" == "null" ]]; then
+    payload="{\"limit\":$LIMIT,\"dry_run\":$DRY_RUN}"
+  else
+    payload="{\"limit\":$LIMIT,\"cursor\":\"$cursor\",\"dry_run\":$DRY_RUN}"
+  fi
+
+  response=$(curl -s -w "\n%{http_code}" \
+    -X POST "$API_BASE/api/admin/sync/fastly" \
+    -H "Content-Type: application/json" \
+    -H "Cookie: session=$ADMIN_TOKEN" \
+    -d "$payload")
+
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "ERROR: HTTP $http_code on page $page"
+    echo "$body"
+    exit 1
+  fi
+
+  ok=$(echo "$body" | jq -r '.ok')
+  if [[ "$ok" != "true" ]]; then
+    echo "ERROR: API returned ok=false on page $page"
+    echo "$body" | jq .
+    exit 1
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    syncable=$(echo "$body" | jq -r '.syncable')
+    skipped=$(echo "$body" | jq -r '.skipped')
+    remaining=$(echo "$body" | jq -r '.remaining')
+    cursor=$(echo "$body" | jq -r '.cursor // "null"')
+    total_synced=$((total_synced + syncable))
+    total_skipped=$((total_skipped + skipped))
+    echo "Page $page: $syncable syncable, $skipped skipped (no pubkey), $remaining remaining"
+  else
+    synced=$(echo "$body" | jq -r '.synced')
+    failed=$(echo "$body" | jq -r '.failed')
+    remaining=$(echo "$body" | jq -r '.remaining')
+    cursor=$(echo "$body" | jq -r '.cursor // "null"')
+    total_synced=$((total_synced + synced))
+    total_failed=$((total_failed + failed))
+    echo "Page $page: $synced synced, $failed failed, $remaining remaining"
+
+    errors=$(echo "$body" | jq -r '.errors // [] | .[]')
+    if [[ -n "$errors" ]]; then
+      echo "  Errors: $errors"
+    fi
+  fi
+
+  if [[ "$cursor" == "null" ]]; then
+    break
+  fi
+done
+
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry run complete: $total_synced would sync, $total_skipped would skip ($page pages)"
+else
+  echo "Backfill complete: $total_synced synced, $total_failed failed ($page pages)"
+fi

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, getActiveUsernamesPaginated, countActiveUsernames, type SearchParams, type Username } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, getActiveUsernamesPaginated, countActiveUsernames, enqueueFastlySyncTask, getQueuedFastlySyncTasks, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -642,6 +642,201 @@ describe('getActiveUsernamesPaginated', () => {
     expect(result).toHaveLength(4)
     expect(result.every(r => r.status === 'active')).toBe(true)
     expect(result.map(r => r.name)).toEqual(['alice', 'charlie', 'dave', 'frank'])
+  })
+})
+
+type QueueRow = {
+  username_canonical: string
+  action: 'sync' | 'delete'
+  payload_json: string | null
+  queued_at: number
+  updated_at: number
+  last_attempt_at: number | null
+  attempt_count: number
+  last_error: string | null
+}
+
+function createFastlyQueueMock(initialRows: QueueRow[] = []) {
+  const rows = [...initialRows]
+
+  return {
+    _rows: rows,
+    prepare: (sql: string) => ({
+      bind: (...params: any[]) => ({
+        run: async () => {
+          if (sql.includes('INSERT INTO fastly_sync_queue')) {
+            const [username, action, payloadJson, queuedAt, updatedAt] = params
+            const existing = rows.find((row) => row.username_canonical === username)
+            if (!existing) {
+              rows.push({
+                username_canonical: username,
+                action,
+                payload_json: payloadJson,
+                queued_at: queuedAt,
+                updated_at: updatedAt,
+                last_attempt_at: null,
+                attempt_count: 0,
+                last_error: null,
+              })
+              return { success: true, meta: { changes: 1 } }
+            }
+
+            const changed = existing.action !== action || (existing.payload_json ?? '') !== (payloadJson ?? '')
+            existing.action = action
+            existing.payload_json = payloadJson
+            existing.updated_at = updatedAt
+            if (changed) {
+              existing.queued_at = queuedAt
+              existing.last_attempt_at = null
+              existing.attempt_count = 0
+              existing.last_error = null
+            }
+            return { success: true, meta: { changes: 1 } }
+          }
+
+          if (sql.includes('DELETE FROM fastly_sync_queue WHERE username_canonical IN')) {
+            const usernames = new Set(params as string[])
+            for (let i = rows.length - 1; i >= 0; i--) {
+              if (usernames.has(rows[i].username_canonical)) rows.splice(i, 1)
+            }
+            return { success: true, meta: { changes: 1 } }
+          }
+
+          if (sql.includes('UPDATE fastly_sync_queue') && sql.includes('attempt_count = attempt_count + 1')) {
+            const [lastAttemptAt, lastError, username] = params
+            const row = rows.find((entry) => entry.username_canonical === username)
+            if (row) {
+              row.last_attempt_at = lastAttemptAt
+              row.last_error = lastError
+              row.attempt_count += 1
+            }
+            return { success: true, meta: { changes: row ? 1 : 0 } }
+          }
+
+          return { success: true, meta: { changes: 0 } }
+        },
+        all: async () => {
+          if (sql.includes('FROM fastly_sync_queue')) {
+            const limit = params[0]
+            return {
+              results: [...rows]
+                .sort((a, b) => a.updated_at - b.updated_at)
+                .slice(0, limit),
+            }
+          }
+          return { results: [] }
+        },
+      }),
+    }),
+    batch: async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      for (const statement of statements) {
+        await statement.run()
+      }
+      return []
+    },
+  } as unknown as D1Database & { _rows: QueueRow[] }
+}
+
+describe('Fastly sync queue helpers', () => {
+  it('enqueueFastlySyncTask preserves attempt metadata for unchanged queued work', async () => {
+    const db = createFastlyQueueMock([{
+      username_canonical: 'alice',
+      action: 'sync',
+      payload_json: JSON.stringify({ pubkey: 'pk1', relays: [], status: 'active', atproto_did: null, atproto_state: null }),
+      queued_at: 100,
+      updated_at: 100,
+      last_attempt_at: 150,
+      attempt_count: 2,
+      last_error: 'boom',
+    }])
+
+    await enqueueFastlySyncTask(db, {
+      username: 'alice',
+      action: 'sync',
+      data: { pubkey: 'pk1', relays: [], status: 'active', atproto_did: null, atproto_state: null },
+    }, 200)
+
+    expect(db._rows[0].attempt_count).toBe(2)
+    expect(db._rows[0].last_attempt_at).toBe(150)
+    expect(db._rows[0].last_error).toBe('boom')
+    expect(db._rows[0].queued_at).toBe(100)
+    expect(db._rows[0].updated_at).toBe(200)
+  })
+
+  it('enqueueFastlySyncTask resets attempt metadata when payload changes', async () => {
+    const db = createFastlyQueueMock([{
+      username_canonical: 'alice',
+      action: 'sync',
+      payload_json: JSON.stringify({ pubkey: 'old', relays: [], status: 'active', atproto_did: null, atproto_state: null }),
+      queued_at: 100,
+      updated_at: 100,
+      last_attempt_at: 150,
+      attempt_count: 2,
+      last_error: 'boom',
+    }])
+
+    await enqueueFastlySyncTask(db, {
+      username: 'alice',
+      action: 'sync',
+      data: { pubkey: 'new', relays: [], status: 'active', atproto_did: null, atproto_state: null },
+    }, 200)
+
+    expect(db._rows[0].attempt_count).toBe(0)
+    expect(db._rows[0].last_attempt_at).toBeNull()
+    expect(db._rows[0].last_error).toBeNull()
+    expect(db._rows[0].queued_at).toBe(200)
+  })
+
+  it('getQueuedFastlySyncTasks orders by updated_at and deserializes payloads', async () => {
+    const db = createFastlyQueueMock([
+      {
+        username_canonical: 'later',
+        action: 'delete',
+        payload_json: null,
+        queued_at: 200,
+        updated_at: 200,
+        last_attempt_at: null,
+        attempt_count: 0,
+        last_error: null,
+      },
+      {
+        username_canonical: 'earlier',
+        action: 'sync',
+        payload_json: JSON.stringify({ pubkey: 'pk1', relays: ['wss://b'], status: 'active', atproto_did: null, atproto_state: null }),
+        queued_at: 100,
+        updated_at: 100,
+        last_attempt_at: 110,
+        attempt_count: 1,
+        last_error: 'nope',
+      },
+    ])
+
+    const tasks = await getQueuedFastlySyncTasks(db, 10)
+
+    expect(tasks.map((task) => task.username)).toEqual(['earlier', 'later'])
+    expect(tasks[0].data?.pubkey).toBe('pk1')
+    expect(tasks[1].data).toBeUndefined()
+  })
+
+  it('clearFastlySyncTasks chunks large deletes and markFastlySyncTaskFailures accumulates attempts', async () => {
+    const db = createFastlyQueueMock(Array.from({ length: 501 }, (_, i) => ({
+      username_canonical: `user-${i}`,
+      action: 'sync' as const,
+      payload_json: JSON.stringify({ pubkey: `pk-${i}`, relays: [], status: 'active', atproto_did: null, atproto_state: null }),
+      queued_at: i,
+      updated_at: i,
+      last_attempt_at: null,
+      attempt_count: 0,
+      last_error: null,
+    })))
+
+    await markFastlySyncTaskFailures(db, [{ username: 'user-0', error: 'first' }], 1000)
+    await markFastlySyncTaskFailures(db, [{ username: 'user-0', error: 'second' }], 2000)
+    expect(db._rows.find((row) => row.username_canonical === 'user-0')?.attempt_count).toBe(2)
+    expect(db._rows.find((row) => row.username_canonical === 'user-0')?.last_error).toBe('second')
+
+    await clearFastlySyncTasks(db, db._rows.map((row) => row.username_canonical))
+    expect(db._rows).toHaveLength(0)
   })
 })
 

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, type SearchParams, type Username } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getActiveUsernamesPaginated, countActiveUsernames, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -572,6 +572,85 @@ describe('revoked_at clearing (ericartell bug)', () => {
     expect(record.status).toBe('revoked')
     expect(record.revoked_at).not.toBeNull()
     expect(typeof record.revoked_at).toBe('number')
+  })
+})
+
+function createCursorMock(records: MockRecord[]) {
+  return {
+    prepare: (sql: string) => ({
+      bind: (...params: any[]) => ({
+        all: async () => {
+          let filtered = records.filter(r => r.status === 'active')
+          if (params.length === 3) {
+            const [, afterId, limit] = params
+            filtered = filtered.filter(r => (r.id ?? 0) > afterId)
+            filtered.sort((a, b) => (a.id ?? 0) - (b.id ?? 0))
+            return { results: filtered.slice(0, limit) }
+          }
+          const limit = params[params.length - 1]
+          filtered.sort((a, b) => (a.id ?? 0) - (b.id ?? 0))
+          return { results: filtered.slice(0, limit) }
+        },
+        first: async () => {
+          const count = records.filter(r => r.status === 'active').length
+          return { count }
+        },
+      }),
+    }),
+  } as unknown as D1Database
+}
+
+const paginationRecords: MockRecord[] = [
+  { id: 1, name: 'alice', username_canonical: 'alice', pubkey: 'pk1', status: 'active', created_at: 1700000000, updated_at: 1700000000 },
+  { id: 2, name: 'bob', username_canonical: 'bob', pubkey: null, status: 'reserved', created_at: 1700000100, updated_at: 1700000100 },
+  { id: 3, name: 'charlie', username_canonical: 'charlie', pubkey: 'pk3', status: 'active', created_at: 1700000200, updated_at: 1700000200 },
+  { id: 4, name: 'dave', username_canonical: 'dave', pubkey: 'pk4', status: 'active', created_at: 1700000300, updated_at: 1700000300 },
+  { id: 5, name: 'eve', username_canonical: 'eve', pubkey: 'pk5', status: 'revoked', created_at: 1700000400, updated_at: 1700000400 },
+  { id: 6, name: 'frank', username_canonical: 'frank', pubkey: 'pk6', status: 'active', created_at: 1700000500, updated_at: 1700000500 },
+]
+
+describe('getActiveUsernamesPaginated', () => {
+  it('first page (cursor null) returns first N active users ordered by id', async () => {
+    const db = createCursorMock(paginationRecords)
+    const result = await getActiveUsernamesPaginated(db, null, 2)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('alice')
+    expect(result[1].name).toBe('charlie')
+  })
+
+  it('next page (with cursor) returns active users after cursor id', async () => {
+    const db = createCursorMock(paginationRecords)
+    const result = await getActiveUsernamesPaginated(db, 3, 2)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('dave')
+    expect(result[1].name).toBe('frank')
+  })
+
+  it('returns empty when cursor past last record', async () => {
+    const db = createCursorMock(paginationRecords)
+    const result = await getActiveUsernamesPaginated(db, 100, 10)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('only returns active usernames (skips reserved and revoked)', async () => {
+    const db = createCursorMock(paginationRecords)
+    const result = await getActiveUsernamesPaginated(db, null, 100)
+
+    expect(result).toHaveLength(4)
+    expect(result.every(r => r.status === 'active')).toBe(true)
+    expect(result.map(r => r.name)).toEqual(['alice', 'charlie', 'dave', 'frank'])
+  })
+})
+
+describe('countActiveUsernames', () => {
+  it('returns count of active usernames', async () => {
+    const db = createCursorMock(paginationRecords)
+    const count = await countActiveUsernames(db)
+
+    expect(count).toBe(4)
   })
 })
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -129,12 +129,39 @@ export async function claimUsername(
   ).bind(nameCanonical, nameDisplay, nameCanonical, pubkey, relaysJson, now, now, now).run()
 }
 
-export async function getAllActiveUsernames(
+export async function getActiveUsernamesPaginated(
+  db: D1Database,
+  afterId: number | null,
+  limit: number
+): Promise<Username[]> {
+  if (afterId !== null) {
+    const result = await db.prepare(
+      'SELECT * FROM usernames WHERE status = ? AND id > ? ORDER BY id LIMIT ?'
+    ).bind('active', afterId, limit).all<Username>()
+    return result.results
+  }
+  const result = await db.prepare(
+    'SELECT * FROM usernames WHERE status = ? ORDER BY id LIMIT ?'
+  ).bind('active', limit).all<Username>()
+  return result.results
+}
+
+export async function countActiveUsernames(
   db: D1Database
+): Promise<number> {
+  const result = await db.prepare(
+    'SELECT COUNT(*) as count FROM usernames WHERE status = ?'
+  ).bind('active').first<{ count: number }>()
+  return result?.count ?? 0
+}
+
+export async function getUsernamesUpdatedSince(
+  db: D1Database,
+  sinceEpoch: number
 ): Promise<Username[]> {
   const result = await db.prepare(
-    'SELECT * FROM usernames WHERE status = ?'
-  ).bind('active').all<Username>()
+    `SELECT * FROM usernames WHERE updated_at >= ? AND status IN ('active', 'revoked', 'burned')`
+  ).bind(sinceEpoch).all<Username>()
 
   return result.results
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -201,11 +201,31 @@ export async function enqueueFastlySyncTask(
      ON CONFLICT(username_canonical) DO UPDATE SET
        action = excluded.action,
        payload_json = excluded.payload_json,
-       queued_at = excluded.queued_at,
+       queued_at = CASE
+         WHEN fastly_sync_queue.action != excluded.action
+           OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
+         THEN excluded.queued_at
+         ELSE fastly_sync_queue.queued_at
+       END,
        updated_at = excluded.updated_at,
-       last_attempt_at = NULL,
-       attempt_count = 0,
-       last_error = NULL`
+       last_attempt_at = CASE
+         WHEN fastly_sync_queue.action != excluded.action
+           OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
+         THEN NULL
+         ELSE fastly_sync_queue.last_attempt_at
+       END,
+       attempt_count = CASE
+         WHEN fastly_sync_queue.action != excluded.action
+           OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
+         THEN 0
+         ELSE fastly_sync_queue.attempt_count
+       END,
+       last_error = CASE
+         WHEN fastly_sync_queue.action != excluded.action
+           OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
+         THEN NULL
+         ELSE fastly_sync_queue.last_error
+       END`
   ).bind(item.username, item.action, payloadJson, now, now).run()
 }
 
@@ -247,10 +267,13 @@ export async function clearFastlySyncTasks(
 ): Promise<void> {
   if (usernames.length === 0) return
 
-  const placeholders = usernames.map(() => '?').join(', ')
-  await db.prepare(
-    `DELETE FROM fastly_sync_queue WHERE username_canonical IN (${placeholders})`
-  ).bind(...usernames).run()
+  for (let i = 0; i < usernames.length; i += 500) {
+    const chunk = usernames.slice(i, i + 500)
+    const placeholders = chunk.map(() => '?').join(', ')
+    await db.prepare(
+      `DELETE FROM fastly_sync_queue WHERE username_canonical IN (${placeholders})`
+    ).bind(...chunk).run()
+  }
 }
 
 export async function markFastlySyncTaskFailures(
@@ -258,6 +281,21 @@ export async function markFastlySyncTaskFailures(
   failures: Array<{ username: string; error: string }>,
   now = Math.floor(Date.now() / 1000)
 ): Promise<void> {
+  if (failures.length === 0) return
+
+  const batched = (db as D1Database & { batch?: (statements: D1PreparedStatement[]) => Promise<unknown> }).batch
+  if (typeof batched === 'function') {
+    const statements = failures.map((failure) =>
+      db.prepare(
+        `UPDATE fastly_sync_queue
+         SET last_attempt_at = ?, attempt_count = attempt_count + 1, last_error = ?
+         WHERE username_canonical = ?`
+      ).bind(now, failure.error, failure.username)
+    )
+    await batched(statements)
+    return
+  }
+
   for (const failure of failures) {
     await db.prepare(
       `UPDATE fastly_sync_queue

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -150,7 +150,7 @@ export async function countActiveUsernames(
   db: D1Database,
   afterId?: number | null
 ): Promise<number> {
-  if (afterId) {
+  if (afterId !== undefined && afterId !== null) {
     const result = await db.prepare(
       'SELECT COUNT(*) as count FROM usernames WHERE status = ? AND id > ?'
     ).bind('active', afterId).first<{ count: number }>()

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -147,8 +147,15 @@ export async function getActiveUsernamesPaginated(
 }
 
 export async function countActiveUsernames(
-  db: D1Database
+  db: D1Database,
+  afterId?: number | null
 ): Promise<number> {
+  if (afterId) {
+    const result = await db.prepare(
+      'SELECT COUNT(*) as count FROM usernames WHERE status = ? AND id > ?'
+    ).bind('active', afterId).first<{ count: number }>()
+    return result?.count ?? 0
+  }
   const result = await db.prepare(
     'SELECT COUNT(*) as count FROM usernames WHERE status = ?'
   ).bind('active').first<{ count: number }>()

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Database query helpers for usernames and reserved words
 // ABOUTME: Provides type-safe D1 database operations
 
+import type { SyncItem, UsernameKVData } from '../utils/fastly-sync'
+
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
 
 export interface Username {
@@ -55,6 +57,14 @@ export interface SearchResult {
     total: number
     total_pages: number
   }
+}
+
+export interface FastlySyncQueueTask extends SyncItem {
+  queued_at: number
+  updated_at: number
+  last_attempt_at: number | null
+  attempt_count: number
+  last_error: string | null
 }
 
 export async function isReservedWord(
@@ -171,6 +181,86 @@ export async function getUsernamesUpdatedSince(
   ).bind(sinceEpoch).all<Username>()
 
   return result.results
+}
+
+export async function enqueueFastlySyncTask(
+  db: D1Database,
+  item: SyncItem,
+  now = Math.floor(Date.now() / 1000)
+): Promise<void> {
+  const payloadJson = item.data ? JSON.stringify(item.data) : null
+
+  await db.prepare(
+    `INSERT INTO fastly_sync_queue (
+       username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error
+     ) VALUES (?, ?, ?, ?, ?, NULL, 0, NULL)
+     ON CONFLICT(username_canonical) DO UPDATE SET
+       action = excluded.action,
+       payload_json = excluded.payload_json,
+       queued_at = excluded.queued_at,
+       updated_at = excluded.updated_at,
+       last_attempt_at = NULL,
+       attempt_count = 0,
+       last_error = NULL`
+  ).bind(item.username, item.action, payloadJson, now, now).run()
+}
+
+export async function getQueuedFastlySyncTasks(
+  db: D1Database,
+  limit = 1000
+): Promise<FastlySyncQueueTask[]> {
+  const result = await db.prepare(
+    `SELECT username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error
+     FROM fastly_sync_queue
+     ORDER BY updated_at ASC
+     LIMIT ?`
+  ).bind(limit).all<{
+    username_canonical: string
+    action: 'sync' | 'delete'
+    payload_json: string | null
+    queued_at: number
+    updated_at: number
+    last_attempt_at: number | null
+    attempt_count: number
+    last_error: string | null
+  }>()
+
+  return result.results.map((row) => ({
+    username: row.username_canonical,
+    action: row.action,
+    data: row.payload_json ? JSON.parse(row.payload_json) as UsernameKVData : undefined,
+    queued_at: row.queued_at,
+    updated_at: row.updated_at,
+    last_attempt_at: row.last_attempt_at,
+    attempt_count: row.attempt_count,
+    last_error: row.last_error,
+  }))
+}
+
+export async function clearFastlySyncTasks(
+  db: D1Database,
+  usernames: string[]
+): Promise<void> {
+  if (usernames.length === 0) return
+
+  const placeholders = usernames.map(() => '?').join(', ')
+  await db.prepare(
+    `DELETE FROM fastly_sync_queue WHERE username_canonical IN (${placeholders})`
+  ).bind(...usernames).run()
+}
+
+export async function markFastlySyncTaskFailures(
+  db: D1Database,
+  failures: Array<{ username: string; error: string }>,
+  now = Math.floor(Date.now() / 1000)
+): Promise<void> {
+  for (const failure of failures) {
+    await db.prepare(
+      `UPDATE fastly_sync_queue
+       SET last_attempt_at = ?, attempt_count = attempt_count + 1, last_error = ?
+       WHERE username_canonical = ?`
+    ).bind(now, failure.error, failure.username).run()
+  }
 }
 
 export async function reserveUsername(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import admin from './routes/admin'
 // Auth routes are mounted inside admin.ts (same Hono app, exempt from auth middleware)
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
-import { getAllActiveUsernames, expireStaleReservations } from './db/queries'
-import { bulkSyncToFastly, parseRelayHints } from './utils/fastly-sync'
+import { getUsernamesUpdatedSince, expireStaleReservations } from './db/queries'
+import { syncBatch, parseRelayHints } from './utils/fastly-sync'
 
 type Bindings = {
   DB: D1Database
@@ -105,22 +105,25 @@ export default {
       console.log(`Cron: expired ${expired} stale pending-confirmation reservations`)
     }
 
-    // Hourly reconciliation: sync all active D1 users to Fastly KV
-    const activeUsers = await getAllActiveUsernames(env.DB)
-    const toSync = activeUsers
-      .filter(u => u.pubkey)
+    // Delta sync: only sync usernames updated in the last 2 hours (overlap for safety)
+    const twoHoursAgo = Math.floor(Date.now() / 1000) - (2 * 60 * 60)
+    const recentlyChanged = await getUsernamesUpdatedSince(env.DB, twoHoursAgo)
+
+    const items = recentlyChanged
+      .filter(u => (u.status === 'active' && u.pubkey) || u.status === 'revoked' || u.status === 'burned')
       .map(u => ({
         username: u.username_canonical || u.name,
-        data: {
+        action: (u.status === 'active' ? 'sync' : 'delete') as 'sync' | 'delete',
+        data: u.status === 'active' ? {
           pubkey: u.pubkey!,
           relays: parseRelayHints(u.relays),
           status: 'active' as const,
           atproto_did: u.atproto_did,
           atproto_state: u.atproto_state,
-        }
+        } : undefined,
       }))
 
-    const results = await bulkSyncToFastly(env, toSync)
-    console.log(`Cron sync: ${results.success} synced, ${results.failed} failed out of ${toSync.length} active users`)
+    const results = await syncBatch(env, items, { concurrency: 10 })
+    console.log(`Cron delta sync: ${recentlyChanged.length} changed, ${results.synced} synced, ${results.deleted} deleted, ${results.failed} failed`)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import admin from './routes/admin'
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
 import { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures } from './db/queries'
-import { syncBatch, parseRelayHints } from './utils/fastly-sync'
+import { syncBatch, parseRelayHints, type UsernameKVData } from './utils/fastly-sync'
 
 type Bindings = {
   DB: D1Database
@@ -114,13 +114,7 @@ export default {
     const itemsByUsername = new Map<string, {
       username: string
       action: 'sync' | 'delete'
-      data?: {
-        pubkey: string
-        relays: string[]
-        status: 'active'
-        atproto_did: string | null
-        atproto_state: 'pending' | 'ready' | 'failed' | 'disabled' | null
-      }
+      data?: UsernameKVData
     }>()
 
     for (const task of queuedTasks) {
@@ -149,12 +143,14 @@ export default {
     }
 
     const items = Array.from(itemsByUsername.values())
-    for (const item of items) {
-      await enqueueFastlySyncTask(env.DB, item)
-    }
-
     const results = await syncBatch(env, items, { concurrency: 10 })
     await clearFastlySyncTasks(env.DB, results.successes.map(result => result.username))
+    for (const failure of results.failures) {
+      const item = itemsByUsername.get(failure.username)
+      if (item) {
+        await enqueueFastlySyncTask(env.DB, item)
+      }
+    }
     await markFastlySyncTaskFailures(
       env.DB,
       results.failures.map(result => ({ username: result.username, error: result.error }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import admin from './routes/admin'
 // Auth routes are mounted inside admin.ts (same Hono app, exempt from auth middleware)
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
-import { getUsernamesUpdatedSince, expireStaleReservations } from './db/queries'
+import { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures } from './db/queries'
 import { syncBatch, parseRelayHints } from './utils/fastly-sync'
 
 type Bindings = {
@@ -105,25 +105,61 @@ export default {
       console.log(`Cron: expired ${expired} stale pending-confirmation reservations`)
     }
 
-    // Delta sync: only sync usernames updated in the last 2 hours (overlap for safety)
-    const twoHoursAgo = Math.floor(Date.now() / 1000) - (2 * 60 * 60)
-    const recentlyChanged = await getUsernamesUpdatedSince(env.DB, twoHoursAgo)
+    // Six-hour overlap covers delayed cron firings while the durable queue
+    // preserves retries for anything that still fails after bounded Fastly retries.
+    const sixHoursAgo = Math.floor(Date.now() / 1000) - (6 * 60 * 60)
+    const recentlyChanged = await getUsernamesUpdatedSince(env.DB, sixHoursAgo)
+    const queuedTasks = await getQueuedFastlySyncTasks(env.DB, 5000)
 
-    const items = recentlyChanged
-      .filter(u => (u.status === 'active' && u.pubkey) || u.status === 'revoked' || u.status === 'burned')
-      .map(u => ({
-        username: u.username_canonical || u.name,
-        action: (u.status === 'active' ? 'sync' : 'delete') as 'sync' | 'delete',
-        data: u.status === 'active' ? {
-          pubkey: u.pubkey!,
-          relays: parseRelayHints(u.relays),
-          status: 'active' as const,
-          atproto_did: u.atproto_did,
-          atproto_state: u.atproto_state,
-        } : undefined,
-      }))
+    const itemsByUsername = new Map<string, {
+      username: string
+      action: 'sync' | 'delete'
+      data?: {
+        pubkey: string
+        relays: string[]
+        status: 'active'
+        atproto_did: string | null
+        atproto_state: 'pending' | 'ready' | 'failed' | 'disabled' | null
+      }
+    }>()
+
+    for (const task of queuedTasks) {
+      itemsByUsername.set(task.username, task)
+    }
+
+    for (const user of recentlyChanged) {
+      if (user.status === 'active' && user.pubkey) {
+        itemsByUsername.set(user.username_canonical || user.name, {
+          username: user.username_canonical || user.name,
+          action: 'sync',
+          data: {
+            pubkey: user.pubkey,
+            relays: parseRelayHints(user.relays),
+            status: 'active',
+            atproto_did: user.atproto_did,
+            atproto_state: user.atproto_state,
+          },
+        })
+      } else if (user.status === 'revoked' || user.status === 'burned') {
+        itemsByUsername.set(user.username_canonical || user.name, {
+          username: user.username_canonical || user.name,
+          action: 'delete',
+        })
+      }
+    }
+
+    const items = Array.from(itemsByUsername.values())
+    for (const item of items) {
+      await enqueueFastlySyncTask(env.DB, item)
+    }
 
     const results = await syncBatch(env, items, { concurrency: 10 })
-    console.log(`Cron delta sync: ${recentlyChanged.length} changed, ${results.synced} synced, ${results.deleted} deleted, ${results.failed} failed`)
+    await clearFastlySyncTasks(env.DB, results.successes.map(result => result.username))
+    await markFastlySyncTaskFailures(
+      env.DB,
+      results.failures.map(result => ({ username: result.username, error: result.error }))
+    )
+
+    console.log(`Cron Fastly reconciliation: ${recentlyChanged.length} recent changes, ${queuedTasks.length} queued, ${results.synced} synced, ${results.deleted} deleted, ${results.failed} failed`)
   }
 }

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+const { getActiveUsernamesPaginated, countActiveUsernames, syncBatch } = vi.hoisted(() => ({
+  getActiveUsernamesPaginated: vi.fn(),
+  countActiveUsernames: vi.fn(),
+  syncBatch: vi.fn(),
+}))
+
+vi.mock('../db/queries', async () => {
+  const actual = await vi.importActual<typeof import('../db/queries')>('../db/queries')
+  return { ...actual, getActiveUsernamesPaginated, countActiveUsernames }
+})
+
+vi.mock('../utils/fastly-sync', async () => {
+  const actual = await vi.importActual<typeof import('../utils/fastly-sync')>('../utils/fastly-sync')
+  return { ...actual, syncBatch }
+})
+
+vi.mock('../utils/email', () => ({
+  sendAssignmentNotificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendReservationConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+}))
+
+import admin from './admin'
+
+function createTestApp() {
+  const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string; FASTLY_API_TOKEN?: string; FASTLY_STORE_ID?: string } }>()
+  app.route('/admin', admin)
+  return app
+}
+
+const ctx = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as unknown as ExecutionContext
+
+const baseEnv = {
+  DB: {} as D1Database,
+  BYPASS_LOCAL_AUTH: 'true',
+  FASTLY_API_TOKEN: 'test-token',
+  FASTLY_STORE_ID: 'test-store',
+}
+
+const activeUsers = [
+  { id: 1, name: 'alice', username_canonical: 'alice', pubkey: 'pk1', relays: '["wss://r.damus.io"]', status: 'active', atproto_did: null, atproto_state: null },
+  { id: 2, name: 'bob', username_canonical: 'bob', pubkey: 'pk2', relays: null, status: 'active', atproto_did: 'did:plc:bob', atproto_state: 'ready' },
+  { id: 3, name: 'nopubkey', username_canonical: 'nopubkey', pubkey: null, relays: null, status: 'active', atproto_did: null, atproto_state: null },
+]
+
+describe('POST /admin/sync/fastly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    syncBatch.mockResolvedValue({ synced: 2, deleted: 0, failed: 0, errors: [] })
+    getActiveUsernamesPaginated.mockResolvedValue(activeUsers)
+    countActiveUsernames.mockResolvedValue(100)
+  })
+
+  it('returns 400 when Fastly config is missing', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    const res = await app.fetch(req, { ...baseEnv, FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }, ctx)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('Fastly')
+  })
+
+  it('syncs first page with default limit', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    const res = await app.fetch(req, baseEnv, ctx)
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.synced).toBe(2)
+    expect(getActiveUsernamesPaginated).toHaveBeenCalledWith(expect.anything(), null, 500)
+    expect(syncBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ username: 'alice', action: 'sync' }),
+        expect.objectContaining({ username: 'bob', action: 'sync' }),
+      ]),
+      { concurrency: 10 }
+    )
+  })
+
+  it('filters out active users without pubkeys', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    await app.fetch(req, baseEnv, ctx)
+
+    const syncItems = syncBatch.mock.calls[0][1]
+    expect(syncItems).toHaveLength(2)
+    expect(syncItems.find((i: any) => i.username === 'nopubkey')).toBeUndefined()
+  })
+
+  it('passes cursor to paginated query', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cursor: '42', limit: 100 }),
+    })
+    await app.fetch(req, baseEnv, ctx)
+
+    expect(getActiveUsernamesPaginated).toHaveBeenCalledWith(expect.anything(), 42, 100)
+  })
+
+  it('returns next cursor when page is full', async () => {
+    getActiveUsernamesPaginated.mockResolvedValue([
+      { id: 10, name: 'u1', username_canonical: 'u1', pubkey: 'pk1', relays: null, status: 'active', atproto_did: null, atproto_state: null },
+      { id: 11, name: 'u2', username_canonical: 'u2', pubkey: 'pk2', relays: null, status: 'active', atproto_did: null, atproto_state: null },
+    ])
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 2 }),
+    })
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+    expect(json.cursor).toBe('11')
+  })
+
+  it('returns null cursor on last page', async () => {
+    getActiveUsernamesPaginated.mockResolvedValue([
+      { id: 99, name: 'last', username_canonical: 'last', pubkey: 'pk99', relays: null, status: 'active', atproto_did: null, atproto_state: null },
+    ])
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 500 }),
+    })
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+    expect(json.cursor).toBeNull()
+  })
+
+  it('dry run returns counts without calling syncBatch', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dry_run: true }),
+    })
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.dry_run).toBe(true)
+    expect(json.syncable).toBe(2)
+    expect(json.skipped).toBe(1)
+    expect(syncBatch).not.toHaveBeenCalled()
+  })
+
+  it('clamps limit to 1000 max', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ limit: 5000 }),
+    })
+    await app.fetch(req, baseEnv, ctx)
+    expect(getActiveUsernamesPaginated).toHaveBeenCalledWith(expect.anything(), null, 1000)
+  })
+
+  it('returns 400 for invalid cursor', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cursor: 'notanumber' }),
+    })
+    const res = await app.fetch(req, baseEnv, ctx)
+    expect(res.status).toBe(400)
+    const json = await res.json() as any
+    expect(json.error).toContain('cursor')
+  })
+
+  it('includes atproto fields in sync data', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    await app.fetch(req, baseEnv, ctx)
+
+    const syncItems = syncBatch.mock.calls[0][1]
+    const bob = syncItems.find((i: any) => i.username === 'bob')
+    expect(bob.data.atproto_did).toBe('did:plc:bob')
+    expect(bob.data.atproto_state).toBe('ready')
+  })
+})

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 
-const { getActiveUsernamesPaginated, countActiveUsernames, syncBatch } = vi.hoisted(() => ({
+const { getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, syncBatch, readUsernameFromFastly, syncAndVerifyUsername, deleteUsernameFromFastly } = vi.hoisted(() => ({
   getActiveUsernamesPaginated: vi.fn(),
   countActiveUsernames: vi.fn(),
+  getUsernameByName: vi.fn(),
   syncBatch: vi.fn(),
+  readUsernameFromFastly: vi.fn(),
+  syncAndVerifyUsername: vi.fn(),
+  deleteUsernameFromFastly: vi.fn(),
 }))
 
 vi.mock('../db/queries', async () => {
   const actual = await vi.importActual<typeof import('../db/queries')>('../db/queries')
-  return { ...actual, getActiveUsernamesPaginated, countActiveUsernames }
+  return { ...actual, getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName }
 })
 
 vi.mock('../utils/fastly-sync', async () => {
   const actual = await vi.importActual<typeof import('../utils/fastly-sync')>('../utils/fastly-sync')
-  return { ...actual, syncBatch }
+  return { ...actual, syncBatch, readUsernameFromFastly, syncAndVerifyUsername, deleteUsernameFromFastly }
 })
 
 vi.mock('../utils/email', () => ({
@@ -201,5 +205,149 @@ describe('POST /admin/sync/fastly', () => {
     const bob = syncItems.find((i: any) => i.username === 'bob')
     expect(bob.data.atproto_did).toBe('did:plc:bob')
     expect(bob.data.atproto_state).toBe('ready')
+  })
+})
+
+describe('GET /admin/username/:name/nip05-status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns synced when Fastly matches DB', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'active', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: { pubkey: 'pk1', status: 'active', relays: [] } })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.ok).toBe(true)
+    expect(json.status).toBe('synced')
+  })
+
+  it('returns mismatch when pubkey differs', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'active', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: { pubkey: 'wrong', status: 'active', relays: [] } })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.status).toBe('mismatch')
+    expect(json.fastly.pubkey).toBe('wrong')
+    expect(json.db.pubkey).toBe('pk1')
+  })
+
+  it('returns missing when key not in Fastly', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'active', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: undefined })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.status).toBe('missing')
+  })
+
+  it('returns not_applicable for non-active usernames', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'revoked', relays: null })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.status).toBe('not_applicable')
+    expect(readUsernameFromFastly).not.toHaveBeenCalled()
+  })
+
+  it('returns not_applicable for active usernames without pubkey', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: null, status: 'active', relays: null })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.status).toBe('not_applicable')
+  })
+
+  it('returns 404 for unknown username', async () => {
+    getUsernameByName.mockResolvedValue(null)
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/unknown/nip05-status')
+    const res = await app.fetch(req, baseEnv, ctx)
+
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /admin/username/:name/sync-to-fastly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('syncs active username and returns verified result', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'active', relays: '["wss://r.damus.io"]', atproto_did: null, atproto_state: null })
+    syncAndVerifyUsername.mockResolvedValue({ success: true, verified: true })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/sync-to-fastly', { method: 'POST' })
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.ok).toBe(true)
+    expect(json.action).toBe('synced')
+    expect(json.verified).toBe(true)
+    expect(syncAndVerifyUsername).toHaveBeenCalledWith(
+      expect.anything(),
+      'alice',
+      expect.objectContaining({ pubkey: 'pk1', status: 'active' })
+    )
+  })
+
+  it('deletes burned username from Fastly', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'burned' })
+    deleteUsernameFromFastly.mockResolvedValue({ success: true })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/sync-to-fastly', { method: 'POST' })
+    const res = await app.fetch(req, baseEnv, ctx)
+    const json = await res.json() as any
+
+    expect(json.action).toBe('deleted')
+    expect(deleteUsernameFromFastly).toHaveBeenCalledWith(expect.anything(), 'alice')
+  })
+
+  it('returns 400 for reserved username without pubkey', async () => {
+    getUsernameByName.mockResolvedValue({ name: 'reserved1', pubkey: null, status: 'reserved' })
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/reserved1/sync-to-fastly', { method: 'POST' })
+    const res = await app.fetch(req, baseEnv, ctx)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for unknown username', async () => {
+    getUsernameByName.mockResolvedValue(null)
+
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/unknown/sync-to-fastly', { method: 'POST' })
+    const res = await app.fetch(req, baseEnv, ctx)
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 when Fastly config is missing', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/admin/username/alice/sync-to-fastly', { method: 'POST' })
+    const res = await app.fetch(req, { ...baseEnv, FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }, ctx)
+
+    expect(res.status).toBe(400)
   })
 })

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 
-const { getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, syncBatch, readUsernameFromFastly, syncAndVerifyUsername, deleteUsernameFromFastly } = vi.hoisted(() => ({
+const { getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, syncBatch, readUsernameFromFastly, syncAndVerifyUsername, deleteUsernameFromFastly } = vi.hoisted(() => ({
   getActiveUsernamesPaginated: vi.fn(),
   countActiveUsernames: vi.fn(),
   getUsernameByName: vi.fn(),
+  enqueueFastlySyncTask: vi.fn(),
+  clearFastlySyncTasks: vi.fn(),
+  markFastlySyncTaskFailures: vi.fn(),
   syncBatch: vi.fn(),
   readUsernameFromFastly: vi.fn(),
   syncAndVerifyUsername: vi.fn(),
@@ -13,7 +16,7 @@ const { getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, sy
 
 vi.mock('../db/queries', async () => {
   const actual = await vi.importActual<typeof import('../db/queries')>('../db/queries')
-  return { ...actual, getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName }
+  return { ...actual, getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures }
 })
 
 vi.mock('../utils/fastly-sync', async () => {
@@ -52,7 +55,7 @@ const activeUsers = [
 describe('POST /admin/sync/fastly', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    syncBatch.mockResolvedValue({ synced: 2, deleted: 0, failed: 0, errors: [] })
+    syncBatch.mockResolvedValue({ synced: 2, deleted: 0, failed: 0, errors: [], successes: [], failures: [] })
     getActiveUsernamesPaginated.mockResolvedValue(activeUsers)
     countActiveUsernames.mockResolvedValue(100)
   })
@@ -163,6 +166,7 @@ describe('POST /admin/sync/fastly', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(true)
     expect(json.dry_run).toBe(true)
+    expect(json.total_active).toBe(100)
     expect(json.syncable).toBe(2)
     expect(json.skipped).toBe(1)
     expect(syncBatch).not.toHaveBeenCalled()

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for admin endpoints
 // ABOUTME: Validates search endpoint input validation, error handling, and hostname auth guard
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import admin from './admin'
 import { getUsernameByName } from '../db/queries'
@@ -11,6 +11,13 @@ vi.mock('../utils/email', () => ({
   sendAssignmentNotificationEmail: vi.fn().mockResolvedValue(undefined),
   sendReservationConfirmationEmail: vi.fn().mockResolvedValue(undefined)
 }))
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
 
 import { createFakeD1 } from '../db/test-helpers'
 
@@ -1109,5 +1116,157 @@ describe('Admin Export Endpoint', () => {
     const csv = await res.text()
     expect(csv).toContain('pending-confirmation')
     expect(csv).toContain('pendinguser')
+  })
+})
+
+describe('Fastly sync endpoints', () => {
+  function createSyncTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database; FASTLY_API_TOKEN?: string; FASTLY_STORE_ID?: string; BYPASS_LOCAL_AUTH?: string } }>()
+    app.route('/admin', admin)
+    return app
+  }
+
+  it('POST /admin/sync/fastly dry run should include remaining count', async () => {
+    const app = createSyncTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'alice', username_display: 'alice', username_canonical: 'alice',
+        pubkey: 'pk1', email: 'alice@example.com', relays: null, status: 'active',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+        revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+      {
+        id: 2, name: 'bob', username_display: 'bob', username_canonical: 'bob',
+        pubkey: 'pk2', email: 'bob@example.com', relays: null, status: 'active',
+        recyclable: 0, created_at: 1700000010, updated_at: 1700000010, claimed_at: 1700000010,
+        revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    const req = new Request('http://localhost/admin/sync/fastly', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dry_run: true, limit: 10 }),
+    })
+    const res = await app.fetch(
+      req,
+      {
+        DB: db,
+        FASTLY_API_TOKEN: 'test-token',
+        FASTLY_STORE_ID: 'test-store',
+        BYPASS_LOCAL_AUTH: 'true',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.dry_run).toBe(true)
+    expect(json.remaining).toBe(0)
+    expect(json.syncable).toBe(2)
+    expect(json.skipped).toBe(0)
+  })
+
+  it('POST /admin/username/:name/sync-to-fastly should delete revoked usernames in Fastly', async () => {
+    const app = createSyncTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'revoked-user', username_display: 'revoked-user', username_canonical: 'revoked-user',
+        pubkey: 'pk1', email: 'revoked@example.com', relays: JSON.stringify(['wss://relay.divine.video']), status: 'revoked',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+        revoked_at: 1700000100, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => '' })
+
+    const req = new Request('http://localhost/admin/username/revoked-user/sync-to-fastly', {
+      method: 'POST',
+    })
+    const res = await app.fetch(
+      req,
+      {
+        DB: db,
+        FASTLY_API_TOKEN: 'test-token',
+        FASTLY_STORE_ID: 'test-store',
+        BYPASS_LOCAL_AUTH: 'true',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.action).toBe('deleted')
+    expect(json.success).toBe(true)
+  })
+
+  it('GET /admin/username/:name/nip05-status should report missing for revoked user with no Fastly key', async () => {
+    const app = createSyncTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'revoked-user', username_display: 'revoked-user', username_canonical: 'revoked-user',
+        pubkey: 'pk1', email: 'revoked@example.com', relays: null, status: 'revoked',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+        revoked_at: 1700000100, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    mockFetch.mockResolvedValue({ ok: false, status: 404, text: async () => 'not found' })
+
+    const req = new Request('http://localhost/admin/username/revoked-user/nip05-status')
+    const res = await app.fetch(
+      req,
+      {
+        DB: db,
+        FASTLY_API_TOKEN: 'test-token',
+        FASTLY_STORE_ID: 'test-store',
+        BYPASS_LOCAL_AUTH: 'true',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.status).toBe('missing')
+  })
+
+  it('GET /admin/username/:name/nip05-status should report mismatch when revoked user still exists in Fastly', async () => {
+    const app = createSyncTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'revoked-user', username_display: 'revoked-user', username_canonical: 'revoked-user',
+        pubkey: 'pk1', email: 'revoked@example.com', relays: null, status: 'revoked',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+        revoked_at: 1700000100, reserved_reason: null, admin_notes: null,
+      },
+    ])
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ pubkey: 'pk1', relays: [], status: 'active', atproto_state: null, atproto_did: null }),
+      text: async () => '',
+    })
+
+    const req = new Request('http://localhost/admin/username/revoked-user/nip05-status')
+    const res = await app.fetch(
+      req,
+      {
+        DB: db,
+        FASTLY_API_TOKEN: 'test-token',
+        FASTLY_STORE_ID: 'test-store',
+        BYPASS_LOCAL_AUTH: 'true',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.status).toBe('mismatch')
+    expect(json.reason).toContain('still present')
   })
 })

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,9 +5,9 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getAllActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
-import { syncUsernameToFastly, deleteUsernameFromFastly, bulkSyncToFastly } from '../utils/fastly-sync'
+import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
@@ -657,40 +657,63 @@ admin.get('/export/csv', async (c) => {
   }
 })
 
-// Full sync: push all active D1 users to Fastly KV (additive only, never deletes)
+// Paginated sync: push active D1 users to Fastly KV one page at a time
 admin.post('/sync/fastly', async (c) => {
   try {
     if (!c.env.FASTLY_API_TOKEN || !c.env.FASTLY_STORE_ID) {
       return c.json({ ok: false, error: 'Fastly credentials not configured' }, 400)
     }
 
-    const activeUsers = await getAllActiveUsernames(c.env.DB)
+    const body: { limit?: number; cursor?: string | null; dry_run?: boolean } = await c.req.json().catch(() => ({}))
+    const limit = Math.min(Math.max(body.limit ?? 500, 1), 1000)
+    const cursor = body.cursor ? parseInt(body.cursor, 10) : null
+    const dryRun = body.dry_run ?? false
 
-    if (activeUsers.length === 0) {
-      return c.json({ ok: true, message: 'No active users to sync', synced: 0 })
+    if (body.cursor && (isNaN(cursor!) || cursor! < 0)) {
+      return c.json({ ok: false, error: 'Invalid cursor' }, 400)
     }
 
-    const toSync = activeUsers
-      .filter(u => u.pubkey) // Only sync users that have a pubkey
-      .map(u => ({
-        username: u.username_canonical || u.name,
-        data: {
-          pubkey: u.pubkey!,
-          relays: u.relays ? (() => { try { return JSON.parse(u.relays!) } catch { return [] } })() : [],
-          status: 'active' as const,
-          atproto_did: u.atproto_did || null,
-          atproto_state: u.atproto_state || null,
-        }
-      }))
+    const page = await getActiveUsernamesPaginated(c.env.DB, cursor, limit)
+    const totalActive = await countActiveUsernames(c.env.DB)
 
-    const results = await bulkSyncToFastly(c.env, toSync)
+    const syncable = page.filter(u => u.pubkey)
+    const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
+    const processed = cursor ? totalActive - page.length : totalActive
+    const remaining = nextCursor ? Math.max(0, totalActive - (cursor ?? 0) - page.length) : 0
+
+    if (dryRun) {
+      return c.json({
+        ok: true,
+        dry_run: true,
+        page_size: page.length,
+        syncable: syncable.length,
+        skipped: page.length - syncable.length,
+        cursor: nextCursor,
+        remaining,
+      })
+    }
+
+    const items = syncable.map(u => ({
+      username: u.username_canonical || u.name,
+      action: 'sync' as const,
+      data: {
+        pubkey: u.pubkey!,
+        relays: parseRelayHints(u.relays),
+        status: 'active' as const,
+        atproto_did: u.atproto_did || null,
+        atproto_state: u.atproto_state || null,
+      },
+    }))
+
+    const results = await syncBatch(c.env, items, { concurrency: 10 })
 
     return c.json({
       ok: true,
-      total_active: activeUsers.length,
-      synced: results.success,
+      synced: results.synced,
       failed: results.failed,
-      errors: results.errors.length > 0 ? results.errors.slice(0, 20) : undefined
+      cursor: nextCursor,
+      remaining,
+      errors: results.errors.length > 0 ? results.errors.slice(0, 20) : undefined,
     })
   } catch (error) {
     console.error('Fastly sync error:', error)

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -7,7 +7,7 @@ import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
 import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
-import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints } from '../utils/fastly-sync'
+import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
@@ -412,14 +412,14 @@ admin.post('/username/revoke', async (c) => {
 
     await revokeUsername(c.env.DB, usernameData.canonical, burn)
 
-    // Sync to Fastly - mark as revoked/burned or delete
+    // Sync to Fastly with verification (delete if burned, update status if revoked)
     c.executionCtx.waitUntil(
       burn
         ? deleteUsernameFromFastly(c.env, usernameData.canonical)
-        : syncUsernameToFastly(c.env, usernameData.canonical, {
+        : syncAndVerifyUsername(c.env, usernameData.canonical, {
             pubkey: existing.pubkey || '',
             relays: [],
-            status: burn ? 'burned' : 'revoked',
+            status: 'revoked',
             atproto_did: null,
             atproto_state: null,
           })
@@ -480,9 +480,9 @@ admin.post('/username/assign', async (c) => {
     const createdBy = (c.get('adminEmail' as never) as string) || null
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
 
-    // Sync to Fastly KV for edge routing
+    // Sync to Fastly KV with read-back verification
     c.executionCtx.waitUntil(
-      syncUsernameToFastly(c.env, usernameData.canonical, {
+      syncAndVerifyUsername(c.env, usernameData.canonical, {
         pubkey: normalizedPubkey,
         relays: [],
         status: 'active',
@@ -563,7 +563,7 @@ admin.post('/username/assign-bulk', async (c) => {
 
         await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'bulk-upload', createdBy)
 
-        // Sync to Fastly (fire and forget)
+        // Sync to Fastly — no read-back verification on bulk to avoid doubling API calls
         c.executionCtx.waitUntil(
           syncUsernameToFastly(c.env, usernameData.canonical, {
             pubkey: normalizedPubkey,
@@ -811,11 +811,11 @@ admin.post('/username/set-atproto', async (c) => {
       `UPDATE usernames SET atproto_did = ?, atproto_state = ?, updated_at = ? WHERE username_canonical = ? OR name = ?`
     ).bind(atproto_did || null, atproto_state || null, now, canonical, name).run()
 
-    // Sync to Fastly KV
+    // Sync to Fastly KV with verification
     if (existing.status === 'active' && existing.pubkey) {
-      const relays = existing.relays ? (() => { try { return JSON.parse(existing.relays!) } catch { return [] } })() : []
+      const relays = parseRelayHints(existing.relays)
       c.executionCtx.waitUntil(
-        syncUsernameToFastly(c.env, canonical, {
+        syncAndVerifyUsername(c.env, canonical, {
           pubkey: existing.pubkey,
           relays,
           status: 'active',
@@ -833,6 +833,123 @@ admin.post('/username/set-atproto', async (c) => {
     })
   } catch (error) {
     console.error('Set ATProto error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+// --- NIP-05 / Fastly KV Status ---
+
+admin.get('/username/:name/nip05-status', async (c) => {
+  try {
+    const name = c.req.param('name')
+    if (!name) {
+      return c.json({ ok: false, error: 'Name parameter is required' }, 400)
+    }
+
+    const canonical = name.toLowerCase()
+    const existing = await getUsernameByName(c.env.DB, canonical)
+    if (!existing) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    if (existing.status !== 'active' || !existing.pubkey) {
+      return c.json({
+        ok: true,
+        status: 'not_applicable',
+        reason: existing.status !== 'active'
+          ? `Username status is ${existing.status}`
+          : 'No pubkey assigned',
+      })
+    }
+
+    if (!c.env.FASTLY_API_TOKEN || !c.env.FASTLY_STORE_ID) {
+      return c.json({ ok: true, status: 'error', detail: 'Fastly credentials not configured' })
+    }
+
+    const fastly = await readUsernameFromFastly(c.env, canonical)
+    if (!fastly.success) {
+      return c.json({ ok: true, status: 'error', detail: fastly.error })
+    }
+
+    if (!fastly.data) {
+      return c.json({ ok: true, status: 'missing' })
+    }
+
+    // Only compare pubkey + status — these drive NIP-05 resolution correctness
+    const pubkeyMatch = fastly.data.pubkey === existing.pubkey
+    const statusMatch = fastly.data.status === existing.status
+
+    if (pubkeyMatch && statusMatch) {
+      return c.json({ ok: true, status: 'synced', fastly: fastly.data })
+    }
+
+    return c.json({
+      ok: true,
+      status: 'mismatch',
+      fastly: fastly.data,
+      db: { pubkey: existing.pubkey, status: existing.status },
+    })
+  } catch (error) {
+    console.error('NIP-05 status error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.post('/username/:name/sync-to-fastly', async (c) => {
+  try {
+    const name = c.req.param('name')
+    if (!name) {
+      return c.json({ ok: false, error: 'Name parameter is required' }, 400)
+    }
+
+    if (!c.env.FASTLY_API_TOKEN || !c.env.FASTLY_STORE_ID) {
+      return c.json({ ok: false, error: 'Fastly credentials not configured' }, 400)
+    }
+
+    const canonical = name.toLowerCase()
+    const existing = await getUsernameByName(c.env.DB, canonical)
+    if (!existing) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    if (existing.status === 'burned') {
+      const deleteResult = await deleteUsernameFromFastly(c.env, canonical)
+      return c.json({
+        ok: true,
+        action: 'deleted',
+        success: deleteResult.success,
+        verified: deleteResult.success,
+        error: deleteResult.error,
+      })
+    }
+
+    if (existing.status !== 'active' || !existing.pubkey) {
+      return c.json({
+        ok: false,
+        error: existing.status !== 'active'
+          ? `Cannot sync: username status is ${existing.status}`
+          : 'Cannot sync: no pubkey assigned',
+      }, 400)
+    }
+
+    const relays = parseRelayHints(existing.relays)
+    const result = await syncAndVerifyUsername(c.env, canonical, {
+      pubkey: existing.pubkey,
+      relays,
+      status: 'active',
+      atproto_did: existing.atproto_did || null,
+      atproto_state: existing.atproto_state || null,
+    })
+
+    return c.json({
+      ok: true,
+      action: 'synced',
+      success: result.success,
+      verified: result.verified,
+      error: result.error,
+    })
+  } catch (error) {
+    console.error('Single username Fastly sync error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -757,6 +757,7 @@ admin.post('/sync/fastly', async (c) => {
 
     const syncable = page.filter(u => u.pubkey)
     const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
+    const remaining = nextCursor ? await countActiveUsernames(c.env.DB, Number(nextCursor)) : 0
 
     if (dryRun) {
       const totalActive = await countActiveUsernames(c.env.DB)
@@ -767,6 +768,7 @@ admin.post('/sync/fastly', async (c) => {
         page_size: page.length,
         syncable: syncable.length,
         skipped: page.length - syncable.length,
+        remaining,
         cursor: nextCursor,
       })
     }
@@ -802,6 +804,7 @@ admin.post('/sync/fastly', async (c) => {
       synced: results.synced,
       deleted: results.deleted,
       failed: results.failed,
+      remaining,
       cursor: nextCursor,
       errors: results.errors.length > 0 ? results.errors.slice(0, 20) : undefined,
     })
@@ -954,13 +957,19 @@ admin.get('/username/:name/nip05-status', async (c) => {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
 
-    if (existing.status !== 'active' || !existing.pubkey) {
+    if (existing.status === 'active' && !existing.pubkey) {
       return c.json({
         ok: true,
         status: 'not_applicable',
-        reason: existing.status !== 'active'
-          ? `Username status is ${existing.status}`
-          : 'No pubkey assigned',
+        reason: 'No pubkey assigned',
+      })
+    }
+
+    if (!['active', 'revoked', 'burned'].includes(existing.status)) {
+      return c.json({
+        ok: true,
+        status: 'not_applicable',
+        reason: `Username status is ${existing.status}`,
       })
     }
 
@@ -971,6 +980,26 @@ admin.get('/username/:name/nip05-status', async (c) => {
     const fastly = await readUsernameFromFastly(c.env, canonical)
     if (!fastly.success) {
       return c.json({ ok: true, status: 'error', detail: fastly.error })
+    }
+
+    if (existing.status === 'revoked' || existing.status === 'burned') {
+      if (!fastly.data) {
+        return c.json({ ok: true, status: 'missing' })
+      }
+
+      return c.json({
+        ok: true,
+        status: 'mismatch',
+        reason: `Username is ${existing.status} and still present in Fastly`,
+        db: {
+          pubkey: existing.pubkey || '',
+          relays: parseRelayHints(existing.relays),
+          status: existing.status,
+          atproto_did: existing.atproto_did || null,
+          atproto_state: existing.atproto_state || null,
+        },
+        fastly: fastly.data,
+      })
     }
 
     if (!fastly.data) {
@@ -1018,7 +1047,7 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
 
-    if (existing.status === 'burned') {
+    if (existing.status === 'burned' || existing.status === 'revoked') {
       const deleteResult = await deleteUsernameFromFastly(c.env, canonical)
       if (!deleteResult.success) {
         await enqueueFastlySyncTask(c.env.DB, {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -674,17 +674,18 @@ admin.post('/sync/fastly', async (c) => {
     }
 
     const page = await getActiveUsernamesPaginated(c.env.DB, cursor, limit)
-    const totalActive = await countActiveUsernames(c.env.DB)
 
     const syncable = page.filter(u => u.pubkey)
     const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
-    const processed = cursor ? totalActive - page.length : totalActive
-    const remaining = nextCursor ? Math.max(0, totalActive - (cursor ?? 0) - page.length) : 0
+    const lastId = page.length > 0 ? page[page.length - 1].id : cursor
+    const remaining = nextCursor ? await countActiveUsernames(c.env.DB, lastId) : 0
 
     if (dryRun) {
+      const totalActive = await countActiveUsernames(c.env.DB)
       return c.json({
         ok: true,
         dry_run: true,
+        total: totalActive,
         page_size: page.length,
         syncable: syncable.length,
         skipped: page.length - syncable.length,
@@ -710,6 +711,7 @@ admin.post('/sync/fastly', async (c) => {
     return c.json({
       ok: true,
       synced: results.synced,
+      deleted: results.deleted,
       failed: results.failed,
       cursor: nextCursor,
       remaining,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -466,14 +466,16 @@ admin.post('/username/revoke', async (c) => {
 
     await revokeUsername(c.env.DB, usernameData.canonical, burn)
 
-    await enqueueFastlySyncTask(c.env.DB, {
-      username: usernameData.canonical,
-      action: 'delete',
-    })
-
     // Delete from Fastly so revoked/burned usernames stop resolving at the edge.
     c.executionCtx.waitUntil(
-      deleteUsernameFromFastly(c.env, usernameData.canonical)
+      deleteUsernameFromFastly(c.env, usernameData.canonical).then(async (result) => {
+        if (!result.success) {
+          await enqueueFastlySyncTask(c.env.DB, {
+            username: usernameData.canonical,
+            action: 'delete',
+          })
+        }
+      })
     )
 
     return c.json({
@@ -530,17 +532,6 @@ admin.post('/username/assign', async (c) => {
 
     const createdBy = (c.get('adminEmail' as never) as string) || null
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
-    await enqueueFastlySyncTask(c.env.DB, {
-      username: usernameData.canonical,
-      action: 'sync',
-      data: {
-        pubkey: normalizedPubkey,
-        relays: [],
-        status: 'active',
-        atproto_did: null,
-        atproto_state: null,
-      },
-    })
 
     // Sync to Fastly KV with read-back verification
     c.executionCtx.waitUntil(
@@ -550,6 +541,20 @@ admin.post('/username/assign', async (c) => {
         status: 'active',
         atproto_did: null,
         atproto_state: null,
+      }).then(async (result) => {
+        if (!result.success || !result.verified) {
+          await enqueueFastlySyncTask(c.env.DB, {
+            username: usernameData.canonical,
+            action: 'sync',
+            data: {
+              pubkey: normalizedPubkey,
+              relays: [],
+              status: 'active',
+              atproto_did: null,
+              atproto_state: null,
+            },
+          })
+        }
       })
     )
 
@@ -624,17 +629,6 @@ admin.post('/username/assign-bulk', async (c) => {
         }
 
         await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'bulk-upload', createdBy)
-        await enqueueFastlySyncTask(c.env.DB, {
-          username: usernameData.canonical,
-          action: 'sync',
-          data: {
-            pubkey: normalizedPubkey,
-            relays: [],
-            status: 'active',
-            atproto_did: null,
-            atproto_state: null,
-          },
-        })
 
         // Sync to Fastly — no read-back verification on bulk to avoid doubling API calls
         c.executionCtx.waitUntil(
@@ -644,6 +638,20 @@ admin.post('/username/assign-bulk', async (c) => {
             status: 'active',
             atproto_did: null,
             atproto_state: null,
+          }).then(async (result) => {
+            if (!result.success) {
+              await enqueueFastlySyncTask(c.env.DB, {
+                username: usernameData.canonical,
+                action: 'sync',
+                data: {
+                  pubkey: normalizedPubkey,
+                  relays: [],
+                  status: 'active',
+                  atproto_did: null,
+                  atproto_state: null,
+                },
+              })
+            }
           })
         )
 
@@ -745,8 +753,7 @@ admin.post('/sync/fastly', async (c) => {
       return c.json({ ok: false, error: 'Invalid cursor' }, 400)
     }
 
-    const cursor = parsedCursor
-    const page = await getActiveUsernamesPaginated(c.env.DB, cursor, limit)
+    const page = await getActiveUsernamesPaginated(c.env.DB, parsedCursor, limit)
 
     const syncable = page.filter(u => u.pubkey)
     const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
@@ -776,12 +783,15 @@ admin.post('/sync/fastly', async (c) => {
       },
     }))
 
-    for (const item of items) {
-      await enqueueFastlySyncTask(c.env.DB, item)
-    }
-
     const results = await syncBatch(c.env, items, { concurrency: 10 })
     await clearFastlySyncTasks(c.env.DB, results.successes.map(result => result.username))
+    const itemsByUsername = new Map(items.map((item) => [item.username, item]))
+    for (const failure of results.failures) {
+      const item = itemsByUsername.get(failure.username)
+      if (item) {
+        await enqueueFastlySyncTask(c.env.DB, item)
+      }
+    }
     await markFastlySyncTaskFailures(
       c.env.DB,
       results.failures.map(result => ({ username: result.username, error: result.error }))
@@ -892,17 +902,6 @@ admin.post('/username/set-atproto', async (c) => {
     // Sync to Fastly KV with verification
     if (existing.status === 'active' && existing.pubkey) {
       const relays = parseRelayHints(existing.relays)
-      await enqueueFastlySyncTask(c.env.DB, {
-        username: canonical,
-        action: 'sync',
-        data: {
-          pubkey: existing.pubkey,
-          relays,
-          status: 'active',
-          atproto_did: atproto_did || null,
-          atproto_state: atproto_state || null,
-        },
-      })
       c.executionCtx.waitUntil(
         syncAndVerifyUsername(c.env, canonical, {
           pubkey: existing.pubkey,
@@ -910,6 +909,20 @@ admin.post('/username/set-atproto', async (c) => {
           status: 'active',
           atproto_did: atproto_did || null,
           atproto_state: atproto_state || null,
+        }).then(async (result) => {
+          if (!result.success || !result.verified) {
+            await enqueueFastlySyncTask(c.env.DB, {
+              username: canonical,
+              action: 'sync',
+              data: {
+                pubkey: existing.pubkey!,
+                relays,
+                status: 'active',
+                atproto_did: atproto_did || null,
+                atproto_state: atproto_state || null,
+              },
+            })
+          }
         })
       )
     }
@@ -1006,11 +1019,13 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
     }
 
     if (existing.status === 'burned') {
-      await enqueueFastlySyncTask(c.env.DB, {
-        username: canonical,
-        action: 'delete',
-      })
       const deleteResult = await deleteUsernameFromFastly(c.env, canonical)
+      if (!deleteResult.success) {
+        await enqueueFastlySyncTask(c.env.DB, {
+          username: canonical,
+          action: 'delete',
+        })
+      }
       return c.json({
         ok: true,
         action: 'deleted',
@@ -1030,17 +1045,6 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
     }
 
     const relays = parseRelayHints(existing.relays)
-    await enqueueFastlySyncTask(c.env.DB, {
-      username: canonical,
-      action: 'sync',
-      data: {
-        pubkey: existing.pubkey,
-        relays,
-        status: 'active',
-        atproto_did: existing.atproto_did || null,
-        atproto_state: existing.atproto_state || null,
-      },
-    })
     const result = await syncAndVerifyUsername(c.env, canonical, {
       pubkey: existing.pubkey,
       relays,
@@ -1048,6 +1052,19 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
       atproto_did: existing.atproto_did || null,
       atproto_state: existing.atproto_state || null,
     })
+    if (!result.success || !result.verified) {
+      await enqueueFastlySyncTask(c.env.DB, {
+        username: canonical,
+        action: 'sync',
+        data: {
+          pubkey: existing.pubkey,
+          relays,
+          status: 'active',
+          atproto_did: existing.atproto_did || null,
+          atproto_state: existing.atproto_state || null,
+        },
+      })
+    }
 
     return c.json({
       ok: true,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,9 +5,9 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
-import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername } from '../utils/fastly-sync'
+import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername, usernameKVDataMatches } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
@@ -412,17 +412,14 @@ admin.post('/username/revoke', async (c) => {
 
     await revokeUsername(c.env.DB, usernameData.canonical, burn)
 
-    // Sync to Fastly with verification (delete if burned, update status if revoked)
+    await enqueueFastlySyncTask(c.env.DB, {
+      username: usernameData.canonical,
+      action: 'delete',
+    })
+
+    // Delete from Fastly so revoked/burned usernames stop resolving at the edge.
     c.executionCtx.waitUntil(
-      burn
-        ? deleteUsernameFromFastly(c.env, usernameData.canonical)
-        : syncAndVerifyUsername(c.env, usernameData.canonical, {
-            pubkey: existing.pubkey || '',
-            relays: [],
-            status: 'revoked',
-            atproto_did: null,
-            atproto_state: null,
-          })
+      deleteUsernameFromFastly(c.env, usernameData.canonical)
     )
 
     return c.json({
@@ -479,6 +476,17 @@ admin.post('/username/assign', async (c) => {
 
     const createdBy = (c.get('adminEmail' as never) as string) || null
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
+    await enqueueFastlySyncTask(c.env.DB, {
+      username: usernameData.canonical,
+      action: 'sync',
+      data: {
+        pubkey: normalizedPubkey,
+        relays: [],
+        status: 'active',
+        atproto_did: null,
+        atproto_state: null,
+      },
+    })
 
     // Sync to Fastly KV with read-back verification
     c.executionCtx.waitUntil(
@@ -562,6 +570,17 @@ admin.post('/username/assign-bulk', async (c) => {
         }
 
         await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'bulk-upload', createdBy)
+        await enqueueFastlySyncTask(c.env.DB, {
+          username: usernameData.canonical,
+          action: 'sync',
+          data: {
+            pubkey: normalizedPubkey,
+            relays: [],
+            status: 'active',
+            atproto_did: null,
+            atproto_state: null,
+          },
+        })
 
         // Sync to Fastly — no read-back verification on bulk to avoid doubling API calls
         c.executionCtx.waitUntil(
@@ -666,31 +685,29 @@ admin.post('/sync/fastly', async (c) => {
 
     const body: { limit?: number; cursor?: string | null; dry_run?: boolean } = await c.req.json().catch(() => ({}))
     const limit = Math.min(Math.max(body.limit ?? 500, 1), 1000)
-    const cursor = body.cursor ? parseInt(body.cursor, 10) : null
+    const parsedCursor = body.cursor ? parseInt(body.cursor, 10) : null
     const dryRun = body.dry_run ?? false
 
-    if (body.cursor && (isNaN(cursor!) || cursor! < 0)) {
+    if (body.cursor && (isNaN(parsedCursor!) || parsedCursor! < 0)) {
       return c.json({ ok: false, error: 'Invalid cursor' }, 400)
     }
 
+    const cursor = parsedCursor
     const page = await getActiveUsernamesPaginated(c.env.DB, cursor, limit)
 
     const syncable = page.filter(u => u.pubkey)
     const nextCursor = page.length === limit ? String(page[page.length - 1].id) : null
-    const lastId = page.length > 0 ? page[page.length - 1].id : cursor
-    const remaining = nextCursor ? await countActiveUsernames(c.env.DB, lastId) : 0
 
     if (dryRun) {
       const totalActive = await countActiveUsernames(c.env.DB)
       return c.json({
         ok: true,
         dry_run: true,
-        total: totalActive,
+        total_active: totalActive,
         page_size: page.length,
         syncable: syncable.length,
         skipped: page.length - syncable.length,
         cursor: nextCursor,
-        remaining,
       })
     }
 
@@ -706,7 +723,16 @@ admin.post('/sync/fastly', async (c) => {
       },
     }))
 
+    for (const item of items) {
+      await enqueueFastlySyncTask(c.env.DB, item)
+    }
+
     const results = await syncBatch(c.env, items, { concurrency: 10 })
+    await clearFastlySyncTasks(c.env.DB, results.successes.map(result => result.username))
+    await markFastlySyncTaskFailures(
+      c.env.DB,
+      results.failures.map(result => ({ username: result.username, error: result.error }))
+    )
 
     return c.json({
       ok: true,
@@ -714,7 +740,6 @@ admin.post('/sync/fastly', async (c) => {
       deleted: results.deleted,
       failed: results.failed,
       cursor: nextCursor,
-      remaining,
       errors: results.errors.length > 0 ? results.errors.slice(0, 20) : undefined,
     })
   } catch (error) {
@@ -814,6 +839,17 @@ admin.post('/username/set-atproto', async (c) => {
     // Sync to Fastly KV with verification
     if (existing.status === 'active' && existing.pubkey) {
       const relays = parseRelayHints(existing.relays)
+      await enqueueFastlySyncTask(c.env.DB, {
+        username: canonical,
+        action: 'sync',
+        data: {
+          pubkey: existing.pubkey,
+          relays,
+          status: 'active',
+          atproto_did: atproto_did || null,
+          atproto_state: atproto_state || null,
+        },
+      })
       c.executionCtx.waitUntil(
         syncAndVerifyUsername(c.env, canonical, {
           pubkey: existing.pubkey,
@@ -875,11 +911,15 @@ admin.get('/username/:name/nip05-status', async (c) => {
       return c.json({ ok: true, status: 'missing' })
     }
 
-    // Only compare pubkey + status — these drive NIP-05 resolution correctness
-    const pubkeyMatch = fastly.data.pubkey === existing.pubkey
-    const statusMatch = fastly.data.status === existing.status
+    const expectedFastly = {
+      pubkey: existing.pubkey,
+      relays: parseRelayHints(existing.relays),
+      status: 'active' as const,
+      atproto_did: existing.atproto_did || null,
+      atproto_state: existing.atproto_state || null,
+    }
 
-    if (pubkeyMatch && statusMatch) {
+    if (usernameKVDataMatches(fastly.data, expectedFastly)) {
       return c.json({ ok: true, status: 'synced', fastly: fastly.data })
     }
 
@@ -887,7 +927,7 @@ admin.get('/username/:name/nip05-status', async (c) => {
       ok: true,
       status: 'mismatch',
       fastly: fastly.data,
-      db: { pubkey: existing.pubkey, status: existing.status },
+      db: expectedFastly,
     })
   } catch (error) {
     console.error('NIP-05 status error:', error)
@@ -913,6 +953,10 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
     }
 
     if (existing.status === 'burned') {
+      await enqueueFastlySyncTask(c.env.DB, {
+        username: canonical,
+        action: 'delete',
+      })
       const deleteResult = await deleteUsernameFromFastly(c.env, canonical)
       return c.json({
         ok: true,
@@ -933,6 +977,17 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
     }
 
     const relays = parseRelayHints(existing.relays)
+    await enqueueFastlySyncTask(c.env.DB, {
+      username: canonical,
+      action: 'sync',
+      data: {
+        pubkey: existing.pubkey,
+        relays,
+        status: 'active',
+        atproto_did: existing.atproto_did || null,
+        atproto_state: existing.atproto_state || null,
+      },
+    })
     const result = await syncAndVerifyUsername(c.env, canonical, {
       pubkey: existing.pubkey,
       relays,

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -21,7 +21,8 @@ vi.mock('../utils/email', () => ({
 // Mock Fastly sync utilities
 vi.mock('../utils/fastly-sync', () => ({
   syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
-  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true })
+  syncAndVerifyUsername: vi.fn().mockResolvedValue({ success: true, verified: true }),
+  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 type MockUsername = {
@@ -398,8 +399,8 @@ describe('Claim → NIP-05 resolution (e2e)', () => {
 
   // Task 6
   it('Fastly KV sync called with status:active after claim', async () => {
-    const { syncUsernameToFastly, deleteUsernameFromFastly } = await import('../utils/fastly-sync')
-    vi.mocked(syncUsernameToFastly).mockClear()
+    const { syncAndVerifyUsername, deleteUsernameFromFastly } = await import('../utils/fastly-sync')
+    vi.mocked(syncAndVerifyUsername).mockClear()
     vi.mocked(deleteUsernameFromFastly).mockClear()
 
     const app = createTestApp()
@@ -421,7 +422,7 @@ describe('Claim → NIP-05 resolution (e2e)', () => {
     // Flush waitUntil promises so Fastly sync mock gets called
     await Promise.all(waitUntilPromises)
 
-    expect(syncUsernameToFastly).toHaveBeenCalledWith(
+    expect(syncAndVerifyUsername).toHaveBeenCalledWith(
       expect.objectContaining({}),
       'dave',
       expect.objectContaining({

--- a/src/routes/internal-atproto.test.ts
+++ b/src/routes/internal-atproto.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import worker from '../index'
-import { syncUsernameToFastly } from '../utils/fastly-sync'
+import { syncAndVerifyUsername } from '../utils/fastly-sync'
 
 vi.mock('../utils/fastly-sync', () => ({
   syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
+  syncAndVerifyUsername: vi.fn().mockResolvedValue({ success: true, verified: true }),
   deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true }),
   syncBatch: vi.fn().mockResolvedValue({ synced: 0, deleted: 0, failed: 0, errors: [] }),
   parseRelayHints: vi.fn().mockReturnValue(['wss://relay.damus.io']),
@@ -115,7 +116,7 @@ describe('internal atproto sync route', () => {
     expect(json.ok).toBe(true)
     expect(json.name).toBe('alice')
     expect(json.atproto_state).toBe('ready')
-    expect(syncUsernameToFastly).toHaveBeenCalledTimes(1)
+    expect(syncAndVerifyUsername).toHaveBeenCalledTimes(1)
   })
 
   it('rejects missing bearer token', async () => {
@@ -171,7 +172,7 @@ describe('internal atproto sync route', () => {
     )
 
     expect(response.status).toBe(404)
-    expect(syncUsernameToFastly).not.toHaveBeenCalled()
+    expect(syncAndVerifyUsername).not.toHaveBeenCalled()
   })
 
   it('returns 400 for an invalid DID payload', async () => {
@@ -213,7 +214,7 @@ describe('internal atproto sync route', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(syncUsernameToFastly).not.toHaveBeenCalled()
+    expect(syncAndVerifyUsername).not.toHaveBeenCalled()
   })
 
   it('returns 400 for an invalid state payload', async () => {
@@ -255,6 +256,6 @@ describe('internal atproto sync route', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(syncUsernameToFastly).not.toHaveBeenCalled()
+    expect(syncAndVerifyUsername).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/internal-atproto.test.ts
+++ b/src/routes/internal-atproto.test.ts
@@ -5,7 +5,7 @@ import { syncUsernameToFastly } from '../utils/fastly-sync'
 vi.mock('../utils/fastly-sync', () => ({
   syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
   deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true }),
-  bulkSyncToFastly: vi.fn().mockResolvedValue({ success: 0, failed: 0, errors: [] }),
+  syncBatch: vi.fn().mockResolvedValue({ synced: 0, deleted: 0, failed: 0, errors: [] }),
   parseRelayHints: vi.fn().mockReturnValue(['wss://relay.damus.io']),
 }))
 

--- a/src/routes/internal-atproto.ts
+++ b/src/routes/internal-atproto.ts
@@ -75,14 +75,14 @@ internalAtproto.post('/username/set-atproto', async (c) => {
         atproto_did: atproto_did || null,
         atproto_state: atproto_state || null,
       }
-      await enqueueFastlySyncTask(c.env.DB, {
-        username: canonical,
-        action: 'sync',
-        data,
-      })
-      await syncAndVerifyUsername(c.env, canonical, {
-        ...data,
-      })
+      const result = await syncAndVerifyUsername(c.env, canonical, data)
+      if (!result.success || !result.verified) {
+        await enqueueFastlySyncTask(c.env.DB, {
+          username: canonical,
+          action: 'sync',
+          data,
+        })
+      }
     }
 
     return c.json({

--- a/src/routes/internal-atproto.ts
+++ b/src/routes/internal-atproto.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { getUsernameByName } from '../db/queries'
-import { parseRelayHints, syncUsernameToFastly } from '../utils/fastly-sync'
+import { parseRelayHints, syncAndVerifyUsername } from '../utils/fastly-sync'
 
 type Bindings = {
   DB: D1Database
@@ -68,7 +68,7 @@ internalAtproto.post('/username/set-atproto', async (c) => {
     ).bind(atproto_did || null, atproto_state || null, now, canonical, name).run()
 
     if (existing.status === 'active' && existing.pubkey) {
-      await syncUsernameToFastly(c.env, canonical, {
+      await syncAndVerifyUsername(c.env, canonical, {
         pubkey: existing.pubkey,
         relays: parseRelayHints(existing.relays),
         status: 'active',

--- a/src/routes/internal-atproto.ts
+++ b/src/routes/internal-atproto.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { getUsernameByName } from '../db/queries'
+import { enqueueFastlySyncTask, getUsernameByName } from '../db/queries'
 import { parseRelayHints, syncAndVerifyUsername } from '../utils/fastly-sync'
 
 type Bindings = {
@@ -68,12 +68,20 @@ internalAtproto.post('/username/set-atproto', async (c) => {
     ).bind(atproto_did || null, atproto_state || null, now, canonical, name).run()
 
     if (existing.status === 'active' && existing.pubkey) {
-      await syncAndVerifyUsername(c.env, canonical, {
+      const data = {
         pubkey: existing.pubkey,
         relays: parseRelayHints(existing.relays),
-        status: 'active',
+        status: 'active' as const,
         atproto_did: atproto_did || null,
         atproto_state: atproto_state || null,
+      }
+      await enqueueFastlySyncTask(c.env.DB, {
+        username: canonical,
+        action: 'sync',
+        data,
+      })
+      await syncAndVerifyUsername(c.env, canonical, {
+        ...data,
       })
     }
 

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -18,7 +18,8 @@ vi.mock('../utils/email', () => ({
 // Mock Fastly sync utilities
 vi.mock('../utils/fastly-sync', () => ({
   syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
-  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true })
+  syncAndVerifyUsername: vi.fn().mockResolvedValue({ success: true, verified: true }),
+  deleteUsernameFromFastly: vi.fn().mockResolvedValue({ success: true }),
 }))
 
 // Mock D1 database with support for reservations and spent Cashu proofs

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -17,7 +17,7 @@ import {
   findSpentProofs,
   storeSpentProofs
 } from '../db/queries'
-import { syncUsernameToFastly, deleteUsernameFromFastly } from '../utils/fastly-sync'
+import { syncAndVerifyUsername, deleteUsernameFromFastly } from '../utils/fastly-sync'
 import { sendReservationConfirmationEmail } from '../utils/email'
 import {
   parseCashuToken,
@@ -485,9 +485,9 @@ username.post('/claim', async (c) => {
     // Claim the username
     await claimUsername(c.env.DB, nameDisplay, nameCanonical, pubkey, relays)
 
-    // Sync to Fastly KV for edge routing (async, don't block response)
+    // Sync to Fastly KV with read-back verification (async, don't block response)
     c.executionCtx.waitUntil(
-      syncUsernameToFastly(c.env, nameCanonical, {
+      syncAndVerifyUsername(c.env, nameCanonical, {
         pubkey,
         relays: relays || [],
         status: 'active',

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -15,7 +15,8 @@ import {
   getReservationByToken,
   confirmReservation,
   findSpentProofs,
-  storeSpentProofs
+  storeSpentProofs,
+  enqueueFastlySyncTask,
 } from '../db/queries'
 import { syncAndVerifyUsername, deleteUsernameFromFastly } from '../utils/fastly-sync'
 import { sendReservationConfirmationEmail } from '../utils/email'
@@ -476,6 +477,10 @@ username.post('/claim', async (c) => {
       if (currentCanonical && currentCanonical !== nameCanonical) {
         // User is claiming a new username, old one will be auto-revoked in D1.
         // Also delete the old entry from Fastly KV so it stops resolving.
+        await enqueueFastlySyncTask(c.env.DB, {
+          username: currentCanonical,
+          action: 'delete',
+        })
         c.executionCtx.waitUntil(
           deleteUsernameFromFastly(c.env, currentCanonical)
         )
@@ -484,6 +489,17 @@ username.post('/claim', async (c) => {
 
     // Claim the username
     await claimUsername(c.env.DB, nameDisplay, nameCanonical, pubkey, relays)
+    await enqueueFastlySyncTask(c.env.DB, {
+      username: nameCanonical,
+      action: 'sync',
+      data: {
+        pubkey,
+        relays: relays || [],
+        status: 'active',
+        atproto_did: null,
+        atproto_state: null,
+      },
+    })
 
     // Sync to Fastly KV with read-back verification (async, don't block response)
     c.executionCtx.waitUntil(

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -477,29 +477,21 @@ username.post('/claim', async (c) => {
       if (currentCanonical && currentCanonical !== nameCanonical) {
         // User is claiming a new username, old one will be auto-revoked in D1.
         // Also delete the old entry from Fastly KV so it stops resolving.
-        await enqueueFastlySyncTask(c.env.DB, {
-          username: currentCanonical,
-          action: 'delete',
-        })
         c.executionCtx.waitUntil(
-          deleteUsernameFromFastly(c.env, currentCanonical)
+          deleteUsernameFromFastly(c.env, currentCanonical).then(async (result) => {
+            if (!result.success) {
+              await enqueueFastlySyncTask(c.env.DB, {
+                username: currentCanonical,
+                action: 'delete',
+              })
+            }
+          })
         )
       }
     }
 
     // Claim the username
     await claimUsername(c.env.DB, nameDisplay, nameCanonical, pubkey, relays)
-    await enqueueFastlySyncTask(c.env.DB, {
-      username: nameCanonical,
-      action: 'sync',
-      data: {
-        pubkey,
-        relays: relays || [],
-        status: 'active',
-        atproto_did: null,
-        atproto_state: null,
-      },
-    })
 
     // Sync to Fastly KV with read-back verification (async, don't block response)
     c.executionCtx.waitUntil(
@@ -509,6 +501,20 @@ username.post('/claim', async (c) => {
         status: 'active',
         atproto_did: null,
         atproto_state: null,
+      }).then(async (result) => {
+        if (!result.success || !result.verified) {
+          await enqueueFastlySyncTask(c.env.DB, {
+            username: nameCanonical,
+            action: 'sync',
+            data: {
+              pubkey,
+              relays: relays || [],
+              status: 'active',
+              atproto_did: null,
+              atproto_state: null,
+            },
+          })
+        }
       })
     )
 

--- a/src/utils/fastly-sync.test.ts
+++ b/src/utils/fastly-sync.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+import { syncBatch, type SyncItem, type FastlyEnv } from './fastly-sync'
+
+const env: FastlyEnv = {
+  FASTLY_API_TOKEN: 'test-token',
+  FASTLY_STORE_ID: 'test-store-id',
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('syncBatch', () => {
+  it('should sync active users and delete revoked users', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, text: async () => '' })
+
+    const items: SyncItem[] = [
+      { username: 'alice', action: 'sync', data: { pubkey: 'abc123', relays: [], status: 'active' } },
+      { username: 'bob', action: 'delete' },
+    ]
+
+    const result = await syncBatch(env, items)
+
+    expect(result.synced).toBe(1)
+    expect(result.deleted).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(result.errors).toEqual([])
+  })
+
+  it('should handle partial failures without aborting', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('user%3Afailing')) {
+        return { ok: false, status: 500, text: async () => 'server error' }
+      }
+      return { ok: true, status: 200, text: async () => '' }
+    })
+
+    const items: SyncItem[] = [
+      { username: 'failing', action: 'sync', data: { pubkey: 'aaa', relays: [], status: 'active' } },
+      { username: 'passing', action: 'sync', data: { pubkey: 'bbb', relays: [], status: 'active' } },
+    ]
+
+    const result = await syncBatch(env, items)
+
+    expect(result.synced).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.errors.length).toBe(1)
+    expect(result.errors[0]).toContain('failing')
+  })
+
+  it('should respect concurrency limit', async () => {
+    let concurrent = 0
+    let maxConcurrent = 0
+
+    mockFetch.mockImplementation(async () => {
+      concurrent++
+      maxConcurrent = Math.max(maxConcurrent, concurrent)
+      await new Promise(r => setTimeout(r, 10))
+      concurrent--
+      return { ok: true, status: 200, text: async () => '' }
+    })
+
+    const items: SyncItem[] = Array.from({ length: 20 }, (_, i) => ({
+      username: `user${i}`,
+      action: 'sync' as const,
+      data: { pubkey: `pk${i}`, relays: [], status: 'active' as const },
+    }))
+
+    await syncBatch(env, items, { concurrency: 3 })
+
+    expect(maxConcurrent).toBeLessThanOrEqual(3)
+    expect(maxConcurrent).toBeGreaterThan(1)
+  })
+
+  it('should return zeros for empty items array', async () => {
+    const result = await syncBatch(env, [])
+
+    expect(result.synced).toBe(0)
+    expect(result.deleted).toBe(0)
+    expect(result.failed).toBe(0)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('should skip sync when Fastly config is missing', async () => {
+    const result = await syncBatch({ FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }, [
+      { username: 'alice', action: 'sync', data: { pubkey: 'abc', relays: [], status: 'active' } },
+    ])
+
+    expect(result.failed).toBe(1)
+    expect(result.errors[0]).toContain('alice')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/fastly-sync.test.ts
+++ b/src/utils/fastly-sync.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-import { syncBatch, type SyncItem, type FastlyEnv } from './fastly-sync'
+import { syncBatch, readUsernameFromFastly, syncAndVerifyUsername, type SyncItem, type FastlyEnv } from './fastly-sync'
 
 const env: FastlyEnv = {
   FASTLY_API_TOKEN: 'test-token',
@@ -93,5 +93,98 @@ describe('syncBatch', () => {
     expect(result.failed).toBe(1)
     expect(result.errors[0]).toContain('alice')
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('readUsernameFromFastly', () => {
+  it('should return data for existing key', async () => {
+    const kvData = { pubkey: 'abc123', relays: [], status: 'active' }
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => kvData,
+    })
+
+    const result = await readUsernameFromFastly(env, 'alice')
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(kvData)
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('user%3Aalice'),
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+
+  it('should return undefined data for 404', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, text: async () => 'not found' })
+
+    const result = await readUsernameFromFastly(env, 'nonexistent')
+
+    expect(result.success).toBe(true)
+    expect(result.data).toBeUndefined()
+  })
+
+  it('should return error for non-404 failures', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, text: async () => 'server error' })
+
+    const result = await readUsernameFromFastly(env, 'alice')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('500')
+  })
+
+  it('should return error when config is missing', async () => {
+    const result = await readUsernameFromFastly({}, 'alice')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('missing')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncAndVerifyUsername', () => {
+  const data = { pubkey: 'abc123', relays: [] as string[], status: 'active' as const }
+
+  it('should return verified:true when read-back matches', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => data })
+
+    const result = await syncAndVerifyUsername(env, 'alice', data)
+
+    expect(result.success).toBe(true)
+    expect(result.verified).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('should return verified:false when read-back has mismatch', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '' })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ ...data, pubkey: 'different' }) })
+
+    const result = await syncAndVerifyUsername(env, 'alice', data)
+
+    expect(result.success).toBe(true)
+    expect(result.verified).toBe(false)
+  })
+
+  it('should return verified:false when key missing after write', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '' })
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'not found' })
+
+    const result = await syncAndVerifyUsername(env, 'alice', data)
+
+    expect(result.success).toBe(true)
+    expect(result.verified).toBe(false)
+  })
+
+  it('should return success:false when sync itself fails', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, text: async () => 'error' })
+
+    const result = await syncAndVerifyUsername(env, 'alice', data)
+
+    expect(result.success).toBe(false)
+    expect(result.verified).toBe(false)
   })
 })

--- a/src/utils/fastly-sync.test.ts
+++ b/src/utils/fastly-sync.test.ts
@@ -3,7 +3,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-import { syncBatch, readUsernameFromFastly, syncAndVerifyUsername, type SyncItem, type FastlyEnv } from './fastly-sync'
+import {
+  syncBatch,
+  readUsernameFromFastly,
+  syncAndVerifyUsername,
+  deleteUsernameFromFastly,
+  type SyncItem,
+  type FastlyEnv,
+} from './fastly-sync'
 
 const env: FastlyEnv = {
   FASTLY_API_TOKEN: 'test-token',
@@ -94,6 +101,17 @@ describe('syncBatch', () => {
     expect(result.errors[0]).toContain('alice')
     expect(mockFetch).not.toHaveBeenCalled()
   })
+
+  it('should fail delete when Fastly config is missing', async () => {
+    const result = await syncBatch({ FASTLY_API_TOKEN: undefined, FASTLY_STORE_ID: undefined }, [
+      { username: 'alice', action: 'delete' },
+    ])
+
+    expect(result.failed).toBe(1)
+    expect(result.deleted).toBe(0)
+    expect(result.errors[0]).toContain('alice')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
 })
 
 describe('readUsernameFromFastly', () => {
@@ -135,6 +153,16 @@ describe('readUsernameFromFastly', () => {
 
   it('should return error when config is missing', async () => {
     const result = await readUsernameFromFastly({}, 'alice')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('missing')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('deleteUsernameFromFastly', () => {
+  it('should fail when Fastly config is missing', async () => {
+    const result = await deleteUsernameFromFastly({}, 'alice')
 
     expect(result.success).toBe(false)
     expect(result.error).toContain('missing')

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -122,8 +122,9 @@ export async function deleteUsernameFromFastly(
   username: string
 ): Promise<{ success: boolean; error?: string }> {
   if (!env.FASTLY_API_TOKEN || !env.FASTLY_STORE_ID) {
-    console.log('Fastly delete skipped: missing FASTLY_API_TOKEN or FASTLY_STORE_ID')
-    return { success: true }
+    const error = 'Fastly sync configuration is missing'
+    console.error('Fastly delete failed: missing FASTLY_API_TOKEN or FASTLY_STORE_ID')
+    return { success: false, error }
   }
 
   // Key format must match compute-js expectations: user:{username}

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -130,25 +130,62 @@ export async function deleteUsernameFromFastly(
   }
 }
 
-/**
- * Bulk sync multiple usernames to Fastly
- * Used for initial sync or recovery
- */
-export async function bulkSyncToFastly(
-  env: FastlyEnv,
-  usernames: Array<{ username: string; data: UsernameKVData }>
-): Promise<{ success: number; failed: number; errors: string[] }> {
-  const results = { success: 0, failed: 0, errors: [] as string[] }
+export interface SyncItem {
+  username: string
+  action: 'sync' | 'delete'
+  data?: UsernameKVData
+}
 
-  for (const { username, data } of usernames) {
-    const result = await syncUsernameToFastly(env, username, data)
-    if (result.success) {
-      results.success++
-    } else {
-      results.failed++
-      results.errors.push(`${username}: ${result.error}`)
+export interface SyncBatchResult {
+  synced: number
+  deleted: number
+  failed: number
+  errors: string[]
+}
+
+export async function syncBatch(
+  env: FastlyEnv,
+  items: SyncItem[],
+  options?: { concurrency?: number }
+): Promise<SyncBatchResult> {
+  const concurrency = options?.concurrency ?? 10
+  const result: SyncBatchResult = { synced: 0, deleted: 0, failed: 0, errors: [] }
+
+  if (items.length === 0) return result
+
+  const queue = [...items]
+  const inflight = new Set<Promise<void>>()
+
+  const processItem = async (item: SyncItem): Promise<void> => {
+    if (item.action === 'sync' && item.data) {
+      const res = await syncUsernameToFastly(env, item.username, item.data)
+      if (res.success) result.synced++
+      else {
+        result.failed++
+        result.errors.push(`${item.username}: ${res.error}`)
+      }
+    } else if (item.action === 'delete') {
+      const res = await deleteUsernameFromFastly(env, item.username)
+      if (res.success) result.deleted++
+      else {
+        result.failed++
+        result.errors.push(`${item.username}: ${res.error}`)
+      }
     }
   }
 
-  return results
+  while (queue.length > 0 || inflight.size > 0) {
+    while (queue.length > 0 && inflight.size < concurrency) {
+      const item = queue.shift()!
+      const promise = processItem(item).then(() => {
+        inflight.delete(promise)
+      })
+      inflight.add(promise)
+    }
+    if (inflight.size > 0) {
+      await Promise.race(inflight)
+    }
+  }
+
+  return result
 }

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -164,6 +164,9 @@ export async function syncBatch(
         result.failed++
         result.errors.push(`${item.username}: ${res.error}`)
       }
+    } else if (item.action === 'sync' && !item.data) {
+      result.failed++
+      result.errors.push(`${item.username}: sync action missing data`)
     } else if (item.action === 'delete') {
       const res = await deleteUsernameFromFastly(env, item.username)
       if (res.success) result.deleted++

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -14,6 +14,27 @@ export interface UsernameKVData {
   atproto_state?: 'pending' | 'ready' | 'failed' | 'disabled' | null
 }
 
+export function normalizeUsernameKVData(data: UsernameKVData): UsernameKVData {
+  return {
+    pubkey: data.pubkey,
+    relays: [...data.relays].sort(),
+    status: data.status,
+    atproto_did: data.atproto_did ?? null,
+    atproto_state: data.atproto_state ?? null,
+  }
+}
+
+export function usernameKVDataMatches(actual: UsernameKVData, expected: UsernameKVData): boolean {
+  const normalizedActual = normalizeUsernameKVData(actual)
+  const normalizedExpected = normalizeUsernameKVData(expected)
+
+  return normalizedActual.pubkey === normalizedExpected.pubkey
+    && normalizedActual.status === normalizedExpected.status
+    && normalizedActual.atproto_did === normalizedExpected.atproto_did
+    && normalizedActual.atproto_state === normalizedExpected.atproto_state
+    && JSON.stringify(normalizedActual.relays) === JSON.stringify(normalizedExpected.relays)
+}
+
 export function parseRelayHints(relays: string | null | undefined): string[] {
   if (!relays) return []
   try {
@@ -106,28 +127,38 @@ export async function deleteUsernameFromFastly(
   const kvKey = `user:${username}`
   const url = `${FASTLY_API_BASE}/resources/stores/kv/${env.FASTLY_STORE_ID}/keys/${encodeURIComponent(kvKey)}`
 
-  try {
-    const response = await fetch(url, {
-      method: 'DELETE',
-      headers: {
-        'Fastly-Key': env.FASTLY_API_TOKEN,
-      },
-    })
+  let lastError = ''
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'Fastly-Key': env.FASTLY_API_TOKEN,
+        },
+      })
 
-    // 404 is fine - key might not exist
-    if (!response.ok && response.status !== 404) {
+      // 404 is fine - key might not exist
+      if (response.ok || response.status === 404) {
+        if (attempt > 0) console.log(`Fastly delete success for ${username} on attempt ${attempt + 1}`)
+        else console.log(`Fastly delete success: ${username}`)
+        return { success: true }
+      }
+
+      lastError = `Fastly API error: ${response.status}`
       const errorText = await response.text()
-      console.error(`Fastly delete failed for ${username}: ${response.status} ${errorText}`)
-      return { success: false, error: `Fastly API error: ${response.status}` }
+      console.error(`Fastly delete attempt ${attempt + 1}/${MAX_RETRIES} failed for ${username}: ${response.status} ${errorText}`)
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : 'Unknown error'
+      console.error(`Fastly delete attempt ${attempt + 1}/${MAX_RETRIES} error for ${username}: ${lastError}`)
     }
 
-    console.log(`Fastly delete success: ${username}`)
-    return { success: true }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error'
-    console.error(`Fastly delete error for ${username}: ${message}`)
-    return { success: false, error: message }
+    if (attempt < MAX_RETRIES - 1) {
+      await sleep(RETRY_BASE_MS * Math.pow(2, attempt))
+    }
   }
+
+  console.error(`Fastly delete FAILED for ${username} after ${MAX_RETRIES} attempts`)
+  return { success: false, error: lastError }
 }
 
 export async function readUsernameFromFastly(
@@ -178,20 +209,23 @@ export async function syncAndVerifyUsername(
 
   const verifyResult = await readUsernameFromFastly(env, username)
   if (!verifyResult.success) {
-    console.warn(`Fastly verify read failed for ${username}: ${verifyResult.error}`)
-    return { success: true, verified: false }
+    const error = `Fastly verify read failed: ${verifyResult.error}`
+    console.warn(`${error} for ${username}`)
+    return { success: true, verified: false, error }
   }
 
   if (!verifyResult.data) {
-    console.error(`Fastly verify FAILED for ${username}: key missing after successful write`)
-    return { success: true, verified: false }
+    const error = 'Fastly verify failed: key missing after successful write'
+    console.error(`${error} for ${username}`)
+    return { success: true, verified: false, error }
   }
 
-  // Only verify pubkey + status — these drive NIP-05 resolution correctness.
-  // Relay hints and atproto metadata are best-effort and not worth flagging.
-  if (verifyResult.data.pubkey !== data.pubkey || verifyResult.data.status !== data.status) {
-    console.error(`Fastly verify FAILED for ${username}: wrote pubkey=${data.pubkey},status=${data.status} but read pubkey=${verifyResult.data.pubkey},status=${verifyResult.data.status}`)
-    return { success: true, verified: false }
+  if (!usernameKVDataMatches(verifyResult.data, data)) {
+    const expected = JSON.stringify(normalizeUsernameKVData(data))
+    const actual = JSON.stringify(normalizeUsernameKVData(verifyResult.data))
+    const error = `Fastly verify failed: wrote ${expected} but read ${actual}`
+    console.error(`${error} for ${username}`)
+    return { success: true, verified: false, error }
   }
 
   return { success: true, verified: true }
@@ -208,6 +242,8 @@ export interface SyncBatchResult {
   deleted: number
   failed: number
   errors: string[]
+  successes: Array<{ username: string; action: 'sync' | 'delete' }>
+  failures: Array<{ username: string; action: 'sync' | 'delete'; error: string }>
 }
 
 export async function syncBatch(
@@ -216,7 +252,7 @@ export async function syncBatch(
   options?: { concurrency?: number }
 ): Promise<SyncBatchResult> {
   const concurrency = options?.concurrency ?? 10
-  const result: SyncBatchResult = { synced: 0, deleted: 0, failed: 0, errors: [] }
+  const result: SyncBatchResult = { synced: 0, deleted: 0, failed: 0, errors: [], successes: [], failures: [] }
 
   if (items.length === 0) return result
 
@@ -226,20 +262,32 @@ export async function syncBatch(
   const processItem = async (item: SyncItem): Promise<void> => {
     if (item.action === 'sync' && item.data) {
       const res = await syncUsernameToFastly(env, item.username, item.data)
-      if (res.success) result.synced++
+      if (res.success) {
+        result.synced++
+        result.successes.push({ username: item.username, action: item.action })
+      }
       else {
         result.failed++
-        result.errors.push(`${item.username}: ${res.error}`)
+        const error = res.error || 'Unknown sync error'
+        result.errors.push(`${item.username}: ${error}`)
+        result.failures.push({ username: item.username, action: item.action, error })
       }
     } else if (item.action === 'sync' && !item.data) {
       result.failed++
-      result.errors.push(`${item.username}: sync action missing data`)
+      const error = 'sync action missing data'
+      result.errors.push(`${item.username}: ${error}`)
+      result.failures.push({ username: item.username, action: item.action, error })
     } else if (item.action === 'delete') {
       const res = await deleteUsernameFromFastly(env, item.username)
-      if (res.success) result.deleted++
+      if (res.success) {
+        result.deleted++
+        result.successes.push({ username: item.username, action: item.action })
+      }
       else {
         result.failed++
-        result.errors.push(`${item.username}: ${res.error}`)
+        const error = res.error || 'Unknown delete error'
+        result.errors.push(`${item.username}: ${error}`)
+        result.failures.push({ username: item.username, action: item.action, error })
       }
     }
   }

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -130,6 +130,73 @@ export async function deleteUsernameFromFastly(
   }
 }
 
+export async function readUsernameFromFastly(
+  env: FastlyEnv,
+  username: string
+): Promise<{ success: boolean; data?: UsernameKVData; error?: string }> {
+  if (!env.FASTLY_API_TOKEN || !env.FASTLY_STORE_ID) {
+    return { success: false, error: 'Fastly sync configuration is missing' }
+  }
+
+  const kvKey = `user:${username}`
+  const url = `${FASTLY_API_BASE}/resources/stores/kv/${env.FASTLY_STORE_ID}/keys/${encodeURIComponent(kvKey)}`
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Fastly-Key': env.FASTLY_API_TOKEN,
+      },
+    })
+
+    if (response.status === 404) {
+      return { success: true, data: undefined }
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return { success: false, error: `Fastly API error: ${response.status} ${errorText}` }
+    }
+
+    const data = await response.json() as UsernameKVData
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return { success: false, error: message }
+  }
+}
+
+export async function syncAndVerifyUsername(
+  env: FastlyEnv,
+  username: string,
+  data: UsernameKVData
+): Promise<{ success: boolean; verified: boolean; error?: string }> {
+  const syncResult = await syncUsernameToFastly(env, username, data)
+  if (!syncResult.success) {
+    return { success: false, verified: false, error: syncResult.error }
+  }
+
+  const verifyResult = await readUsernameFromFastly(env, username)
+  if (!verifyResult.success) {
+    console.warn(`Fastly verify read failed for ${username}: ${verifyResult.error}`)
+    return { success: true, verified: false }
+  }
+
+  if (!verifyResult.data) {
+    console.error(`Fastly verify FAILED for ${username}: key missing after successful write`)
+    return { success: true, verified: false }
+  }
+
+  // Only verify pubkey + status — these drive NIP-05 resolution correctness.
+  // Relay hints and atproto metadata are best-effort and not worth flagging.
+  if (verifyResult.data.pubkey !== data.pubkey || verifyResult.data.status !== data.status) {
+    console.error(`Fastly verify FAILED for ${username}: wrote pubkey=${data.pubkey},status=${data.status} but read pubkey=${verifyResult.data.pubkey},status=${verifyResult.data.status}`)
+    return { success: true, verified: false }
+  }
+
+  return { success: true, verified: true }
+}
+
 export interface SyncItem {
   username: string
   action: 'sync' | 'delete'

--- a/src/utils/fastly-sync.ts
+++ b/src/utils/fastly-sync.ts
@@ -95,6 +95,9 @@ export async function syncUsernameToFastly(
       lastError = `Fastly API error: ${response.status}`
       const errorText = await response.text()
       console.error(`Fastly sync attempt ${attempt + 1}/${MAX_RETRIES} failed for ${username}: ${response.status} ${errorText}`)
+      if (response.status < 500 && response.status !== 429) {
+        return { success: false, error: `${lastError} ${errorText}`.trim() }
+      }
     } catch (error) {
       lastError = error instanceof Error ? error.message : 'Unknown error'
       console.error(`Fastly sync attempt ${attempt + 1}/${MAX_RETRIES} error for ${username}: ${lastError}`)
@@ -147,6 +150,9 @@ export async function deleteUsernameFromFastly(
       lastError = `Fastly API error: ${response.status}`
       const errorText = await response.text()
       console.error(`Fastly delete attempt ${attempt + 1}/${MAX_RETRIES} failed for ${username}: ${response.status} ${errorText}`)
+      if (response.status < 500 && response.status !== 429) {
+        return { success: false, error: `${lastError} ${errorText}`.trim() }
+      }
     } catch (error) {
       lastError = error instanceof Error ? error.message : 'Unknown error'
       console.error(`Fastly delete attempt ${attempt + 1}/${MAX_RETRIES} error for ${username}: ${lastError}`)

--- a/tests/atproto-cron-sync.test.ts
+++ b/tests/atproto-cron-sync.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Username } from '../src/db/queries'
 
-const { getAllActiveUsernames, expireStaleReservations, bulkSyncToFastly } = vi.hoisted(() => ({
-  getAllActiveUsernames: vi.fn<() => Promise<Username[]>>(),
+const { getUsernamesUpdatedSince, expireStaleReservations, syncBatch } = vi.hoisted(() => ({
+  getUsernamesUpdatedSince: vi.fn<() => Promise<Username[]>>(),
   expireStaleReservations: vi.fn<() => Promise<number>>(),
-  bulkSyncToFastly: vi.fn(),
+  syncBatch: vi.fn(),
 }))
 
 vi.mock('../src/db/queries', async () => {
   const actual = await vi.importActual<typeof import('../src/db/queries')>('../src/db/queries')
   return {
     ...actual,
-    getAllActiveUsernames,
+    getUsernamesUpdatedSince,
     expireStaleReservations,
   }
 })
@@ -20,7 +20,7 @@ vi.mock('../src/utils/fastly-sync', async () => {
   const actual = await vi.importActual<typeof import('../src/utils/fastly-sync')>('../src/utils/fastly-sync')
   return {
     ...actual,
-    bulkSyncToFastly,
+    syncBatch,
   }
 })
 
@@ -30,11 +30,11 @@ describe('ATProto cron sync payloads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     expireStaleReservations.mockResolvedValue(0)
-    bulkSyncToFastly.mockResolvedValue({ success: 1, failed: 0, errors: [] })
+    syncBatch.mockResolvedValue({ synced: 1, deleted: 0, failed: 0, errors: [] })
   })
 
   it('includes atproto_did and atproto_state in the hourly Fastly reconciliation payload', async () => {
-    getAllActiveUsernames.mockResolvedValue([
+    getUsernamesUpdatedSince.mockResolvedValue([
       {
         id: 1,
         name: 'alice',
@@ -55,6 +55,8 @@ describe('ATProto cron sync payloads', () => {
         confirmation_token: null,
         reservation_expires_at: null,
         subscription_expires_at: null,
+        claim_source: 'self-service',
+        created_by: null,
         atproto_did: 'did:plc:abc123',
         atproto_state: 'ready',
       },
@@ -71,7 +73,7 @@ describe('ATProto cron sync payloads', () => {
       { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
     )
 
-    expect(bulkSyncToFastly).toHaveBeenCalledWith(
+    expect(syncBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         FASTLY_API_TOKEN: 'fastly-token',
         FASTLY_STORE_ID: 'store-id',
@@ -79,6 +81,7 @@ describe('ATProto cron sync payloads', () => {
       [
         {
           username: 'alice',
+          action: 'sync',
           data: {
             pubkey: 'abc123',
             relays: ['wss://relay.damus.io'],
@@ -87,7 +90,123 @@ describe('ATProto cron sync payloads', () => {
             atproto_state: 'ready',
           },
         },
-      ]
+      ],
+      { concurrency: 10 }
+    )
+  })
+
+  it('maps revoked usernames to delete action', async () => {
+    getUsernamesUpdatedSince.mockResolvedValue([
+      {
+        id: 2,
+        name: 'baduser',
+        username_display: 'baduser',
+        username_canonical: 'baduser',
+        pubkey: 'def456',
+        email: null,
+        relays: null,
+        status: 'revoked',
+        recyclable: 1,
+        created_at: 0,
+        updated_at: 0,
+        claimed_at: 0,
+        revoked_at: 1700000000,
+        reserved_reason: null,
+        admin_notes: null,
+        reservation_email: null,
+        confirmation_token: null,
+        reservation_expires_at: null,
+        subscription_expires_at: null,
+        claim_source: 'self-service',
+        created_by: null,
+        atproto_did: null,
+        atproto_state: null,
+      },
+    ])
+
+    await worker.scheduled(
+      {} as ScheduledEvent,
+      {
+        DB: {} as D1Database,
+        ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
+        FASTLY_API_TOKEN: 'fastly-token',
+        FASTLY_STORE_ID: 'store-id',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
+    )
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ username: 'baduser', action: 'delete', data: undefined }],
+      { concurrency: 10 }
+    )
+  })
+
+  it('filters out active users without pubkeys', async () => {
+    getUsernamesUpdatedSince.mockResolvedValue([
+      {
+        id: 3,
+        name: 'reserved-name',
+        username_display: 'reserved-name',
+        username_canonical: 'reserved-name',
+        pubkey: null,
+        email: null,
+        relays: null,
+        status: 'active',
+        recyclable: 0,
+        created_at: 0,
+        updated_at: 0,
+        claimed_at: null,
+        revoked_at: null,
+        reserved_reason: 'brand protection',
+        admin_notes: null,
+        reservation_email: null,
+        confirmation_token: null,
+        reservation_expires_at: null,
+        subscription_expires_at: null,
+        claim_source: 'admin',
+        created_by: null,
+        atproto_did: null,
+        atproto_state: null,
+      },
+    ])
+
+    await worker.scheduled(
+      {} as ScheduledEvent,
+      {
+        DB: {} as D1Database,
+        ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
+        FASTLY_API_TOKEN: 'fastly-token',
+        FASTLY_STORE_ID: 'store-id',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
+    )
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      { concurrency: 10 }
+    )
+  })
+
+  it('completes without error when no changes exist', async () => {
+    getUsernamesUpdatedSince.mockResolvedValue([])
+
+    await worker.scheduled(
+      {} as ScheduledEvent,
+      {
+        DB: {} as D1Database,
+        ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
+        FASTLY_API_TOKEN: 'fastly-token',
+        FASTLY_STORE_ID: 'store-id',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
+    )
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      [],
+      { concurrency: 10 }
     )
   })
 })

--- a/tests/atproto-cron-sync.test.ts
+++ b/tests/atproto-cron-sync.test.ts
@@ -218,4 +218,110 @@ describe('ATProto cron sync payloads', () => {
       { concurrency: 10 }
     )
   })
+
+  it('re-enqueues failed work, preserves queued work, and prefers recent payloads', async () => {
+    getQueuedFastlySyncTasks.mockResolvedValue([
+      {
+        username: 'alice',
+        action: 'sync',
+        data: {
+          pubkey: 'stale-pubkey',
+          relays: [],
+          status: 'active',
+          atproto_did: null,
+          atproto_state: null,
+        },
+        queued_at: 100,
+        updated_at: 100,
+        last_attempt_at: 110,
+        attempt_count: 2,
+        last_error: 'old error',
+      },
+      {
+        username: 'burned-user',
+        action: 'delete',
+        queued_at: 90,
+        updated_at: 90,
+        last_attempt_at: 100,
+        attempt_count: 1,
+        last_error: 'delete error',
+      },
+    ])
+    getUsernamesUpdatedSince.mockResolvedValue([
+      {
+        id: 1,
+        name: 'alice',
+        username_display: 'alice',
+        username_canonical: 'alice',
+        pubkey: 'fresh-pubkey',
+        email: null,
+        relays: '["wss://relay.damus.io"]',
+        status: 'active',
+        recyclable: 0,
+        created_at: 0,
+        updated_at: 0,
+        claimed_at: 0,
+        revoked_at: null,
+        reserved_reason: null,
+        admin_notes: null,
+        reservation_email: null,
+        confirmation_token: null,
+        reservation_expires_at: null,
+        subscription_expires_at: null,
+        claim_source: 'self-service',
+        created_by: null,
+        atproto_did: 'did:plc:fresh',
+        atproto_state: 'ready',
+      },
+    ])
+    syncBatch.mockResolvedValue({
+      synced: 0,
+      deleted: 1,
+      failed: 1,
+      errors: ['alice: boom'],
+      successes: [{ username: 'burned-user', action: 'delete' }],
+      failures: [{ username: 'alice', action: 'sync', error: 'boom' }],
+    })
+
+    await worker.scheduled(
+      {} as ScheduledEvent,
+      {
+        DB: {} as D1Database,
+        ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
+        FASTLY_API_TOKEN: 'fastly-token',
+        FASTLY_STORE_ID: 'store-id',
+      },
+      { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
+    )
+
+    expect(syncBatch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({
+          username: 'alice',
+          data: expect.objectContaining({
+            pubkey: 'fresh-pubkey',
+            atproto_did: 'did:plc:fresh',
+          }),
+        }),
+        expect.objectContaining({
+          username: 'burned-user',
+          action: 'delete',
+        }),
+      ]),
+      { concurrency: 10 }
+    )
+    expect(clearFastlySyncTasks).toHaveBeenCalledWith(expect.anything(), ['burned-user'])
+    expect(enqueueFastlySyncTask).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        username: 'alice',
+        data: expect.objectContaining({ pubkey: 'fresh-pubkey' }),
+      })
+    )
+    expect(markFastlySyncTaskFailures).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ username: 'alice', error: 'boom' }]
+    )
+  })
 })

--- a/tests/atproto-cron-sync.test.ts
+++ b/tests/atproto-cron-sync.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Username } from '../src/db/queries'
 
-const { getUsernamesUpdatedSince, expireStaleReservations, syncBatch } = vi.hoisted(() => ({
+const { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, syncBatch } = vi.hoisted(() => ({
   getUsernamesUpdatedSince: vi.fn<() => Promise<Username[]>>(),
   expireStaleReservations: vi.fn<() => Promise<number>>(),
+  getQueuedFastlySyncTasks: vi.fn<() => Promise<any[]>>(),
+  enqueueFastlySyncTask: vi.fn<() => Promise<void>>(),
+  clearFastlySyncTasks: vi.fn<() => Promise<void>>(),
+  markFastlySyncTaskFailures: vi.fn<() => Promise<void>>(),
   syncBatch: vi.fn(),
 }))
 
@@ -13,6 +17,10 @@ vi.mock('../src/db/queries', async () => {
     ...actual,
     getUsernamesUpdatedSince,
     expireStaleReservations,
+    getQueuedFastlySyncTasks,
+    enqueueFastlySyncTask,
+    clearFastlySyncTasks,
+    markFastlySyncTaskFailures,
   }
 })
 
@@ -30,7 +38,8 @@ describe('ATProto cron sync payloads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     expireStaleReservations.mockResolvedValue(0)
-    syncBatch.mockResolvedValue({ synced: 1, deleted: 0, failed: 0, errors: [] })
+    getQueuedFastlySyncTasks.mockResolvedValue([])
+    syncBatch.mockResolvedValue({ synced: 1, deleted: 0, failed: 0, errors: [], successes: [], failures: [] })
   })
 
   it('includes atproto_did and atproto_state in the hourly Fastly reconciliation payload', async () => {


### PR DESCRIPTION
## Summary

This PR fixes the Fastly KV sync reliability and scale issues behind issue #40, and completes the admin verification/status tooling around that path.

**Fastly sync scaling and reliability:**
- Replaces the old sequential full-table cron sync with hourly reconciliation over:
  - usernames updated in the last 6 hours
  - a durable `fastly_sync_queue` retry queue for failed Fastly writes/deletes
- Uses `syncBatch` with bounded concurrency for Fastly API calls
- Adds paginated admin backfill endpoint: `POST /api/admin/sync/fastly`
- Adds CLI backfill script: `scripts/backfill-fastly-kv.sh`
- Adds dashboard-triggered backfill flow with progress + real request abort support
- Adds queue cleanup/failure bookkeeping helpers and tests

**NIP-05 status and verification:**
- Adds `GET /api/admin/username/:name/nip05-status`
- Adds `POST /api/admin/username/:name/sync-to-fastly`
- Verifies full Fastly payload on individual write paths, including ATProto fields and relay hints
- Surfaces verification state in the username detail UI

**Related admin improvements brought in from main during branch update:**
- admin sort controls
- stats endpoint/cards
- admin notes editing + audit metadata
- extended admin search

## Operational notes

Deployment must include these migrations:
- `0010_add_admin_notes_audit_fields.sql`
- `0010_add_updated_at_index.sql`
- `0011_add_fastly_sync_queue.sql`

The build still emits the existing non-failing Browserslist / `baseline-browser-mapping` freshness warnings. That follow-up remains intentionally scoped to the separate tooling issue.

## Validation

- `npm run test:once` passed: `314/314`
- `npm run build:admin` passed

## Test plan

- [ ] Apply migrations `0010_add_admin_notes_audit_fields.sql`, `0010_add_updated_at_index.sql`, and `0011_add_fastly_sync_queue.sql`
- [ ] Deploy and verify hourly cron logs show recent-change count, queued-task count, and sync/delete/failure totals
- [ ] Run `scripts/backfill-fastly-kv.sh --dry-run`, verify counts match active D1 users
- [ ] Run `scripts/backfill-fastly-kv.sh --apply`, then spot-check Fastly KV entries
- [ ] Verify admin dashboard backfill button: confirm, progress, stop/abort, completion
- [ ] Verify username detail page: NIP-05 status indicator and single-user re-sync
- [ ] Spot-check `/.well-known/nostr.json` resolution on several `*.divine.video` names

## Related

- Closes #40
- Follow-up tooling issue covers Browserslist / `baseline-browser-mapping` refresh
