### PR TITLE
fix(admin-ui): reduce Fastly KV sync page limit from 500 to 100

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -314,7 +314,7 @@ export async function updateAdminNotes(
 
 export async function syncFastlyPage(
   cursor?: string | null,
-  limit = 500,
+  limit = 100,
   dryRun = false,
   signal?: AbortSignal
 ): Promise<FastlySyncPageResponse> {

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -51,13 +51,13 @@ export default function Dashboard() {
       abortRef.current = new AbortController()
 
       // Dry run first page to get total count
-      const dryRun = await syncFastlyPage(null, 500, true, abortRef.current.signal)
+      const dryRun = await syncFastlyPage(null, 100, true, abortRef.current.signal)
       const estimatedTotal = dryRun.total_active ?? 0
       setSyncProgress(p => ({ ...p, total: estimatedTotal }))
 
       // Now sync for real
       while (!cancelRef.current) {
-        const result = await syncFastlyPage(cursor, 500, false, abortRef.current.signal)
+        const result = await syncFastlyPage(cursor, 100, false, abortRef.current.signal)
         totalSynced += result.synced ?? 0
         totalFailed += result.failed ?? 0
         setSyncProgress({ synced: totalSynced, failed: totalFailed, total: estimatedTotal })


### PR DESCRIPTION
## Summary

- reduces the admin UI "Sync to Fastly KV" button's page limit from 500 to 100
- limit=500 causes Worker timeout due to concurrent Fastly API calls
- limit=100 was validated during the full 131,951-username backfill on 2026-05-07

## Test plan

- [x] tested paginated sync at limit=100 against production (dry run and writes) — completed 131,951 usernames with 0 failures
- [x] confirmed limit=150+ causes Worker timeout; limit=100 is the safe ceiling