### PR TITLE
feat: admin restore endpoint for previously banned usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Fields:
 - `name` (required): Username to revoke
 - `burn` (optional): If true, permanently burns the name; if false, makes it recyclable
 
+The `pubkey` column is preserved on `revoked` and `burned` rows so the moderation service can later look up a banned user's names by pubkey and call `/api/admin/username/restore` if the ban is reversed.
+
 **Response (200):**
 ```json
 {
@@ -261,6 +263,43 @@ Fields:
   "recyclable": false
 }
 ```
+
+#### POST /api/admin/username/restore
+
+Restore a previously revoked or burned username and re-bind it to a specific pubkey. Used by the moderation service when a ban is reversed: after `revoke {burn: true}`, the original `pubkey` is preserved on the row so the moderation service can find the user's burned names via `GET /api/admin/usernames/search?q=<pubkey>&status=burned` and call this endpoint to give the name back.
+
+**Request Body:**
+```json
+{
+  "name": "previouslybanned",
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "reason": "Ban reversed by moderation"
+}
+```
+
+Fields:
+- `name` (required): Username to restore (must currently be `revoked` or `burned`)
+- `pubkey` (required): The pubkey to re-bind the name to (hex or npub)
+- `reason` (optional): Audit reason; appended as a timestamped line to `admin_notes`
+
+**Behavior:**
+- Sets `status='active'`, `recyclable=1`, clears `revoked_at`, sets `pubkey`, resets `claimed_at` to now
+- Appends `[<iso-timestamp> restored by <admin-email>]: <reason>` to `admin_notes`
+- If the target pubkey already holds another active name, that other name is revoked first (matches `assign` behavior; required by the partial unique index)
+- Re-syncs the row to Fastly KV via `waitUntil`
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "username": { /* full updated row */ }
+}
+```
+
+**Errors:**
+- `400` — missing/invalid `name` or `pubkey`
+- `404` — username does not exist
+- `409` — username is currently `active` (response includes `current_pubkey`); silently overwriting an active claim is forbidden
 
 #### POST /api/admin/username/assign
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -350,6 +350,63 @@ export async function revokeUsername(
   ).bind(status, recyclable, now, now, canonical, name).run()
 }
 
+/**
+ * Restore a previously revoked or burned username to a specific pubkey.
+ *
+ * Sets status='active', recyclable=1, pubkey=<provided>, clears revoked_at,
+ * resets claimed_at to now, and appends an audit line to admin_notes.
+ *
+ * Caller must verify the row exists and is currently revoked/burned — this
+ * function trusts the caller's status check and performs the update unconditionally.
+ *
+ * Releases any other active username currently held by the target pubkey
+ * (mirrors assignUsername) so the partial unique index on (pubkey,status='active')
+ * is not violated.
+ */
+export async function restoreUsername(
+  db: D1Database,
+  nameCanonical: string,
+  pubkey: string,
+  reason: string | null,
+  restoredBy: string | null
+): Promise<Username | null> {
+  const now = Math.floor(Date.now() / 1000)
+
+  const existing = await getUsernameByName(db, nameCanonical)
+  if (!existing) return null
+
+  const auditLine = `[${new Date(now * 1000).toISOString()} restored by ${restoredBy || 'unknown'}]${reason ? `: ${reason}` : ''}`
+  const newNotes = existing.admin_notes && existing.admin_notes.length > 0
+    ? `${existing.admin_notes}\n${auditLine}`
+    : auditLine
+
+  // Release any other active name held by this pubkey before flipping this row
+  // back to active — the partial unique index forbids two active rows per pubkey.
+  await db.prepare(
+    `UPDATE usernames
+     SET status = 'revoked',
+         revoked_at = ?,
+         updated_at = ?
+     WHERE pubkey = ? AND status = 'active' AND username_canonical != ?`
+  ).bind(now, now, pubkey, nameCanonical).run()
+
+  await db.prepare(
+    `UPDATE usernames
+     SET status = 'active',
+         recyclable = 1,
+         revoked_at = NULL,
+         pubkey = ?,
+         claimed_at = ?,
+         updated_at = ?,
+         admin_notes = ?,
+         admin_notes_updated_by = ?,
+         admin_notes_updated_at = ?
+     WHERE username_canonical = ?`
+  ).bind(pubkey, now, now, newNotes, restoredBy, now, nameCanonical).run()
+
+  return getUsernameByName(db, nameCanonical)
+}
+
 export async function assignUsername(
   db: D1Database,
   nameDisplay: string,

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -261,6 +261,71 @@ export function createFakeD1(records: MockRecord[]) {
             },
 
             run: async () => {
+              // Restore UPDATE — keyed off the unique "SET status = 'active', recyclable = 1, revoked_at = NULL"
+              // shape before the generic admin_notes branch (which would otherwise match because restore
+              // also updates admin_notes).
+              if (
+                sql.includes('UPDATE usernames') &&
+                sql.includes("status = 'active'") &&
+                sql.includes('recyclable = 1') &&
+                sql.includes('revoked_at = NULL') &&
+                sql.includes('admin_notes = ?')
+              ) {
+                const [newPubkey, claimedAt, updatedAt, newNotes, notesBy, notesAt, canonical] = boundParams
+                const rec = records.find(r => r.username_canonical === canonical || r.name === canonical)
+                if (rec) {
+                  rec.status = 'active'
+                  rec.recyclable = 1
+                  rec.revoked_at = null
+                  rec.pubkey = newPubkey
+                  rec.claimed_at = claimedAt
+                  rec.updated_at = updatedAt
+                  rec.admin_notes = newNotes
+                  rec.admin_notes_updated_by = notesBy
+                  rec.admin_notes_updated_at = notesAt
+                }
+                return { success: true, meta: { changes: rec ? 1 : 0 } }
+              }
+              // Revoke UPDATE: status/recyclable/revoked_at/updated_at WHERE canonical OR name
+              if (
+                sql.includes('UPDATE usernames') &&
+                sql.includes('status = ?') &&
+                sql.includes('recyclable = ?') &&
+                sql.includes('revoked_at = ?')
+              ) {
+                const [status, recyclable, revokedAt, updatedAt, canonical, nameParam] = boundParams
+                const rec = records.find(r =>
+                  r.username_canonical === canonical || r.name === nameParam || r.name === canonical
+                )
+                if (rec) {
+                  rec.status = status
+                  rec.recyclable = recyclable
+                  rec.revoked_at = revokedAt
+                  rec.updated_at = updatedAt
+                  // Pubkey is intentionally preserved — moderation service depends on it
+                }
+                return { success: true, meta: { changes: rec ? 1 : 0 } }
+              }
+              // Release-other-active-name UPDATE (restoreUsername's first statement, also assignUsername's):
+              // WHERE pubkey = ? AND status = 'active' [AND username_canonical != ?]
+              if (
+                sql.includes('UPDATE usernames') &&
+                sql.includes("status = 'revoked'") &&
+                sql.includes('pubkey = ?') &&
+                sql.includes("status = 'active'")
+              ) {
+                const [revokedAt, updatedAt, pk, excludeCanonical] = boundParams
+                let changes = 0
+                for (const r of records) {
+                  if (r.pubkey === pk && r.status === 'active' && r.username_canonical !== excludeCanonical) {
+                    r.status = 'revoked'
+                    r.revoked_at = revokedAt
+                    r.updated_at = updatedAt
+                    changes++
+                  }
+                }
+                return { success: true, meta: { changes } }
+              }
               // Admin notes UPDATE
               if (sql.includes('UPDATE usernames') && sql.includes('admin_notes = ?')) {
                 const [adminNotes, updatedBy, updatedAtNotes, updatedAt, id] = boundParams

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -1270,3 +1270,167 @@ describe('Fastly sync endpoints', () => {
     expect(json.reason).toContain('still present')
   })
 })
+
+describe('POST /api/admin/username/restore', () => {
+  const VALID_PUBKEY = 'a'.repeat(64)
+  const OTHER_PUBKEY = 'b'.repeat(64)
+
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string; FASTLY_API_TOKEN?: string; FASTLY_STORE_ID?: string } }>()
+    app.route('/api/admin', admin)
+    return app
+  }
+
+  function callRestore(app: Hono<any>, env: any, body: any) {
+    const req = new Request('http://localhost/api/admin/username/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+  }
+
+  it('restores a burned username back to active for the provided pubkey', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'banneduser', username_display: 'banneduser', username_canonical: 'banneduser',
+        pubkey: OTHER_PUBKEY, email: null, relays: null, status: 'burned',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000100,
+        claimed_at: 1700000000, revoked_at: 1700000100, reserved_reason: null,
+        admin_notes: 'existing notes',
+      },
+    ])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, {
+      name: 'banneduser', pubkey: VALID_PUBKEY, reason: 'ban reversed',
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.username.status).toBe('active')
+    expect(json.username.recyclable).toBe(1)
+    expect(json.username.revoked_at).toBeNull()
+    expect(json.username.pubkey).toBe(VALID_PUBKEY)
+    expect(json.username.admin_notes).toContain('existing notes')
+    expect(json.username.admin_notes).toContain('restored by')
+    expect(json.username.admin_notes).toContain('ban reversed')
+  })
+
+  it('restores a revoked username back to active', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'rev-user', username_display: 'rev-user', username_canonical: 'rev-user',
+        pubkey: OTHER_PUBKEY, email: null, relays: null, status: 'revoked',
+        recyclable: 1, created_at: 1700000000, updated_at: 1700000100,
+        claimed_at: 1700000000, revoked_at: 1700000100, reserved_reason: null,
+        admin_notes: null,
+      },
+    ])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, {
+      name: 'rev-user', pubkey: VALID_PUBKEY,
+    })
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.username.status).toBe('active')
+    expect(json.username.pubkey).toBe(VALID_PUBKEY)
+    expect(json.username.revoked_at).toBeNull()
+  })
+
+  it('returns 404 when the username does not exist', async () => {
+    const db = createFakeD1([])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, {
+      name: 'ghost', pubkey: VALID_PUBKEY,
+    })
+    expect(res.status).toBe(404)
+    const json = await res.json() as any
+    expect(json.ok).toBe(false)
+    expect(json.error).toContain('not found')
+  })
+
+  it('returns 409 when the username is currently active', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'liveuser', username_display: 'liveuser', username_canonical: 'liveuser',
+        pubkey: OTHER_PUBKEY, email: null, relays: null, status: 'active',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000,
+        claimed_at: 1700000000, revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+    ])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, {
+      name: 'liveuser', pubkey: VALID_PUBKEY,
+    })
+    expect(res.status).toBe(409)
+    const json = await res.json() as any
+    expect(json.ok).toBe(false)
+    expect(json.current_pubkey).toBe(OTHER_PUBKEY)
+    // Active row must NOT have been overwritten
+    const row = await getUsernameByName(db, 'liveuser')
+    expect(row?.pubkey).toBe(OTHER_PUBKEY)
+    expect(row?.status).toBe('active')
+  })
+
+  it('search by pubkey&status=burned finds the row after revoke-with-burn', async () => {
+    // Seed an active user, burn them, then look them up by pubkey filtered to burned status.
+    // This is the moderation-service discovery flow: ban → revoke{burn:true} → later find
+    // burned names owned by the banned pubkey so we know what to restore.
+    const db = createFakeD1([
+      {
+        id: 1, name: 'abuser', username_display: 'abuser', username_canonical: 'abuser',
+        pubkey: VALID_PUBKEY, email: null, relays: null, status: 'active',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000,
+        claimed_at: 1700000000, revoked_at: null, reserved_reason: null, admin_notes: null,
+      },
+    ])
+    const app = createTestApp()
+
+    const revokeReq = new Request('http://localhost/api/admin/username/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'abuser', burn: true }),
+    })
+    const revokeRes = await app.fetch(revokeReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    expect(revokeRes.status).toBe(200)
+
+    // pubkey must be preserved through burn so moderation can find it
+    const after = await getUsernameByName(db, 'abuser')
+    expect(after?.status).toBe('burned')
+    expect(after?.pubkey).toBe(VALID_PUBKEY)
+
+    const searchReq = new Request(`http://localhost/api/admin/usernames/search?q=${VALID_PUBKEY}&status=burned`)
+    const searchRes = await app.fetch(searchReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    expect(searchRes.status).toBe(200)
+    const json = await searchRes.json() as any
+    expect(json.ok).toBe(true)
+    expect(json.results).toHaveLength(1)
+    expect(json.results[0].name).toBe('abuser')
+    expect(json.results[0].pubkey).toBe(VALID_PUBKEY)
+    expect(json.results[0].status).toBe('burned')
+  })
+
+  it('rejects an invalid pubkey', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'banneduser', username_display: 'banneduser', username_canonical: 'banneduser',
+        pubkey: OTHER_PUBKEY, email: null, relays: null, status: 'burned',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000100,
+        claimed_at: 1700000000, revoked_at: 1700000100, reserved_reason: null, admin_notes: null,
+      },
+    ])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, {
+      name: 'banneduser', pubkey: 'not-a-pubkey',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('requires name and pubkey', async () => {
+    const db = createFakeD1([])
+    const app = createTestApp()
+    const res = await callRestore(app, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { name: 'x' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,7 +5,7 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchSort } from '../db/queries'
+import { reserveUsername, revokeUsername, restoreUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername, usernameKVDataMatches } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
@@ -486,6 +486,96 @@ admin.post('/username/revoke', async (c) => {
     })
   } catch (error) {
     console.error('Revoke error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.post('/username/restore', async (c) => {
+  try {
+    const body = await c.req.json<{ name: string; pubkey: string; reason?: string }>()
+    const { name, pubkey, reason } = body
+
+    if (!name || !pubkey) {
+      return c.json({ ok: false, error: 'Name and pubkey are required' }, 400)
+    }
+
+    let usernameData: { display: string; canonical: string }
+    try {
+      usernameData = validateUsername(name)
+    } catch (error) {
+      if (error instanceof UsernameValidationError) {
+        return c.json({ ok: false, error: error.message }, 400)
+      }
+      throw error
+    }
+
+    let normalizedPubkey: string
+    try {
+      normalizedPubkey = validateAndNormalizePubkey(pubkey)
+    } catch (error) {
+      if (error instanceof PubkeyValidationError) {
+        return c.json({ ok: false, error: error.message }, 400)
+      }
+      throw error
+    }
+
+    const existing = await getUsernameByName(c.env.DB, usernameData.canonical)
+    if (!existing) {
+      return c.json({ ok: false, error: 'Username not found' }, 404)
+    }
+
+    if (existing.status === 'active') {
+      return c.json({
+        ok: false,
+        error: 'Username is currently active; revoke before restoring',
+        current_pubkey: existing.pubkey,
+      }, 409)
+    }
+
+    if (existing.status !== 'revoked' && existing.status !== 'burned') {
+      return c.json({
+        ok: false,
+        error: `Cannot restore from status '${existing.status}'`,
+      }, 409)
+    }
+
+    const restoredBy = (c.get('adminEmail' as never) as string) || null
+    const updated = await restoreUsername(
+      c.env.DB,
+      usernameData.canonical,
+      normalizedPubkey,
+      reason || null,
+      restoredBy
+    )
+
+    const relays = parseRelayHints(existing.relays)
+    const fastlyData = {
+      pubkey: normalizedPubkey,
+      relays,
+      status: 'active' as const,
+      atproto_did: existing.atproto_did || null,
+      atproto_state: existing.atproto_state || null,
+    }
+
+    c.executionCtx.waitUntil(
+      syncAndVerifyUsername(c.env, usernameData.canonical, fastlyData).then(async (result) => {
+        if (!result.success || !result.verified) {
+          await enqueueFastlySyncTask(c.env.DB, {
+            username: usernameData.canonical,
+            action: 'sync',
+            data: fastlyData,
+          })
+        }
+      })
+    )
+
+    console.log(
+      `Username "${usernameData.canonical}" restored to ${normalizedPubkey.slice(0, 8)}... by ${restoredBy || 'unknown'}${reason ? ` (reason: ${reason})` : ''}`
+    )
+
+    return c.json({ ok: true, username: updated })
+  } catch (error) {
+    console.error('Restore error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })


### PR DESCRIPTION
## Summary

Adds `POST /api/admin/username/restore` so the moderation service can reverse a ban: after `revoke {burn: true}` retired a user's `<name>.divine.video`, this endpoint re-binds the name to the original pubkey.

- `200` → flips `status='active'`, `recyclable=1`, `revoked_at=NULL`, sets `pubkey`, resets `claimed_at=now`, appends a timestamped audit line to `admin_notes`, and re-syncs to Fastly KV via `waitUntil`.
- `404` → row does not exist.
- `409` → row is currently `active` (response includes `current_pubkey`); silently overwriting an active claim is forbidden.

## Requirement-2 decision (per task spec)

The task gave two options for letting the moderation service look up a banned user's burned names by pubkey:
1. Keep `pubkey` populated on `revoked`/`burned` rows.
2. Add a `previous_pubkey` column and copy on revoke.

**Choice: option 1 (zero-diff).** The existing `revokeUsername` query already preserves `pubkey` — it only updates `status`, `recyclable`, `revoked_at`, `updated_at`. No schema change needed. The README's revoke section now documents that this preservation is load-bearing for the moderation workflow, and a regression test (`search by pubkey&status=burned finds the row after revoke-with-burn`) locks in the behavior.

## Other notes for reviewers

- **Side effect worth flagging**: if the target pubkey already holds another active name, `restoreUsername` revokes that other row before flipping the target row to active. This mirrors `assignUsername`'s existing behavior and is required by the partial unique index on `(pubkey, status='active')`. The task spec only specified the 409 case for the *name being restored*; this handles the orthogonal collision.
- **`claimed_at` on restore**: reset to now (treated as a fresh claim — consistent with `assignUsername`'s UPSERT).
- **Audit field**: revoke does not actually write `reason` anywhere today, so there was no pattern to mirror. Restore appends `[<iso-timestamp> restored by <admin-email>]: <reason>` to `admin_notes` so the trail is preserved without a new migration.

## Pre-existing issues (not introduced here)

- `admin-sync.test.ts:267` fails on `main` already (`not_applicable` expected for revoked status, code returns `missing`).
- `tsc --noEmit` reports one pre-existing error in `admin.ts` on the `sync-to-fastly` route's `pubkey: string | null` argument.

## Test plan
- [x] `npx vitest run src/routes/admin.test.ts` — 76/76 pass (7 new restore tests)
- [x] `npx vitest run src/routes/username.test.ts` — 35/35 pass
- [x] Full `npx vitest run` — only the one pre-existing failure above
- [ ] Smoke test against staging once deployed: revoke with burn → search by pubkey&status=burned → restore → confirm `<name>.divine.video` resolves at the edge again

🤖 Generated with [Claude Code](https://claude.com/claude-code)