### PR TITLE
fix: harden username restore and WebFinger

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates search functionality with fake D1 database
 
 import { describe, it, expect } from 'vitest'
-import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, getActiveUsernamesPaginated, countActiveUsernames, enqueueFastlySyncTask, getQueuedFastlySyncTasks, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchParams, type Username } from './queries'
+import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, restoreUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, getActiveUsernamesPaginated, countActiveUsernames, enqueueFastlySyncTask, getQueuedFastlySyncTasks, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
 const mockRecords: MockRecord[] = [
@@ -245,6 +245,59 @@ describe('assignUsername', () => {
     const insertSql = sqlStatements[1]
     expect(insertSql).toContain('ON CONFLICT')
     expect(insertSql).toContain('revoked_at = NULL')
+  })
+})
+
+describe('restoreUsername', () => {
+  it('releases the target pubkey active name and clears previous owner identity on owner change', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'oldactive', username_display: 'oldactive', username_canonical: 'oldactive',
+        pubkey: 'new-owner', status: 'active', relays: null, atproto_did: null, atproto_state: null,
+        created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+      },
+      {
+        id: 2, name: 'restoreme', username_display: 'restoreme', username_canonical: 'restoreme',
+        pubkey: 'prior-owner', status: 'burned', relays: '["wss://relay.example"]',
+        atproto_did: 'did:plc:prior', atproto_state: 'ready',
+        recyclable: 0, created_at: 1700000000, updated_at: 1700000000,
+        claimed_at: 1700000000, revoked_at: 1700000000,
+      },
+    ])
+
+    const result = await restoreUsername(db, 'restoreme', 'new-owner', 'appeal accepted', 'admin@example.com')
+
+    expect(result?.username.status).toBe('active')
+    expect(result?.username.pubkey).toBe('new-owner')
+    expect(result?.username.relays).toBeNull()
+    expect(result?.username.atproto_did).toBeNull()
+    expect(result?.username.atproto_state).toBeNull()
+    expect(result?.releasedUsernameCanonical).toBe('oldactive')
+    expect(result?.ownerChanged).toBe(true)
+
+    const oldActive = await getUsernameByName(db, 'oldactive')
+    expect(oldActive?.status).toBe('revoked')
+  })
+
+  it('returns null and does not release an active name when the target is no longer restorable', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'oldactive', username_display: 'oldactive', username_canonical: 'oldactive',
+        pubkey: 'new-owner', status: 'active',
+        created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+      },
+      {
+        id: 2, name: 'restoreme', username_display: 'restoreme', username_canonical: 'restoreme',
+        pubkey: 'prior-owner', status: 'active',
+        created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+      },
+    ])
+
+    const result = await restoreUsername(db, 'restoreme', 'new-owner', null, 'admin@example.com')
+
+    expect(result).toBeNull()
+    const oldActive = await getUsernameByName(db, 'oldactive')
+    expect(oldActive?.status).toBe('active')
   })
 })
 

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -279,7 +279,10 @@ describe('restoreUsername', () => {
     expect(oldActive?.status).toBe('revoked')
   })
 
