### PR TITLE
test: align admin Fastly status expectation

### DIFF
--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -256,16 +256,17 @@ describe('GET /admin/username/:name/nip05-status', () => {
     expect(json.status).toBe('missing')
   })
 
-  it('returns not_applicable for non-active usernames', async () => {
+  it('returns missing for revoked usernames absent from Fastly', async () => {
     getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'revoked', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: undefined })
 
     const app = createTestApp()
     const req = new Request('http://localhost/admin/username/alice/nip05-status')
     const res = await app.fetch(req, baseEnv, ctx)
     const json = await res.json() as any
 
-    expect(json.status).toBe('not_applicable')
-    expect(readUsernameFromFastly).not.toHaveBeenCalled()
+    expect(json.status).toBe('missing')
+    expect(readUsernameFromFastly).toHaveBeenCalledWith(baseEnv, 'alice')
   })
 
   it('returns not_applicable for active usernames without pubkey', async () => {


### PR DESCRIPTION
## Summary

Updates the stale admin Fastly status test for revoked usernames to match the current route contract.

## Motivation

The admin NIP-05 status endpoint now checks revoked and burned usernames against Fastly so operators can confirm stale KV records are absent. The old test still expected revoked usernames to be `not_applicable` and to skip the Fastly read entirely, which made `npm run test:once` fail on `main`.

Closes #54

## Manual Validation

- `npm run test:once -- src/routes/admin-sync.test.ts`
- `npm run test:once`

## Visuals / API Examples

No visual change. Test-only update.

## Public Artifact Review

PR title, branch name, and description avoid sensitive external identities.
