### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     name: Deploy
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`