### PR TITLE
fix(username): add CORS preflight support + normalize claim pubkey case (#4199)

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -448,22 +448,22 @@ function createStatefulMockDB(initialRecords: Partial<Username>[] = []) {
                   lookupValues.includes(r.name as string)
                 ) as T) || null
               }
-              if (sql.includes('pubkey = ?') && sql.includes('status = ?')) {
+              if ((sql.includes('pubkey = ?') || sql.includes('LOWER(pubkey) = LOWER(?)')) && sql.includes('status = ?')) {
                 const pubkey = boundParams[0]
                 const status = boundParams[1]
-                return (records.find(r => r.pubkey === pubkey && r.status === status) as T) || null
+                return (records.find(r => r.pubkey?.toLowerCase() === pubkey.toLowerCase() && r.status === status) as T) || null
               }
               return null
             },
             all: async () => ({ results: records }),
             run: async () => {
               // UPDATE ... SET status = 'revoked', revoked_at = ? ... WHERE pubkey = ? AND status = 'active'
-              if (sql.includes("SET status = 'revoked'") && sql.includes('WHERE pubkey = ?')) {
+              if (sql.includes("SET status = 'revoked'") && (sql.includes('WHERE pubkey = ?') || sql.includes('WHERE LOWER(pubkey) = LOWER(?)'))) {
                 const revokedAt = boundParams[0]
                 const updatedAt = boundParams[1]
                 const pubkey = boundParams[2]
                 for (const r of records) {
-                  if (r.pubkey === pubkey && r.status === 'active') {
+                  if (r.pubkey?.toLowerCase() === pubkey.toLowerCase() && r.status === 'active') {
                     r.status = 'revoked'
                     r.revoked_at = revokedAt
                     r.updated_at = updatedAt

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -106,7 +106,7 @@ export async function getUsernameByPubkey(
   pubkey: string
 ): Promise<Username | null> {
   const result = await db.prepare(
-    'SELECT * FROM usernames WHERE pubkey = ? AND status = ?'
+    'SELECT * FROM usernames WHERE LOWER(pubkey) = LOWER(?) AND status = ?'
   ).bind(pubkey, 'active').first<Username>()
 
   return result
@@ -122,13 +122,14 @@ export async function claimUsername(
   const now = Math.floor(Date.now() / 1000)
   const relaysJson = relays ? JSON.stringify(relays) : null
 
-  // First, revoke any existing active username for this pubkey
+  // First, revoke any existing active username for this pubkey.
+  // Legacy rows may contain mixed-case hex pubkeys, so match case-insensitively.
   await db.prepare(
     `UPDATE usernames
      SET status = 'revoked',
          revoked_at = ?,
          updated_at = ?
-     WHERE pubkey = ? AND status = 'active'`
+     WHERE LOWER(pubkey) = LOWER(?) AND status = 'active'`
   ).bind(now, now, pubkey).run()
 
   // Then insert or update the new username using canonical for uniqueness
@@ -394,7 +395,7 @@ export async function restoreUsername(
     existingActiveForPubkey.username_canonical !== nameCanonical
     ? existingActiveForPubkey.username_canonical
     : null
-  const ownerChanged = existing.pubkey !== pubkey
+  const ownerChanged = existing.pubkey?.toLowerCase() !== pubkey.toLowerCase()
   const relays = ownerChanged ? null : existing.relays
   const atprotoDid = ownerChanged ? null : existing.atproto_did
   const atprotoState = ownerChanged ? null : existing.atproto_state
@@ -404,7 +405,7 @@ export async function restoreUsername(
      SET status = 'revoked',
          revoked_at = ?,
          updated_at = ?
-     WHERE pubkey = ?
+     WHERE LOWER(pubkey) = LOWER(?)
        AND status = 'active'
        AND username_canonical != ?
        AND EXISTS (
@@ -449,13 +450,14 @@ export async function assignUsername(
 ): Promise<void> {
   const now = Math.floor(Date.now() / 1000)
 
-  // Revoke existing username for this pubkey
+  // Revoke existing username for this pubkey.
+  // Legacy rows may contain mixed-case hex pubkeys, so match case-insensitively.
   await db.prepare(
     `UPDATE usernames
      SET status = 'revoked',
          revoked_at = ?,
          updated_at = ?
-     WHERE pubkey = ? AND status = 'active'`
+     WHERE LOWER(pubkey) = LOWER(?) AND status = 'active'`
   ).bind(now, now, pubkey).run()
 
   // Assign username using canonical for uniqueness

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -170,9 +170,9 @@ export function createFakeD1(
               }
 
               // Active username lookup by pubkey
-              if (sql.includes('WHERE pubkey = ? AND status = ?')) {
+              if (sql.includes('WHERE pubkey = ? AND status = ?') || sql.includes('WHERE LOWER(pubkey) = LOWER(?) AND status = ?')) {
                 const [pubkey, status] = boundParams
-                return records.find((u) => u.pubkey === pubkey && u.status === status) || null
+                return records.find((u) => u.pubkey?.toLowerCase() === pubkey.toLowerCase() && u.status === status) || null
               }
 
               // Direct username lookup
@@ -321,12 +321,12 @@ export function createFakeD1(
                 }
                 return { success: true, meta: { changes: rec ? 1 : 0 } }
               }
-              // Release-other-active-name UPDATE (restoreUsername's first statement, also assignUsername's):
-              // WHERE pubkey = ? AND status = 'active' [AND username_canonical != ?]
+              // Release-other-active-name UPDATE (restoreUsername's first statement, also assignUsername's).
+              // Supports exact and LOWER(pubkey) matching shapes.
               if (
                 sql.includes('UPDATE usernames') &&
                 sql.includes("status = 'revoked'") &&
-                sql.includes('pubkey = ?') &&
+                (sql.includes('pubkey = ?') || sql.includes('LOWER(pubkey) = LOWER(?)')) &&
                 sql.includes("status = 'active'")
               ) {
                 const [revokedAt, updatedAt, pk, excludeCanonical, targetCanonical] = boundParams
@@ -335,7 +335,7 @@ export function createFakeD1(
                 )
                 let changes = 0
                 for (const r of records) {
-                  if (targetIsRestorable && r.pubkey === pk && r.status === 'active' && r.username_canonical !== excludeCanonical) {
+                  if (targetIsRestorable && r.pubkey?.toLowerCase() === pk.toLowerCase() && r.status === 'active' && r.username_canonical !== excludeCanonical) {
                     r.status = 'revoked'
                     r.revoked_at = revokedAt
                     r.updated_at = updatedAt

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -122,10 +122,10 @@ function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
               }
 
               // Username lookup by pubkey + status='active'
-              if (sql.includes('pubkey = ?') && sql.includes('status = ?')) {
+              if ((sql.includes('pubkey = ?') || sql.includes('LOWER(pubkey) = LOWER(?)')) && sql.includes('status = ?')) {
                 const pubkey = boundParams[0]
                 const status = boundParams[1]
-                return mockUsernames.find(u => u.pubkey === pubkey && u.status === status) ?? null
+                return mockUsernames.find(u => u.pubkey?.toLowerCase() === pubkey.toLowerCase() && u.status === status) ?? null
               }
 
               return null
@@ -144,9 +144,9 @@ function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
               //   WHERE pubkey=? AND status='active'
               // Bound: [revoked_at, updated_at, pubkey]
               // -------------------------------------------------------------------
-              if (sql.includes("SET status = 'revoked'") && sql.includes('WHERE pubkey = ?')) {
+              if (sql.includes("SET status = 'revoked'") && (sql.includes('WHERE pubkey = ?') || sql.includes('WHERE LOWER(pubkey) = LOWER(?)'))) {
                 const pubkey = boundParams[2]
-                const record = mockUsernames.find(u => u.pubkey === pubkey && u.status === 'active')
+                const record = mockUsernames.find(u => u.pubkey?.toLowerCase() === pubkey.toLowerCase() && u.status === 'active')
                 if (record) {
                   record.status = 'revoked'
                   record.revoked_at = boundParams[0]

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -76,9 +76,9 @@ function createMockDB(initialUsernames: any[] = []) {
               }
 
               // Check for pubkey lookup
-              if (sql.includes('pubkey = ?')) {
+              if (sql.includes('pubkey = ?') || sql.includes('LOWER(pubkey) = LOWER(?)')) {
                 const pubkey = boundParams[0]
-                return mockUsernames.find(u => u.pubkey === pubkey && u.status === 'active') || null
+                return mockUsernames.find(u => u.pubkey?.toLowerCase() === pubkey.toLowerCase() && u.status === 'active') || null
               }
 
               return null
@@ -155,6 +155,19 @@ function createMockDB(initialUsernames: any[] = []) {
                     reservation_expires_at: expiresAt,
                     subscription_expires_at: null
                   })
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
+              // Handle active username revocation by pubkey
+              if (sql.includes("SET status = 'revoked'") && (sql.includes('pubkey = ?') || sql.includes('LOWER(pubkey) = LOWER(?)'))) {
+                const pubkey = boundParams[2]
+                for (const record of mockUsernames) {
+                  if (record.pubkey?.toLowerCase() === pubkey.toLowerCase() && record.status === 'active') {
+                    record.status = 'revoked'
+                    record.revoked_at = boundParams[0]
+                    record.updated_at = boundParams[1]
+                  }
                 }
                 return { success: true, meta: { changes: 1 } }
               }
@@ -317,6 +330,33 @@ describe('Username Claiming - Case Insensitive', () => {
     const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
     // Without the pubkey normalization this is a 409 (treated as a different owner).
     expect(res.status).toBe(200)
+  })
+
+  it('releases a legacy mixed-case active username when the same pubkey claims a new name', async () => {
+    const app = createTestApp()
+    const db = createMockDB([
+      { id: 1, name: 'oldname', username_display: 'OldName', username_canonical: 'oldname', pubkey: 'ABC123', status: 'active', relays: null },
+    ])
+    vi.mocked(verifyNip98Event).mockResolvedValue('abc123')
+
+    const { deleteUsernameFromFastly } = await import('../utils/fastly-sync')
+    vi.mocked(deleteUsernameFromFastly).mockClear()
+
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'newname' })
+    })
+
+    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(200)
+    expect(db._mockUsernames.find(u => u.username_canonical === 'oldname')?.status).toBe('revoked')
+    expect(db._mockUsernames.find(u => u.username_canonical === 'newname')?.status).toBe('active')
+    expect(deleteUsernameFromFastly).toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      'oldname'
+    )
   })
 
   it('answers the /claim CORS preflight so browsers can POST cross-origin (#4199 H1)', async () => {

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -299,6 +299,57 @@ describe('Username Claiming - Case Insensitive', () => {
     expect(json2.error).toBe('That username is already taken')
   })
 
+  it('lets the same owner re-claim their own name when the pubkey case differs (#4199 H4)', async () => {
+    const app = createTestApp()
+    // Existing active name owned by a lower-cased pubkey.
+    const db = createMockDB([
+      { id: 1, name: 'MrBeast', username_display: 'MrBeast', username_canonical: 'mrbeast', pubkey: 'abc123', status: 'active', relays: null },
+    ])
+    // NIP-98 presents the SAME key, upper-cased.
+    vi.mocked(verifyNip98Event).mockResolvedValue('ABC123')
+
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'MrBeast' })
+    })
+
+    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    // Without the pubkey normalization this is a 409 (treated as a different owner).
+    expect(res.status).toBe(200)
+  })
+
+  it('answers the /claim CORS preflight so browsers can POST cross-origin (#4199 H1)', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/api/username/claim', {
+      method: 'OPTIONS',
+      headers: {
+        'Origin': 'https://app.divine.video',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'authorization,content-type'
+      }
+    })
+
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-methods') || '').toContain('POST')
+    expect((res.headers.get('access-control-allow-headers') || '').toLowerCase()).toContain('authorization')
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
+  it('exposes exactly one Access-Control-Allow-Origin on GET /check (no duplicate) (#4199)', async () => {
+    const app = createTestApp()
+    const req = new Request('http://localhost/api/username/check/probe', {
+      headers: { 'Origin': 'https://app.divine.video' }
+    })
+
+    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+
+    // Headers.get() joins duplicates with ", " — assert a single "*", not "*, *".
+    expect(res.headers.get('access-control-allow-origin')).toBe('*')
+  })
+
   it('should validate username format correctly', async () => {
     const app = createTestApp()
     

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -472,7 +472,7 @@ username.post('/claim', async (c) => {
     // Check if name exists (using canonical for lookup)
     const existing = await getUsernameByName(c.env.DB, nameCanonical)
     if (existing) {
-      if (existing.status === 'active' && existing.pubkey !== pubkey) {
+      if (existing.status === 'active' && existing.pubkey?.toLowerCase() !== pubkey) {
         return c.json({ ok: false, error: 'That username is already taken' }, 409)
       }
       if (existing.status === 'reserved') {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -3,6 +3,7 @@
 // ABOUTME: Authenticated: POST /claim (NIP-98 auth - works for both custodial and non-custodial users)
 
 import { Hono } from 'hono'
+import { cors } from 'hono/cors'
 import { verifyNip98Event } from '../middleware/nip98'
 import { validateUsername, validateRelays, UsernameValidationError, RelayValidationError } from '../utils/validation'
 import {
@@ -41,6 +42,19 @@ type Bindings = {
 }
 
 const username = new Hono<{ Bindings: Bindings }>()
+
+// CORS for browser clients (e.g. the Flutter web app at app.divine.video).
+// Without an OPTIONS/preflight response, the browser blocks the cross-origin
+// POST /claim (Authorization + JSON body is a preflighted request), surfacing
+// as "Failed to claim username" on web while native works. See #4199.
+// `hono/cors` uses headers.set(), so the manual ACAO:* on some GET responses
+// is not duplicated.
+username.use('*', cors({
+  origin: '*',
+  allowMethods: ['GET', 'POST', 'OPTIONS'],
+  allowHeaders: ['Authorization', 'Content-Type'],
+  maxAge: 86400,
+}))
 
 // Public endpoint: check username availability (no auth required)
 // Used by Flutter app and web clients before attempting to claim
@@ -408,14 +422,17 @@ username.post('/claim', async (c) => {
     // Read raw body text first (needed for NIP-98 payload verification)
     const bodyText = await c.req.text()
 
-    // Verify NIP-98 authentication with payload
+    // Verify NIP-98 authentication with payload.
+    // Normalize the pubkey to lowercase so the owner comparison below, the
+    // by-pubkey lookup, and storage stay case-consistent — otherwise a
+    // same-owner re-claim with a differently-cased pubkey could 409. See #4199.
     const url = new URL(c.req.url)
-    const pubkey = await verifyNip98Event(
+    const pubkey = (await verifyNip98Event(
       c.req.raw.headers,
       'POST',
       url.toString(),
       bodyText
-    )
+    )).toLowerCase()
 
     // Parse request body
     const body = JSON.parse(bodyText) as { name: string; relays?: string[] }


### PR DESCRIPTION
## Summary

- Add CORS middleware on the username router so browser preflights for `POST /api/username/claim` and `POST /api/username/reserve` receive the expected `Access-Control-Allow-*` headers.
- Normalize NIP-98 claim pubkeys to lowercase before storage and response payloads.
- Match existing active pubkey rows case-insensitively when checking ownership, looking up current usernames, and releasing previous active usernames, including legacy mixed-case rows.

## Motivation

Browser clients send `Authorization` and JSON content headers when claiming usernames, so claim requests are preflighted. Without an `OPTIONS` response, browsers block the request before it reaches the claim handler. The pubkey normalization hardening prevents same-owner operations from failing or leaving multiple active usernames when older rows contain mixed-case hex pubkeys.

## Linked issue

Fixes divinevideo/divine-mobile#4199.

## Validation

- `npm test -- src/routes/username.test.ts --run`
- `npm run test:once` (346/346 passing)
- `npx tsc --noEmit`
- `npm run build:admin`

## Notes

No admin UI visual changes. API behavior changes are limited to CORS preflight responses and case-insensitive pubkey ownership handling for username claim/assignment/restore flows.