### PR TITLE
fix(#48): username confusable protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@noble/secp256k1": "^3.0.0",
         "@scure/base": "^2.0.0",
-        "hono": "^4.10.6"
+        "hono": "^4.10.6",
+        "namespace-guard": "^0.20.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251115.0",
@@ -1912,6 +1913,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/namespace-guard": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/namespace-guard/-/namespace-guard-0.20.0.tgz",
+      "integrity": "sha512-C74oYmp+xXu4DPX114TN1Cx31SG236Ns02uhecVg/4stei6XzcS2XuG1T50HLr4uCkcd7szlfzNeuxcjfiCJnA==",
+      "license": "MIT",
+      "bin": {
+        "namespace-guard": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=5.0.0",
+        "@prisma/client": ">=5.0.0",
+        "drizzle-orm": ">=0.29.0",
+        "knex": ">=2.0.0",
+        "kysely": ">=0.26.0",
+        "mongoose": ">=7.0.0",
+        "pg": ">=8.0.0",
+        "sequelize": ">=6.0.0",
+        "typeorm": ">=0.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1959,7 +2009,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.11.0",
@@ -1995,14 +2045,14 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
       "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -2012,7 +2062,7 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
       "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -2022,14 +2072,14 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
       "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -2046,7 +2096,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -2105,7 +2155,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2115,7 +2165,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2125,7 +2175,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2135,7 +2185,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -2270,7 +2320,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -2700,7 +2750,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@noble/secp256k1": "^3.0.0",
     "@scure/base": "^2.0.0",
-    "hono": "^4.10.6"
+    "hono": "^4.10.6",
+    "namespace-guard": "^0.20.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251115.0",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -95,6 +95,18 @@ export async function getUsernameByName(
   return result
 }
 
+export async function getPotentialConfusableUsernames(
+  db: D1Database
+): Promise<Array<Pick<Username, 'name' | 'username_display' | 'username_canonical' | 'status' | 'reservation_expires_at'>>> {
+  const result = await db.prepare(
+    `SELECT name, username_display, username_canonical, status, reservation_expires_at
+     FROM usernames
+     WHERE status IN ('active', 'reserved', 'burned', 'pending-confirmation')`
+  ).bind().all<Pick<Username, 'name' | 'username_display' | 'username_canonical' | 'status' | 'reservation_expires_at'>>()
+
+  return result.results
+}
+
 export async function getUsernameByPubkey(
   db: D1Database,
   pubkey: string

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -256,16 +256,17 @@ describe('GET /admin/username/:name/nip05-status', () => {
     expect(json.status).toBe('missing')
   })
 
-  it('returns not_applicable for non-active usernames', async () => {
+  it('returns missing for revoked usernames when key is absent', async () => {
     getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'revoked', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: undefined })
 
     const app = createTestApp()
     const req = new Request('http://localhost/admin/username/alice/nip05-status')
     const res = await app.fetch(req, baseEnv, ctx)
     const json = await res.json() as any
 
-    expect(json.status).toBe('not_applicable')
-    expect(readUsernameFromFastly).not.toHaveBeenCalled()
+    expect(json.status).toBe('missing')
+    expect(readUsernameFromFastly).toHaveBeenCalled()
   })
 
   it('returns not_applicable for active usernames without pubkey', async () => {

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -441,6 +441,33 @@ describe('Admin Bulk Reserve Endpoint', () => {
     expect(result.error).toContain('underscores')
   })
 
+  it('should reject visually confusable usernames in bulk', async () => {
+    const app = createTestApp()
+    const db = createFakeD1([
+      {
+        id: 1, name: 'matt', username_display: 'matt', username_canonical: 'matt',
+        pubkey: 'a'.repeat(64), email: null, relays: null, status: 'active',
+        recyclable: 1, created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+        revoked_at: null, reserved_reason: null, admin_notes: null,
+      }
+    ])
+
+    const req = new Request('http://localhost/admin/username/reserve-bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ names: 'mаtt' }) // Cyrillic "а"
+    })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.total).toBe(1)
+    expect(json.results[0].success).toBe(false)
+    expect(json.results[0].status).toBe('confusable')
+    expect(json.results[0].error).toContain('Visually confusable')
+  })
+
   it('should strip @ symbols from usernames', async () => {
     const app = createTestApp()
 

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,9 +5,10 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchSort } from '../db/queries'
+import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, getPotentialConfusableUsernames, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername, usernameKVDataMatches } from '../utils/fastly-sync'
+import { findUsernameConfusableCollision, getConfusableCollision } from '../utils/username-confusable'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
@@ -346,6 +347,14 @@ admin.post('/username/reserve', async (c) => {
       return c.json({ ok: false, error }, 409)
     }
 
+    const confusableCollision = await getConfusableCollision(c.env.DB, usernameData.display, usernameData.canonical)
+    if (confusableCollision) {
+      return c.json({
+        ok: false,
+        error: `Username is visually confusable with existing name "${confusableCollision.canonical}"`
+      }, 409)
+    }
+
     // Include override reason in the reserved_reason if provided
     const finalReason = overrideReason ? `${reason} [Override: ${overrideReason}]` : reason
     const createdBy = (c.get('adminEmail' as never) as string) || null
@@ -397,6 +406,7 @@ admin.post('/username/reserve-bulk', async (c) => {
 
     // Process each name
     const createdBy = (c.get('adminEmail' as never) as string) || null
+    const confusableCandidates = await getPotentialConfusableUsernames(c.env.DB)
     const results = []
     for (const name of nameList) {
       try {
@@ -416,7 +426,30 @@ admin.post('/username/reserve-bulk', async (c) => {
           }
           continue
         }
+
+        const confusableCollision = findUsernameConfusableCollision(
+          usernameData.display,
+          usernameData.canonical,
+          confusableCandidates
+        )
+        if (confusableCollision) {
+          results.push({
+            name,
+            status: 'confusable',
+            success: false,
+            error: `Visually confusable with existing name "${confusableCollision.candidateCanonical}"`
+          })
+          continue
+        }
+
         await reserveUsername(c.env.DB, usernameData.display, usernameData.canonical, reason, 'bulk-upload', createdBy)
+        confusableCandidates.push({
+          name: usernameData.canonical,
+          username_display: usernameData.display,
+          username_canonical: usernameData.canonical,
+          status: 'reserved',
+          reservation_expires_at: null
+        })
         results.push({ name, status: 'reserved', success: true })
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
@@ -530,6 +563,14 @@ admin.post('/username/assign', async (c) => {
       throw error
     }
 
+    const confusableCollision = await getConfusableCollision(c.env.DB, usernameData.display, usernameData.canonical)
+    if (confusableCollision) {
+      return c.json({
+        ok: false,
+        error: `Username is visually confusable with existing name "${confusableCollision.canonical}"`
+      }, 409)
+    }
+
     const createdBy = (c.get('adminEmail' as never) as string) || null
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
 
@@ -592,6 +633,7 @@ admin.post('/username/assign-bulk', async (c) => {
 
     // Process each assignment
     const createdBy = (c.get('adminEmail' as never) as string) || null
+    const confusableCandidates = await getPotentialConfusableUsernames(c.env.DB)
     const results = []
     for (const assignment of assignments) {
       const { name, pubkey } = assignment
@@ -628,7 +670,29 @@ admin.post('/username/assign-bulk', async (c) => {
           }
         }
 
+        const confusableCollision = findUsernameConfusableCollision(
+          usernameData.display,
+          usernameData.canonical,
+          confusableCandidates
+        )
+        if (confusableCollision) {
+          results.push({
+            name,
+            status: 'confusable',
+            success: false,
+            error: `Visually confusable with existing name "${confusableCollision.candidateCanonical}"`
+          })
+          continue
+        }
+
         await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'bulk-upload', createdBy)
+        confusableCandidates.push({
+          name: usernameData.canonical,
+          username_display: usernameData.display,
+          username_canonical: usernameData.canonical,
+          status: 'active',
+          reservation_expires_at: null
+        })
 
         // Sync to Fastly — no read-back verification on bulk to avoid doubling API calls
         c.executionCtx.waitUntil(

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -84,6 +84,14 @@ function createMockDB(initialUsernames: any[] = []) {
               return null
             },
             all: async () => {
+              // Confusable candidate lookup for blocking statuses
+              if (sql.includes('FROM usernames') && sql.includes('status IN')) {
+                return {
+                  results: mockUsernames.filter((u: any) =>
+                    ['active', 'reserved', 'burned', 'pending-confirmation'].includes(u.status)
+                  )
+                }
+              }
               return { results: [] }
             },
             run: async () => {
@@ -297,6 +305,33 @@ describe('Username Claiming - Case Insensitive', () => {
     expect(res2.status).toBe(409) // Conflict
     const json2 = await res2.json() as any
     expect(json2.error).toBe('That username is already taken')
+  })
+
+  it('should reject confusable collisions during claim', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      id: 1,
+      name: 'matt',
+      username_display: 'matt',
+      username_canonical: 'matt',
+      pubkey: 'a'.repeat(64),
+      status: 'active',
+      reservation_expires_at: null
+    }])
+
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'mаtt' }) // Cyrillic "а"
+    })
+
+    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    expect(res.status).toBe(409)
+    const json = await res.json() as any
+    expect(json.error).toContain('visually confusable')
   })
 
   it('should validate username format correctly', async () => {
@@ -603,6 +638,31 @@ describe('Public Username Endpoints', () => {
       expect(json.name).toBe('MrBeast')
       expect(json.canonical).toBe('mrbeast')
     })
+
+    it('should return unavailable for visually confusable usernames', async () => {
+      const app = createTestApp()
+      const db = createMockDB([{
+        id: 1,
+        name: 'matt',
+        username_display: 'matt',
+        username_canonical: 'matt',
+        pubkey: 'a'.repeat(64),
+        status: 'active',
+        reservation_expires_at: null
+      }])
+
+      const req = new Request(`http://localhost/api/username/check/${encodeURIComponent('mаtt')}`, {
+        method: 'GET'
+      })
+
+      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      expect(res.status).toBe(200)
+      const json = await res.json() as any
+      expect(json.ok).toBe(true)
+      expect(json.available).toBe(false)
+      expect(json.code).toBe('confusable')
+      expect(json.reason).toContain('visually confusable')
+    })
   })
 
   describe('GET /by-pubkey/:pubkey - Lookup by Pubkey', () => {
@@ -823,6 +883,26 @@ describe('Public Name Reservation', () => {
       const json = await res.json() as any
       expect(json.ok).toBe(false)
       expect(json.error).toContain('pending email confirmation')
+    })
+
+    it('should reject reservation for visually confusable username', async () => {
+      const app = createTestApp()
+      const db = createMockDB([{
+        id: 1, name: 'matt', username_display: 'matt', username_canonical: 'matt',
+        pubkey: 'a'.repeat(64), status: 'active', reservation_expires_at: null
+      }])
+
+      const req = new Request('http://localhost/api/username/reserve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'mаtt', email: 'alice@example.com', cashu_token: mockCashuToken() })
+      })
+
+      const res = await app.fetch(req, { DB: db, ALLOWED_MINTS: 'https://testmint.example.com' }, mockEnv)
+      expect(res.status).toBe(409)
+      const json = await res.json() as any
+      expect(json.ok).toBe(false)
+      expect(json.error).toContain('visually confusable')
     })
 
     it('should allow reservation when pending-confirmation has expired', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -19,6 +19,7 @@ import {
   enqueueFastlySyncTask,
 } from '../db/queries'
 import { syncAndVerifyUsername, deleteUsernameFromFastly } from '../utils/fastly-sync'
+import { getConfusableCollision } from '../utils/username-confusable'
 import { sendReservationConfirmationEmail } from '../utils/email'
 import {
   parseCashuToken,
@@ -121,6 +122,18 @@ username.get('/check/:name', async (c) => {
         // "taken by me" (admin-assigned) from "taken by someone else".
         // Pubkeys are already public via NIP-05 resolution.
         ...(existing.status === 'active' && existing.pubkey ? { pubkey: existing.pubkey.toLowerCase() } : {})
+      }, 200, { 'Access-Control-Allow-Origin': '*' })
+    }
+
+    const confusableCollision = await getConfusableCollision(c.env.DB, usernameData.display, usernameData.canonical)
+    if (confusableCollision) {
+      return c.json({
+        ok: true,
+        available: false,
+        name: usernameData.display,
+        canonical: usernameData.canonical,
+        code: 'confusable',
+        reason: `Username is visually confusable with existing name "${confusableCollision.canonical}"`
       }, 200, { 'Access-Control-Allow-Origin': '*' })
     }
 
@@ -248,6 +261,14 @@ username.post('/reserve', async (c) => {
         }
       }
       // Expired pending-confirmation or revoked: allow re-reservation
+    }
+
+    const confusableCollision = await getConfusableCollision(c.env.DB, nameDisplay, nameCanonical)
+    if (confusableCollision) {
+      return c.json({
+        ok: false,
+        error: `Username is visually confusable with existing name "${confusableCollision.canonical}"`
+      }, 409, { 'Access-Control-Allow-Origin': '*' })
     }
 
     // Rate limit: max 5 reservations per email per hour
@@ -468,6 +489,14 @@ username.post('/claim', async (c) => {
         return c.json({ ok: false, error: 'Username is pending email confirmation' }, 409)
       }
       // If revoked and recyclable, allow claim (continue below)
+    }
+
+    const confusableCollision = await getConfusableCollision(c.env.DB, nameDisplay, nameCanonical)
+    if (confusableCollision) {
+      return c.json({
+        ok: false,
+        error: `Username is visually confusable with existing name "${confusableCollision.canonical}"`
+      }, 409)
     }
 
     // Check if pubkey already has an active username

--- a/src/utils/username-confusable.test.ts
+++ b/src/utils/username-confusable.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { findUsernameConfusableCollision, toUsernameSkeleton, type UsernameConfusableCandidate } from './username-confusable'
+
+describe('username confusable detection', () => {
+  it('generates the same skeleton for cross-script lookalikes', () => {
+    const ascii = toUsernameSkeleton('matt')
+    const mixedScript = toUsernameSkeleton('mаtt') // Cyrillic "а"
+    expect(ascii).toBe(mixedScript)
+  })
+
+  it('finds a collision against active usernames', () => {
+    const candidates: UsernameConfusableCandidate[] = [{
+      name: 'matt',
+      username_display: 'matt',
+      username_canonical: 'matt',
+      status: 'active',
+      reservation_expires_at: null
+    }]
+
+    const collision = findUsernameConfusableCollision('mаtt', 'xn--mtt-5cd', candidates)
+    expect(collision).not.toBeNull()
+    expect(collision?.candidateCanonical).toBe('matt')
+  })
+
+  it('ignores collisions against the same canonical username', () => {
+    const candidates: UsernameConfusableCandidate[] = [{
+      name: 'matt',
+      username_display: 'matt',
+      username_canonical: 'matt',
+      status: 'active',
+      reservation_expires_at: null
+    }]
+
+    const collision = findUsernameConfusableCollision('matt', 'matt', candidates)
+    expect(collision).toBeNull()
+  })
+
+  it('ignores revoked usernames', () => {
+    const candidates: UsernameConfusableCandidate[] = [{
+      name: 'matt',
+      username_display: 'matt',
+      username_canonical: 'matt',
+      status: 'revoked',
+      reservation_expires_at: null
+    }]
+
+    const collision = findUsernameConfusableCollision('mаtt', 'xn--mtt-5cd', candidates)
+    expect(collision).toBeNull()
+  })
+
+  it('ignores expired pending-confirmation usernames', () => {
+    const now = Math.floor(Date.now() / 1000)
+    const candidates: UsernameConfusableCandidate[] = [{
+      name: 'matt',
+      username_display: 'matt',
+      username_canonical: 'matt',
+      status: 'pending-confirmation',
+      reservation_expires_at: now - 60
+    }]
+
+    const collision = findUsernameConfusableCollision('mаtt', 'xn--mtt-5cd', candidates, now)
+    expect(collision).toBeNull()
+  })
+})

--- a/src/utils/username-confusable.ts
+++ b/src/utils/username-confusable.ts
@@ -1,0 +1,111 @@
+import { skeleton } from 'namespace-guard'
+import { getPotentialConfusableUsernames, type Username } from '../db/queries'
+
+export type UsernameConfusableCandidate = Pick<
+  Username,
+  'name' | 'username_display' | 'username_canonical' | 'status' | 'reservation_expires_at'
+>
+
+export interface UsernameConfusableCollision {
+  candidate: UsernameConfusableCandidate
+  candidateCanonical: string
+}
+
+function getCandidateCanonical(candidate: UsernameConfusableCandidate): string | null {
+  if (candidate.username_canonical && candidate.username_canonical.length > 0) {
+    return candidate.username_canonical.toLowerCase()
+  }
+
+  if (candidate.name && candidate.name.length > 0) {
+    return candidate.name.toLowerCase()
+  }
+
+  return null
+}
+
+function getCandidateSkeletonSource(candidate: UsernameConfusableCandidate): string | null {
+  if (candidate.username_display && candidate.username_display.length > 0) {
+    return candidate.username_display
+  }
+
+  if (candidate.username_canonical && candidate.username_canonical.length > 0) {
+    return candidate.username_canonical
+  }
+
+  if (candidate.name && candidate.name.length > 0) {
+    return candidate.name
+  }
+
+  return null
+}
+
+function isCandidateBlocking(
+  candidate: UsernameConfusableCandidate,
+  now = Math.floor(Date.now() / 1000)
+): boolean {
+  if (candidate.status === 'active' || candidate.status === 'reserved' || candidate.status === 'burned') {
+    return true
+  }
+
+  if (candidate.status === 'pending-confirmation') {
+    return candidate.reservation_expires_at === null || candidate.reservation_expires_at >= now
+  }
+
+  return false
+}
+
+export function toUsernameSkeleton(input: string): string {
+  // Apply NFKC first so canonical equivalents collapse before skeleton mapping.
+  return skeleton(input.normalize('NFKC'))
+}
+
+export async function getConfusableCollision(
+  db: D1Database,
+  nameDisplay: string,
+  nameCanonical: string
+): Promise<{ canonical: string; status: string } | null> {
+  const candidates = await getPotentialConfusableUsernames(db)
+  const collision = findUsernameConfusableCollision(nameDisplay, nameCanonical, candidates)
+  if (!collision) {
+    return null
+  }
+
+  return {
+    canonical: collision.candidateCanonical,
+    status: collision.candidate.status
+  }
+}
+
+export function findUsernameConfusableCollision(
+  display: string,
+  canonical: string,
+  candidates: UsernameConfusableCandidate[],
+  now = Math.floor(Date.now() / 1000)
+): UsernameConfusableCollision | null {
+  const targetSkeleton = toUsernameSkeleton(display)
+
+  for (const candidate of candidates) {
+    if (!isCandidateBlocking(candidate, now)) {
+      continue
+    }
+
+    const candidateCanonical = getCandidateCanonical(candidate)
+    if (!candidateCanonical || candidateCanonical === canonical) {
+      continue
+    }
+
+    const skeletonSource = getCandidateSkeletonSource(candidate)
+    if (!skeletonSource) {
+      continue
+    }
+
+    if (toUsernameSkeleton(skeletonSource) === targetSkeleton) {
+      return {
+        candidate,
+        candidateCanonical
+      }
+    }
+  }
+
+  return null
+}

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -135,6 +135,12 @@ describe('validateUsername', () => {
       expect(result.display).toBe('Mr-Beast-123')
       expect(result.canonical).toBe('mr-beast-123')
     })
+
+    it('should normalize NFKC compatibility characters before storing', () => {
+      const result = validateUsername('Ａｌｉｃｅ')
+      expect(result.display).toBe('Alice')
+      expect(result.canonical).toBe('alice')
+    })
   })
 
   describe('internationalized domain names (IDN)', () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -51,7 +51,7 @@ function isAsciiLabel(str: string): boolean {
  */
 export function validateUsername(username: string): { display: string; canonical: string } {
   // Trim whitespace
-  const candidate = username.trim()
+  const candidate = username.trim().normalize('NFKC')
 
   // Reject empty
   if (!candidate || candidate.length === 0) {


### PR DESCRIPTION
## Summary

- Added protection against visually confusable usernames (homographs / cross-script lookalikes) using a **skeleton** check (via `namespace-guard`) on registration-related flows.
- Applied **NFKC** normalization at the start of `validateUsername` so equivalent Unicode representations collapse before other rules run.
- New DB helper `getPotentialConfusableUsernames` and utility module `src/utils/username-confusable.ts` (including shared `getConfusableCollision`).
- Public routes: `GET /api/username/check/:name`, `POST /api/username/reserve`, `POST /api/username/claim` — reject with clear messaging; check returns `code: "confusable"` when applicable.
- Admin routes: `POST .../reserve`, `reserve-bulk`, `assign`, `assign-bulk` — same rules; bulk failures for confusables use a consistent `status: "confusable"` (aligned between reserve-bulk and assign-bulk).
- Tests for routes, `username-confusable`, and NFKC in `validation`; separate commit adjusts `nip05-status` expectations for revoked users when the Fastly key is absent.

## Motivation

- Reduces identity-spoofing risk for NIP-05: different bytes/canonical labels (e.g. Latin vs Cyrillic in the same visual slot) that would otherwise both verify.
- Matches the issue recommendation: **skeleton-style detection + NFKC**, without dropping IDN support and without running confusable checks on NIP-05 read/lookup paths.

## Related Issue

- Closes #48

## Validation

- [ ] `npm run test:once`
- [ ] `npm run build:admin`
- [ ] relevant local Wrangler validation if applicable
- [ ] I could not run some validation locally, and I explained why below

## Manual Test Plan / Notes

- Public: `GET /api/username/check/...` for a string that looks like an existing name but uses a different script — expect `available: false`, `code: "confusable"`, HTTP 200.
- `POST /api/username/reserve` and `POST /api/username/claim` with such a name — HTTP 409 and an error mentioning visually confusable.
- Admin: single reserve/assign and bulk paths reject confusable collisions; for `reserve-bulk` / `assign-bulk`, failed rows have `success: false` and `status: "confusable"`.
- Regression: NIP-05 name resolution behavior unchanged (checks are on write/registration paths only).
- Optional follow-up from the issue: audit existing DB rows for confusable pairs (not part of this change).

## Visuals / API Examples

- [x] No visual change
- [ ] Screenshots, sample payloads, or logs attached if needed

Example `check` response when an existing `matt` collides with a visually similar label that punycodes differently:

```json
{
  "ok": true,
  "available": false,
  "name": "…",
  "canonical": "…",
  "code": "confusable",
  "reason": "Username is visually confusable with existing name \"matt\""
}