-  it('returns null and does not release an active name when the target is no longer restorable', async () => {
+  it('returns null at the pre-batch status guard when the target is already active', async () => {
+    // Target seeded active: restoreUsername short-circuits at the status precondition
+    // (before db.batch), so no other name is released. This covers the precondition
+    // check only, not the in-batch EXISTS guard (see the TOCTOU test below).
     const db = createFakeD1([
       {
         id: 1, name: 'oldactive', username_display: 'oldactive', username_canonical: 'oldactive',
@@ -298,6 +301,41 @@ describe('restoreUsername', () => {
     expect(result).toBeNull()
     const oldActive = await getUsernameByName(db, 'oldactive')
     expect(oldActive?.status).toBe('active')
+  })
+
+  it('returns null without releasing the prior active name when the target is claimed concurrently', async () => {
+    // TOCTOU: the target reads as restorable, but a concurrent claim flips it to active
+    // before the batch runs. The release statement's EXISTS guard must then make the
+    // release a no-op and the restore statement must match zero rows (meta.changes===0),
+    // so restoreUsername returns null and the target pubkey's existing name is untouched.
+    const records: MockRecord[] = [
+      {
+        id: 1, name: 'oldactive', username_display: 'oldactive', username_canonical: 'oldactive',
+        pubkey: 'new-owner', status: 'active',
+        created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000,
+      },
+      {
+        id: 2, name: 'restoreme', username_display: 'restoreme', username_canonical: 'restoreme',
+        pubkey: 'prior-owner', status: 'burned',
+        created_at: 1700000000, updated_at: 1700000000, claimed_at: 1700000000, revoked_at: 1700000000,
+      },
+    ]
+    const db = createFakeD1(records, {
+      onBeforeBatch: () => {
+        const target = records.find((r) => r.username_canonical === 'restoreme')!
+        target.status = 'active'
+        target.pubkey = 'someone-else'
+      },
+    })
+
+    const result = await restoreUsername(db, 'restoreme', 'new-owner', null, 'admin@example.com')
+
+    expect(result).toBeNull()
+    const oldActive = await getUsernameByName(db, 'oldactive')
+    expect(oldActive?.status).toBe('active')
+    const target = await getUsernameByName(db, 'restoreme')
+    expect(target?.status).toBe('active')
+    expect(target?.pubkey).toBe('someone-else')
   })
 })
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -384,6 +384,11 @@ export async function restoreUsername(
     ? `${existing.admin_notes}\n${auditLine}`
     : auditLine
 
+  // Pre-batch read: the name the batch will release, so the caller can delete its
+  // stale Fastly edge record. If a concurrent same-pubkey claim lands between this
+  // read and the batch, the reported released name can lag the actually-revoked one
+  // by a sync cycle; the DB stays correct (transactional batch + partial unique
+  // index) and nip05-status / the Fastly sync queue self-heal the edge.
   const existingActiveForPubkey = await getUsernameByPubkey(db, pubkey)
   const releasedUsernameCanonical = existingActiveForPubkey?.username_canonical &&
     existingActiveForPubkey.username_canonical !== nameCanonical

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -71,6 +71,12 @@ export interface FastlySyncQueueTask extends SyncItem {
   last_error: string | null
 }
 
+export interface RestoreUsernameResult {
+  username: Username
+  releasedUsernameCanonical: string | null
+  ownerChanged: boolean
+}
+
 export async function isReservedWord(
   db: D1Database,
   word: string
@@ -356,9 +362,6 @@ export async function revokeUsername(
  * Sets status='active', recyclable=1, pubkey=<provided>, clears revoked_at,
  * resets claimed_at to now, and appends an audit line to admin_notes.
  *
- * Caller must verify the row exists and is currently revoked/burned — this
- * function trusts the caller's status check and performs the update unconditionally.
- *
  * Releases any other active username currently held by the target pubkey
  * (mirrors assignUsername) so the partial unique index on (pubkey,status='active')
  * is not violated.
@@ -369,42 +372,66 @@ export async function restoreUsername(
   pubkey: string,
   reason: string | null,
   restoredBy: string | null
-): Promise<Username | null> {
+): Promise<RestoreUsernameResult | null> {
   const now = Math.floor(Date.now() / 1000)
 
   const existing = await getUsernameByName(db, nameCanonical)
   if (!existing) return null
+  if (existing.status !== 'revoked' && existing.status !== 'burned') return null
 
   const auditLine = `[${new Date(now * 1000).toISOString()} restored by ${restoredBy || 'unknown'}]${reason ? `: ${reason}` : ''}`
   const newNotes = existing.admin_notes && existing.admin_notes.length > 0
     ? `${existing.admin_notes}\n${auditLine}`
     : auditLine
 
-  // Release any other active name held by this pubkey before flipping this row
-  // back to active — the partial unique index forbids two active rows per pubkey.
-  await db.prepare(
+  const existingActiveForPubkey = await getUsernameByPubkey(db, pubkey)
+  const releasedUsernameCanonical = existingActiveForPubkey?.username_canonical &&
+    existingActiveForPubkey.username_canonical !== nameCanonical
+    ? existingActiveForPubkey.username_canonical
+    : null
+  const ownerChanged = existing.pubkey !== pubkey
+  const relays = ownerChanged ? null : existing.relays
+  const atprotoDid = ownerChanged ? null : existing.atproto_did
+  const atprotoState = ownerChanged ? null : existing.atproto_state
+
+  const releaseStatement = db.prepare(
     `UPDATE usernames
      SET status = 'revoked',
          revoked_at = ?,
          updated_at = ?
-     WHERE pubkey = ? AND status = 'active' AND username_canonical != ?`
-  ).bind(now, now, pubkey, nameCanonical).run()
+     WHERE pubkey = ?
+       AND status = 'active'
+       AND username_canonical != ?
+       AND EXISTS (
+         SELECT 1 FROM usernames
+         WHERE username_canonical = ? AND status IN ('revoked', 'burned')
+       )`
+  ).bind(now, now, pubkey, nameCanonical, nameCanonical)
 
-  await db.prepare(
+  const restoreStatement = db.prepare(
     `UPDATE usernames
      SET status = 'active',
          recyclable = 1,
          revoked_at = NULL,
+         relays = ?,
+         atproto_did = ?,
+         atproto_state = ?,
          pubkey = ?,
          claimed_at = ?,
          updated_at = ?,
          admin_notes = ?,
          admin_notes_updated_by = ?,
          admin_notes_updated_at = ?
-     WHERE username_canonical = ?`
-  ).bind(pubkey, now, now, newNotes, restoredBy, now, nameCanonical).run()
+     WHERE username_canonical = ? AND status IN ('revoked', 'burned')`
+  ).bind(relays, atprotoDid, atprotoState, pubkey, now, now, newNotes, restoredBy, now, nameCanonical)
 
-  return getUsernameByName(db, nameCanonical)
+  const [, restoreResult] = await db.batch([releaseStatement, restoreStatement])
+  if (!restoreResult.meta || restoreResult.meta.changes === 0) return null
+
+  const username = await getUsernameByName(db, nameCanonical)
+  if (!username) return null
+
+  return { username, releasedUsernameCanonical, ownerChanged }
 }
 
 export async function assignUsername(

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -15,7 +15,10 @@ export type MockRecord = Partial<Username> & { name: string; username_canonical:
  * behavior with less coupling to query text and parameter ordering than the
  * old duplicated mocks.
  */
-export function createFakeD1(records: MockRecord[]) {
+export function createFakeD1(
+  records: MockRecord[],
+  options: { onBeforeBatch?: () => void } = {}
+) {
   const tags: { username_id: number; tag: string; created_at: number; created_by: string }[] = []
 
   return {
@@ -375,6 +378,10 @@ export function createFakeD1(records: MockRecord[]) {
       }
     },
     batch: async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      // Lets a test mutate records between restoreUsername's pre-batch reads and the
+      // batch execution, reproducing a concurrent-claim TOCTOU that a single-threaded
+      // fake otherwise cannot, exercising the EXISTS guard + meta.changes===0 path.
+      options.onBeforeBatch?.()
       const results = []
       for (const statement of statements) {
         results.push(await statement.run())

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -166,6 +166,12 @@ export function createFakeD1(records: MockRecord[]) {
                 return { count: filtered.length }
               }
 
+              // Active username lookup by pubkey
+              if (sql.includes('WHERE pubkey = ? AND status = ?')) {
+                const [pubkey, status] = boundParams
+                return records.find((u) => u.pubkey === pubkey && u.status === status) || null
+              }
+
               // Direct username lookup
               if (sql.includes('username_canonical = ?') || sql.includes('name = ?')) {
                 const lookupValues = boundParams.filter((p) => typeof p === 'string')
@@ -271,12 +277,18 @@ export function createFakeD1(records: MockRecord[]) {
                 sql.includes('revoked_at = NULL') &&
                 sql.includes('admin_notes = ?')
               ) {
-                const [newPubkey, claimedAt, updatedAt, newNotes, notesBy, notesAt, canonical] = boundParams
-                const rec = records.find(r => r.username_canonical === canonical || r.name === canonical)
+                const [relays, atprotoDid, atprotoState, newPubkey, claimedAt, updatedAt, newNotes, notesBy, notesAt, canonical] = boundParams
+                const rec = records.find(r =>
+                  (r.username_canonical === canonical || r.name === canonical) &&
+                  (sql.includes("status IN ('revoked', 'burned')") ? (r.status === 'revoked' || r.status === 'burned') : true)
+                )
                 if (rec) {
                   rec.status = 'active'
                   rec.recyclable = 1
                   rec.revoked_at = null
+                  rec.relays = relays
+                  rec.atproto_did = atprotoDid
+                  rec.atproto_state = atprotoState
                   rec.pubkey = newPubkey
                   rec.claimed_at = claimedAt
                   rec.updated_at = updatedAt
@@ -314,10 +326,13 @@ export function createFakeD1(records: MockRecord[]) {
                 sql.includes('pubkey = ?') &&
                 sql.includes("status = 'active'")
               ) {
-                const [revokedAt, updatedAt, pk, excludeCanonical] = boundParams
+                const [revokedAt, updatedAt, pk, excludeCanonical, targetCanonical] = boundParams
+                const targetIsRestorable = !targetCanonical || records.some(
+                  r => r.username_canonical === targetCanonical && (r.status === 'revoked' || r.status === 'burned')
+                )
                 let changes = 0
                 for (const r of records) {
-                  if (r.pubkey === pk && r.status === 'active' && r.username_canonical !== excludeCanonical) {
+                  if (targetIsRestorable && r.pubkey === pk && r.status === 'active' && r.username_canonical !== excludeCanonical) {
                     r.status = 'revoked'
                     r.revoked_at = revokedAt
                     r.updated_at = updatedAt
@@ -358,6 +373,13 @@ export function createFakeD1(records: MockRecord[]) {
           }
         },
       }
+    },
+    batch: async (statements: Array<{ run: () => Promise<unknown> }>) => {
+      const results = []
+      for (const statement of statements) {
+        results.push(await statement.run())
+      }
+      return results
     },
   } as unknown as D1Database
 }

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -256,16 +256,17 @@ describe('GET /admin/username/:name/nip05-status', () => {
     expect(json.status).toBe('missing')
   })
 
-  it('returns not_applicable for non-active usernames', async () => {
+  it('returns missing for revoked usernames absent from Fastly', async () => {
     getUsernameByName.mockResolvedValue({ name: 'alice', pubkey: 'pk1', status: 'revoked', relays: null })
+    readUsernameFromFastly.mockResolvedValue({ success: true, data: undefined })
 
     const app = createTestApp()
     const req = new Request('http://localhost/admin/username/alice/nip05-status')
     const res = await app.fetch(req, baseEnv, ctx)
     const json = await res.json() as any
 
-    expect(json.status).toBe('not_applicable')
-    expect(readUsernameFromFastly).not.toHaveBeenCalled()
+    expect(json.status).toBe('missing')
+    expect(readUsernameFromFastly).toHaveBeenCalledWith(baseEnv, 'alice')
   })
 
   it('returns not_applicable for active usernames without pubkey', async () => {

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -1281,13 +1281,13 @@ describe('POST /api/admin/username/restore', () => {
     return app
   }
 
-  function callRestore(app: Hono<any>, env: any, body: any) {
+  function callRestore(app: Hono<any>, env: any, body: any, ctx: ExecutionContext = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }) {
     const req = new Request('http://localhost/api/admin/username/restore', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     })
-    return app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    return app.fetch(req, env, ctx)
   }
 
   it('restores a burned username back to active for the provided pubkey', async () => {
@@ -1336,6 +1336,109 @@ describe('POST /api/admin/username/restore', () => {
     expect(json.username.status).toBe('active')
     expect(json.username.pubkey).toBe(VALID_PUBKEY)
     expect(json.username.revoked_at).toBeNull()
+  })
+
+  it('does not replay previous owner relay or ATProto identity when restoring to a new pubkey', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'rev-user', username_display: 'rev-user', username_canonical: 'rev-user',
+        pubkey: OTHER_PUBKEY, email: null, relays: '["wss://relay.example"]', status: 'revoked',
+        atproto_did: 'did:plc:previous', atproto_state: 'ready',
+        recyclable: 1, created_at: 1700000000, updated_at: 1700000100,
+        claimed_at: 1700000000, revoked_at: 1700000100, reserved_reason: null,
+        admin_notes: null,
+      },
+    ])
+    mockFetch
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        pubkey: VALID_PUBKEY,
+        relays: [],
+        status: 'active',
+        atproto_did: null,
+        atproto_state: null,
+      }), { status: 200 }))
+    const waitUntilPromises: Promise<unknown>[] = []
+    const ctx = {
+      waitUntil: (promise: Promise<unknown>) => { waitUntilPromises.push(promise) },
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext
+
+    const app = createTestApp()
+    const res = await callRestore(app, {
+      DB: db,
+      BYPASS_LOCAL_AUTH: 'true',
+      FASTLY_API_TOKEN: 'test-token',
+      FASTLY_STORE_ID: 'test-store',
+    }, {
+      name: 'rev-user', pubkey: VALID_PUBKEY,
+    }, ctx)
+    await Promise.all(waitUntilPromises)
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.username.relays).toBeNull()
+    expect(json.username.atproto_did).toBeNull()
+    expect(json.username.atproto_state).toBeNull()
+
+    const syncBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(syncBody.relays).toEqual([])
+    expect(syncBody.atproto_did).toBeNull()
+    expect(syncBody.atproto_state).toBeNull()
+  })
+
+  it('deletes a released active name from Fastly when restore moves a pubkey', async () => {
+    const db = createFakeD1([
+      {
+        id: 1, name: 'current', username_display: 'current', username_canonical: 'current',
+        pubkey: VALID_PUBKEY, email: null, relays: null, status: 'active',
+        recyclable: 1, created_at: 1700000000, updated_at: 1700000000,
+        claimed_at: 1700000000, revoked_at: null, reserved_reason: null,
+        admin_notes: null,
+      },
+      {
+        id: 2, name: 'restoreme', username_display: 'restoreme', username_canonical: 'restoreme',
+        pubkey: OTHER_PUBKEY, email: null, relays: null, status: 'revoked',
+        recyclable: 1, created_at: 1700000000, updated_at: 1700000100,
+        claimed_at: 1700000000, revoked_at: 1700000100, reserved_reason: null,
+        admin_notes: null,
+      },
+    ])
+    mockFetch
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        pubkey: VALID_PUBKEY,
+        relays: [],
+        status: 'active',
+        atproto_did: null,
+        atproto_state: null,
+      }), { status: 200 }))
+    const waitUntilPromises: Promise<unknown>[] = []
+    const ctx = {
+      waitUntil: (promise: Promise<unknown>) => { waitUntilPromises.push(promise) },
+      passThroughOnException: () => {},
+      props: {},
+    } as unknown as ExecutionContext
+
+    const app = createTestApp()
+    const res = await callRestore(app, {
+      DB: db,
+      BYPASS_LOCAL_AUTH: 'true',
+      FASTLY_API_TOKEN: 'test-token',
+      FASTLY_STORE_ID: 'test-store',
+    }, {
+      name: 'restoreme', pubkey: VALID_PUBKEY,
+    }, ctx)
+    await Promise.all(waitUntilPromises)
+
+    expect(res.status).toBe(200)
+    expect(mockFetch.mock.calls[0][0]).toContain('/keys/user%3Acurrent')
+    expect(mockFetch.mock.calls[0][1].method).toBe('DELETE')
+
+    const current = await getUsernameByName(db, 'current')
+    expect(current?.status).toBe('revoked')
   })
 
   it('returns 404 when the username does not exist', async () => {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1114,6 +1114,10 @@ admin.get('/username/:name/nip05-status', async (c) => {
       return c.json({ ok: true, status: 'missing' })
     }
 
+    // Unreachable at runtime here (status is necessarily active with a non-null
+    // pubkey by this point; revoked/burned and active-without-pubkey both returned
+    // above), but load-bearing for the type checker: it narrows existing.pubkey from
+    // string | null to string for expectedFastly below. Removing it fails tsc (TS2345).
     if (!existing.pubkey) {
       return c.json({
         ok: true,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -540,7 +540,7 @@ admin.post('/username/restore', async (c) => {
     }
 
     const restoredBy = (c.get('adminEmail' as never) as string) || null
-    const updated = await restoreUsername(
+    const restoreResult = await restoreUsername(
       c.env.DB,
       usernameData.canonical,
       normalizedPubkey,
@@ -548,17 +548,35 @@ admin.post('/username/restore', async (c) => {
       restoredBy
     )
 
-    const relays = parseRelayHints(existing.relays)
+    if (!restoreResult) {
+      return c.json({
+        ok: false,
+        error: 'Username is no longer restorable; reload and try again',
+      }, 409)
+    }
+
+    const relays = restoreResult.ownerChanged ? [] : parseRelayHints(existing.relays)
     const fastlyData = {
       pubkey: normalizedPubkey,
       relays,
       status: 'active' as const,
-      atproto_did: existing.atproto_did || null,
-      atproto_state: existing.atproto_state || null,
+      atproto_did: restoreResult.ownerChanged ? null : existing.atproto_did || null,
+      atproto_state: restoreResult.ownerChanged ? null : existing.atproto_state || null,
     }
 
     c.executionCtx.waitUntil(
-      syncAndVerifyUsername(c.env, usernameData.canonical, fastlyData).then(async (result) => {
+      (async () => {
+        if (restoreResult.releasedUsernameCanonical) {
+          const deleteResult = await deleteUsernameFromFastly(c.env, restoreResult.releasedUsernameCanonical)
+          if (!deleteResult.success) {
+            await enqueueFastlySyncTask(c.env.DB, {
+              username: restoreResult.releasedUsernameCanonical,
+              action: 'delete',
+            })
+          }
+        }
+
+        const result = await syncAndVerifyUsername(c.env, usernameData.canonical, fastlyData)
         if (!result.success || !result.verified) {
           await enqueueFastlySyncTask(c.env.DB, {
             username: usernameData.canonical,
@@ -566,14 +584,14 @@ admin.post('/username/restore', async (c) => {
             data: fastlyData,
           })
         }
-      })
+      })()
     )
 
     console.log(
       `Username "${usernameData.canonical}" restored to ${normalizedPubkey.slice(0, 8)}... by ${restoredBy || 'unknown'}${reason ? ` (reason: ${reason})` : ''}`
     )
 
-    return c.json({ ok: true, username: updated })
+    return c.json({ ok: true, username: restoreResult.username })
   } catch (error) {
     console.error('Restore error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
@@ -1094,6 +1112,14 @@ admin.get('/username/:name/nip05-status', async (c) => {
 
     if (!fastly.data) {
       return c.json({ ok: true, status: 'missing' })
+    }
+
+    if (!existing.pubkey) {
+      return c.json({
+        ok: true,
+        status: 'not_applicable',
+        reason: 'No pubkey assigned',
+      })
     }
 
     const expectedFastly = {

--- a/src/routes/webfinger.test.ts
+++ b/src/routes/webfinger.test.ts
@@ -75,6 +75,30 @@ describe('WebFinger', () => {
     expect(jrd.subject).toBe('acct:alice@divine.video')
   })
 
+  it('rejects acct resources for foreign domains', async () => {
+    const db = createFakeD1(records)
+    const res = await worker.fetch(
+      new Request('https://divine.video/.well-known/webfinger?resource=acct:alice@example.com'),
+      env(db),
+      ctx
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it('allows bare username resources', async () => {
+    const db = createFakeD1(records)
+    const res = await worker.fetch(
+      new Request('https://divine.video/.well-known/webfinger?resource=alice'),
+      env(db),
+      ctx
+    )
+
+    expect(res.status).toBe(200)
+    const jrd = await res.json() as any
+    expect(jrd.subject).toBe('acct:alice@divine.video')
+  })
+
   it('honors a configurable actor base URL', async () => {
     const db = createFakeD1(records)
     const res = await worker.fetch(

--- a/src/routes/webfinger.ts
+++ b/src/routes/webfinger.ts
@@ -30,12 +30,13 @@ webfinger.get('/.well-known/webfinger', async (c) => {
       })
     }
 
-    // Parse `acct:{user}@{domain}` — extract the user part before the @.
+    // Parse `acct:{user}@{domain}` and reject acct domains this service does not own.
     const acct = resource.startsWith('acct:') ? resource.slice('acct:'.length) : resource
     const atIndex = acct.lastIndexOf('@')
     const user = atIndex === -1 ? acct : acct.slice(0, atIndex)
+    const domain = atIndex === -1 ? null : acct.slice(atIndex + 1).toLowerCase()
 
-    if (!user) {
+    if (!user || (domain !== null && domain !== 'divine.video')) {
       return c.notFound()
     }
 


### PR DESCRIPTION
## Summary

- Makes username restore conditional on the target row still being revoked or burned and runs the release/restore writes in one D1 batch.
- Clears prior-owner relays and ATProto identity when restoring a username to a different pubkey.
- Deletes any released active username from Fastly KV, queueing a delete retry on failure.
- Rejects WebFinger acct resources for domains other than divine.video while keeping bare username lookup.
- Includes the PR #55 stale Fastly status test alignment so this branch validates cleanly against current main.

## Motivation

Follows up the real restore/WebFinger findings raised during review of #55 without expanding that test-only PR. The restore path could race stale status reads, orphan a released edge record, replay prior-owner identity metadata, or leave writes split across non-atomic statements. WebFinger also answered authoritatively for foreign acct domains.

## Linked issue

Related to #55.

## Manual validation

- npm run test:once
- npx tsc --noEmit

## Visuals / API examples

No visual change. API behavior changes are limited to safer restore conflict handling, Fastly cleanup for released names, and WebFinger 404s for foreign acct domains.

## Public artifact review

PR title, branch name, and description avoid sensitive external identities.