### PR TITLE
fix(admin-ui): surface backend error message on reserve failures

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -17,6 +17,29 @@ import type {
 
 const API_BASE = '/api/admin'
 
+// For endpoints whose callers render `result.error` directly, a non-2xx
+// response still carries a useful JSON body (e.g. validation messages,
+// `requiresOverride`). Return that parsed body instead of throwing on
+// `response.statusText`, which is an empty string over HTTP/2 (no reason
+// phrase) and produced messages like "Reserve failed:" with nothing after it.
+async function parseErrorResponse<T extends ApiResponse>(
+  response: Response,
+  fallback: string
+): Promise<T> {
+  try {
+    const body = (await response.json()) as T
+    if (body && typeof body.error === 'string') {
+      return body
+    }
+  } catch {
+    // Body was not JSON; fall through to a synthesized error.
+  }
+  return {
+    ok: false,
+    error: `${fallback}: ${response.statusText || `HTTP ${response.status}`}`
+  } as T
+}
+
 export async function searchUsernames(
   query: string,
   status?: string,
@@ -90,7 +113,7 @@ export async function reserveUsername(
   })
 
   if (!response.ok) {
-    throw new Error(`Reserve failed: ${response.statusText}`)
+    return parseErrorResponse<ReserveResponse>(response, 'Reserve failed')
   }
 
   return response.json()
@@ -107,7 +130,7 @@ export async function bulkReserveUsernames(
   })
 
   if (!response.ok) {
-    throw new Error(`Bulk reserve failed: ${response.statusText}`)
+    return parseErrorResponse<BulkReserveResponse>(response, 'Bulk reserve failed')
   }
 
   return response.json()

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -28,7 +28,9 @@ async function parseErrorResponse<T extends ApiResponse>(
 ): Promise<T> {
   try {
     const body = (await response.json()) as T
-    if (body && typeof body.error === 'string') {
+    // Only trust an error body that explicitly reports failure, so a
+    // contradictory { ok: true } on a non-2xx never masquerades as success.
+    if (body && body.ok === false && typeof body.error === 'string') {
       return body
     }
   } catch {


### PR DESCRIPTION
**Summary**

Parse the worker's JSON error body on failed reservations instead of throwing on `response.statusText`, so the Reserve form shows the real reason.

**Motivation**

Closes #59. The form rendered an empty `Reserve failed:` on every rejection because the client read `response.statusText` (empty over HTTP/2) and discarded the `{ ok: false, error }` body the worker returns.

**Changes**

- Add `parseErrorResponse<T>()` helper in `admin-ui/src/api/client.ts`
- Wire it into `reserveUsername` and `bulkReserveUsernames`
- Falls back to a synthesized `HTTP <status>` message when the body is not JSON
- Bonus: the server-side `requiresOverride` path now reaches the form as designed

**Manual validation**

- `npm run build` in `admin-ui/` passes (`tsc` + vite, clean); `tsc --noEmit` clean
- Submitting an invalid username now surfaces the validation message instead of an empty error
- No visual change beyond the error text now being populated

**Note:** other client functions share the same `statusText` pattern; out of scope here, noted in #59 for a follow-up.