### PR TITLE
feat(username): add POST /api/username/release to burn a caller's own handle

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -358,6 +358,36 @@ export async function revokeUsername(
 }
 
 /**
+ * Revoke/burn a username scoped to a specific pubkey.
+ *
+ * Unlike revokeUsername (which matches `username_canonical = ? OR name = ?`
+ * for admin use, where naming either column is intentional), this only ever
+ * touches the row owned by `pubkey`. A self-service `/release` caller must not
+ * be able to collaterally burn a *different* user's globally-unique row when a
+ * legacy `name != canonical` row's `name` happens to equal the caller's
+ * canonical.
+ */
+export async function revokeUsernameByPubkey(
+  db: D1Database,
+  pubkey: string,
+  canonical: string,
+  burn: boolean
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000)
+  const status = burn ? 'burned' : 'revoked'
+  const recyclable = burn ? 0 : 1
+
+  await db.prepare(
+    `UPDATE usernames
+     SET status = ?,
+         recyclable = ?,
+         revoked_at = ?,
+         updated_at = ?
+     WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?)`
+  ).bind(status, recyclable, now, now, canonical, pubkey).run()
+}
+
+/**
  * Restore a previously revoked or burned username to a specific pubkey.
  *
  * Sets status='active', recyclable=1, pubkey=<provided>, clears revoked_at,

--- a/src/middleware/nip98.ts
+++ b/src/middleware/nip98.ts
@@ -55,7 +55,8 @@ export async function verifyNip98Event(
   headers: Headers,
   method: string,
   url: string,
-  body?: string
+  body?: string,
+  maxAgeSeconds: number = 60
 ): Promise<string> {
   const authHeader = headers.get('Authorization')
 
@@ -110,9 +111,9 @@ export async function verifyNip98Event(
     throw new Nip98Error('Signature verification failed')
   }
 
-  // Verify timestamp (within 60 seconds)
+  // Verify timestamp (within maxAgeSeconds of now; default 60s)
   const now = Math.floor(Date.now() / 1000)
-  if (Math.abs(now - event.created_at) > 60) {
+  if (Math.abs(now - event.created_at) > maxAgeSeconds) {
     throw new Nip98Error('Event timestamp too old or in future')
   }
 

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -1213,4 +1213,48 @@ describe('POST /release - burn own username', () => {
     const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
     expect(res.status).toBe(401)
   })
+
+  it('returns 400 when the name is missing', async () => {
+    const app = createTestApp()
+    const db = createMockDB([])
+    const req = new Request('http://localhost/api/username/release', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({})
+    })
+    const res = await app.fetch(req, { DB: db }, ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('a burned name can no longer be claimed by anyone', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      name: 'alice', username_display: 'alice', username_canonical: 'alice',
+      pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
+      status: 'active', recyclable: 1,
+    }])
+
+    const burn = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(burn.status).toBe(200)
+
+    // A different user tries to claim the now-burned name.
+    vi.mocked(verifyNip98Event).mockResolvedValue(
+      '345352a677feb41d624589f2169278dbd5a25ba940663f2020101d30a09ef96f'
+    )
+    const claimReq = new Request('http://localhost/api/username/claim', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name: 'alice' })
+    })
+    const claim = await app.fetch(claimReq, { DB: db }, ctx)
+    expect(claim.status).toBe(403)
+    const json = await claim.json() as any
+    expect(json.error).toContain('permanently unavailable')
+  })
 })

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -1104,3 +1104,77 @@ describe('Public Name Reservation', () => {
     })
   })
 })
+
+describe('POST /release - burn own username', () => {
+  let verifyNip98Event: any
+
+  beforeEach(async () => {
+    const nip98Module = await import('../middleware/nip98')
+    verifyNip98Event = nip98Module.verifyNip98Event
+    vi.mocked(verifyNip98Event).mockResolvedValue(
+      '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b'
+    )
+  })
+
+  function createTestApp() {
+    const app = new Hono<{ Bindings: { DB: D1Database } }>()
+    app.route('/api/username', username)
+    return app
+  }
+
+  const ctx = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+
+  function releaseReq(name: string) {
+    return new Request('http://localhost/api/username/release', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Nostr base64...',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ name })
+    })
+  }
+
+  it('burns the caller\'s own active name', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      name: 'alice', username_display: 'alice', username_canonical: 'alice',
+      pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
+      status: 'active',
+    }])
+    const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json).toMatchObject({ ok: true, released: true, name: 'alice', status: 'burned' })
+  })
+
+  it('returns 403 when the caller owns a different active name', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      name: 'bob', username_display: 'bob', username_canonical: 'bob',
+      pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
+      status: 'active',
+    }])
+    const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 no-op when the caller owns no active name', async () => {
+    const app = createTestApp()
+    const db = createMockDB([])
+    const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json).toMatchObject({ ok: true, released: false, reason: 'no_active_name' })
+  })
+
+  it('returns 401 on NIP-98 failure', async () => {
+    vi.mocked(verifyNip98Event).mockRejectedValue(
+      Object.assign(new Error('bad auth'), { name: 'Nip98Error' })
+    )
+    const app = createTestApp()
+    const db = createMockDB([])
+    const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -185,6 +185,28 @@ function createMockDB(initialUsernames: any[] = []) {
                 return { success: true, meta: { changes: 1 } }
               }
 
+              // Handle revokeUsernameByPubkey (scoped burn: canonical AND pubkey)
+              if (
+                sql.includes('SET status = ?') &&
+                sql.includes('recyclable = ?') &&
+                sql.includes('LOWER(pubkey)')
+              ) {
+                const status = boundParams[0]
+                const recyclable = boundParams[1]
+                const canonical = boundParams[4]
+                const pubkey = boundParams[5]
+                for (const record of mockUsernames) {
+                  if (
+                    record.username_canonical === canonical &&
+                    record.pubkey?.toLowerCase() === pubkey.toLowerCase()
+                  ) {
+                    record.status = status
+                    record.recyclable = recyclable
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
               // Handle revokeUsername (burn/revoke by canonical or name)
               if (
                 sql.includes('SET status = ?') &&
@@ -1225,6 +1247,39 @@ describe('POST /release - burn own username', () => {
       (u: any) => u.username_canonical === 'xn--caf-dma'
     )
     expect(row.status).toBe('burned')
+  })
+
+  it('does not collaterally burn another user\'s row via OR-name', async () => {
+    const attackerPubkey =
+      '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b'
+    const victimPubkey =
+      '345352a677feb41d624589f2169278dbd5a25ba940663f2020101d30a09ef96f'
+    const app = createTestApp()
+    const db = createMockDB([
+      // Attacker owns a legacy row where name != canonical.
+      {
+        name: 'Alice2', username_display: 'Alice2', username_canonical: 'alice',
+        pubkey: attackerPubkey, status: 'active', recyclable: 1,
+      },
+      // A different user's active row whose display name equals the attacker's
+      // canonical — the exact collision the OR-name clause would burn.
+      {
+        name: 'alice', username_display: 'alice', username_canonical: 'alice-v',
+        pubkey: victimPubkey, status: 'active', recyclable: 1,
+      },
+    ])
+    // beforeEach mocks verifyNip98Event -> attackerPubkey.
+    const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
+    expect(res.status).toBe(200)
+
+    const attacker = (db as any)._mockUsernames.find(
+      (u: any) => u.username_canonical === 'alice'
+    )
+    const victim = (db as any)._mockUsernames.find(
+      (u: any) => u.username_canonical === 'alice-v'
+    )
+    expect(attacker.status).toBe('burned') // caller's own row is burned
+    expect(victim.status).toBe('active') // the foreign row is untouched
   })
 
   it('returns 403 when the caller owns a different active name', async () => {

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -185,6 +185,28 @@ function createMockDB(initialUsernames: any[] = []) {
                 return { success: true, meta: { changes: 1 } }
               }
 
+              // Handle revokeUsername (burn/revoke by canonical or name)
+              if (
+                sql.includes('SET status = ?') &&
+                sql.includes('recyclable = ?') &&
+                sql.includes('username_canonical = ?')
+              ) {
+                const status = boundParams[0]
+                const recyclable = boundParams[1]
+                const canonical = boundParams[4]
+                const name = boundParams[5]
+                for (const record of mockUsernames) {
+                  if (
+                    record.username_canonical === canonical ||
+                    record.name === name
+                  ) {
+                    record.status = status
+                    record.recyclable = recyclable
+                  }
+                }
+                return { success: true, meta: { changes: 1 } }
+              }
+
               // Handle INSERT/UPDATE operations for claim
               if (sql.includes('INSERT INTO usernames') || sql.includes('ON CONFLICT')) {
                 const display = boundParams[1] // username_display
@@ -1136,16 +1158,30 @@ describe('POST /release - burn own username', () => {
   }
 
   it('burns the caller\'s own active name', async () => {
+    const { deleteUsernameFromFastly } = await import('../utils/fastly-sync')
+    vi.mocked(deleteUsernameFromFastly).mockClear()
     const app = createTestApp()
     const db = createMockDB([{
       name: 'alice', username_display: 'alice', username_canonical: 'alice',
       pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
-      status: 'active',
+      status: 'active', recyclable: 1,
     }])
     const res = await app.fetch(releaseReq('alice'), { DB: db }, ctx)
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json).toMatchObject({ ok: true, released: true, name: 'alice', status: 'burned' })
+
+    // The row is actually burned (not merely revoked) and de-synced from
+    // Fastly, so a burn->revoke regression or a dropped Fastly delete fails here.
+    const row = (db as any)._mockUsernames.find(
+      (u: any) => u.username_canonical === 'alice'
+    )
+    expect(row.status).toBe('burned')
+    expect(row.recyclable).toBe(0)
+    expect(deleteUsernameFromFastly).toHaveBeenCalledWith(
+      expect.anything(),
+      'alice'
+    )
   })
 
   it('returns 403 when the caller owns a different active name', async () => {

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -1214,19 +1214,27 @@ describe('POST /release - burn own username', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 400 when the name is missing', async () => {
+  it('returns 400 for invalid bodies', async () => {
     const app = createTestApp()
     const db = createMockDB([])
-    const req = new Request('http://localhost/api/username/release', {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Nostr base64...',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({})
-    })
-    const res = await app.fetch(req, { DB: db }, ctx)
-    expect(res.status).toBe(400)
+    const badBodies = [
+      JSON.stringify({}), // missing name
+      JSON.stringify({ name: 123 }), // non-string name
+      'null', // JSON null
+      '{not valid json' // malformed JSON
+    ]
+    for (const body of badBodies) {
+      const req = new Request('http://localhost/api/username/release', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Nostr base64...',
+          'Content-Type': 'application/json'
+        },
+        body
+      })
+      const res = await app.fetch(req, { DB: db }, ctx)
+      expect(res.status, `body=${body}`).toBe(400)
+    }
   })
 
   it('a burned name can no longer be claimed by anyone', async () => {

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -1182,6 +1182,49 @@ describe('POST /release - burn own username', () => {
       expect.anything(),
       'alice'
     )
+    // Pin the signed NIP-98 contract the client depends on: exact absolute
+    // URL, POST, raw unmodified body, and the wider release window.
+    expect(verifyNip98Event).toHaveBeenCalledWith(
+      expect.anything(),
+      'POST',
+      'http://localhost/api/username/release',
+      JSON.stringify({ name: 'alice' }),
+      300
+    )
+  })
+
+  it('burns a legacy underscore name (no claim-time char gate)', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      name: 'the_funny_vine', username_display: 'the_funny_vine',
+      username_canonical: 'the_funny_vine',
+      pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
+      status: 'active', recyclable: 1,
+    }])
+    const res = await app.fetch(releaseReq('the_funny_vine'), { DB: db }, ctx)
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json).toMatchObject({ released: true, status: 'burned' })
+    const row = (db as any)._mockUsernames.find(
+      (u: any) => u.username_canonical === 'the_funny_vine'
+    )
+    expect(row.status).toBe('burned')
+  })
+
+  it('burns a Unicode name via its stored punycode canonical', async () => {
+    const app = createTestApp()
+    const db = createMockDB([{
+      name: 'Café', username_display: 'Café', username_canonical: 'xn--caf-dma',
+      pubkey: '156dd13a1f8a488037fa1b43ad934a5e58644a1d6e1ad6697a02c2e93b8b013b',
+      status: 'active', recyclable: 1,
+    }])
+    // Client sends the stored canonical (round-trip-safe for legacy shapes).
+    const res = await app.fetch(releaseReq('xn--caf-dma'), { DB: db }, ctx)
+    expect(res.status).toBe(200)
+    const row = (db as any)._mockUsernames.find(
+      (u: any) => u.username_canonical === 'xn--caf-dma'
+    )
+    expect(row.status).toBe('burned')
   })
 
   it('returns 403 when the caller owns a different active name', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -564,15 +564,27 @@ username.post('/release', async (c) => {
     const bodyText = await c.req.text()
 
     const url = new URL(c.req.url)
-    const pubkey = await verifyNip98Event(
-      c.req.raw.headers,
-      'POST',
-      url.toString(),
-      bodyText
-    )
+    // Lowercase for parity with /claim; getUsernameByPubkey compares
+    // case-insensitively, so this is defensive normalization.
+    const pubkey = (
+      await verifyNip98Event(
+        c.req.raw.headers,
+        'POST',
+        url.toString(),
+        bodyText
+      )
+    ).toLowerCase()
 
-    const body = JSON.parse(bodyText) as { name: string }
+    let body: { name?: unknown }
+    try {
+      body = JSON.parse(bodyText)
+    } catch {
+      return c.json({ ok: false, error: 'Invalid JSON body' }, 400)
+    }
     const { name } = body
+    if (typeof name !== 'string' || name.length === 0) {
+      return c.json({ ok: false, error: 'name is required' }, 400)
+    }
 
     let usernameData: { display: string; canonical: string }
     try {
@@ -597,7 +609,10 @@ username.post('/release', async (c) => {
       return c.json({ ok: false, error: 'You do not own that username' }, 403)
     }
 
-    // Burn: permanent, blocks re-registration (recyclable=0).
+    // Burn: permanent, blocks re-registration (recyclable=0). The ownership
+    // check above plus the unique username_canonical invariant ensure this
+    // hits exactly the caller's row, even though revokeUsername matches by
+    // canonical/name rather than pubkey.
     await revokeUsername(c.env.DB, nameCanonical, true)
 
     // Delete from Fastly so the burned name stops resolving at the edge.

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -575,13 +575,16 @@ username.post('/release', async (c) => {
       )
     ).toLowerCase()
 
-    let body: { name?: unknown }
+    let body: unknown
     try {
       body = JSON.parse(bodyText)
     } catch {
       return c.json({ ok: false, error: 'Invalid JSON body' }, 400)
     }
-    const { name } = body
+    if (typeof body !== 'object' || body === null) {
+      return c.json({ ok: false, error: 'Invalid JSON body' }, 400)
+    }
+    const { name } = body as { name?: unknown }
     if (typeof name !== 'string' || name.length === 0) {
       return c.json({ ok: false, error: 'name is required' }, 400)
     }

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -11,7 +11,7 @@ import {
   getUsernameByName,
   getUsernameByPubkey,
   claimUsername,
-  revokeUsername,
+  revokeUsernameByPubkey,
   countRecentReservationsByEmail,
   createReservation,
   getReservationByToken,
@@ -622,9 +622,11 @@ username.post('/release', async (c) => {
       return c.json({ ok: false, error: 'You do not own that username' }, 403)
     }
 
-    // Burn the stored canonical: permanent, blocks re-registration
-    // (recyclable=0).
-    await revokeUsername(c.env.DB, ownedCanonical, true)
+    // Burn the caller's own row, scoped by pubkey (NOT the shared
+    // revokeUsername, whose `OR name = ?` could collaterally burn a different
+    // user's globally-unique row in the legacy name != canonical regime).
+    // Permanent; recyclable=0 blocks re-registration.
+    await revokeUsernameByPubkey(c.env.DB, pubkey, ownedCanonical, true)
 
     // Delete from Fastly so the burned name stops resolving at the edge.
     c.executionCtx.waitUntil(

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -1,6 +1,6 @@
 // ABOUTME: Username API endpoints for claiming, checking, and reserving usernames
 // ABOUTME: Public endpoints: GET /check/:name, GET /by-pubkey/:pubkey, POST /reserve, GET /confirm
-// ABOUTME: Authenticated: POST /claim (NIP-98 auth - works for both custodial and non-custodial users)
+// ABOUTME: Authenticated: POST /claim, POST /release (NIP-98 auth - works for both custodial and non-custodial users)
 
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
@@ -11,6 +11,7 @@ import {
   getUsernameByName,
   getUsernameByPubkey,
   claimUsername,
+  revokeUsername,
   countRecentReservationsByEmail,
   createReservation,
   getReservationByToken,
@@ -553,6 +554,75 @@ username.post('/claim', async (c) => {
       return c.json({ ok: false, error: error.message }, 401)
     }
     console.error('Claim error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+username.post('/release', async (c) => {
+  try {
+    // Read raw body text first (needed for NIP-98 payload verification)
+    const bodyText = await c.req.text()
+
+    const url = new URL(c.req.url)
+    const pubkey = await verifyNip98Event(
+      c.req.raw.headers,
+      'POST',
+      url.toString(),
+      bodyText
+    )
+
+    const body = JSON.parse(bodyText) as { name: string }
+    const { name } = body
+
+    let usernameData: { display: string; canonical: string }
+    try {
+      usernameData = validateUsername(name)
+    } catch (error) {
+      if (error instanceof UsernameValidationError) {
+        return c.json({ ok: false, error: error.message }, 400)
+      }
+      throw error
+    }
+    const { canonical: nameCanonical } = usernameData
+
+    // The caller must currently hold this exact active name. One active name
+    // per pubkey (partial unique index on pubkey, status='active').
+    const owned = await getUsernameByPubkey(c.env.DB, pubkey)
+    if (!owned) {
+      // Nothing active to release (e.g. already burned). Idempotent no-op.
+      return c.json({ ok: true, released: false, reason: 'no_active_name' })
+    }
+    const ownedCanonical = owned.username_canonical || owned.name?.toLowerCase()
+    if (ownedCanonical !== nameCanonical) {
+      return c.json({ ok: false, error: 'You do not own that username' }, 403)
+    }
+
+    // Burn: permanent, blocks re-registration (recyclable=0).
+    await revokeUsername(c.env.DB, nameCanonical, true)
+
+    // Delete from Fastly so the burned name stops resolving at the edge.
+    c.executionCtx.waitUntil(
+      deleteUsernameFromFastly(c.env, nameCanonical).then(async (result) => {
+        if (!result.success) {
+          await enqueueFastlySyncTask(c.env.DB, {
+            username: nameCanonical,
+            action: 'delete',
+          })
+        }
+      })
+    )
+
+    return c.json({
+      ok: true,
+      released: true,
+      name: owned.username_display || owned.name,
+      status: 'burned',
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'Nip98Error') {
+      return c.json({ ok: false, error: error.message }, 401)
+    }
+    console.error('Release error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -564,6 +564,14 @@ username.post('/release', async (c) => {
     const bodyText = await c.req.text()
 
     const url = new URL(c.req.url)
+    // Wider NIP-98 timestamp window than the default 60s: for vine-import
+    // users /release is often their first-ever NIP-98 call, and the mobile
+    // client stamps created_at before a remote-signer RPC that can take up to
+    // ~30s; with clock skew a 60s window yields systematic 401s that trap the
+    // whole account deletion. Safe to widen here because /release is idempotent
+    // (re-burning an already-burned name is a no-op) and self-scoped (only ever
+    // acts on the signer's own single active name).
+    const releaseNip98MaxAgeSeconds = 300
     // Lowercase for parity with /claim; getUsernameByPubkey compares
     // case-insensitively, so this is defensive normalization.
     const pubkey = (
@@ -571,7 +579,8 @@ username.post('/release', async (c) => {
         c.req.raw.headers,
         'POST',
         url.toString(),
-        bodyText
+        bodyText,
+        releaseNip98MaxAgeSeconds
       )
     ).toLowerCase()
 
@@ -589,41 +598,40 @@ username.post('/release', async (c) => {
       return c.json({ ok: false, error: 'name is required' }, 400)
     }
 
-    let usernameData: { display: string; canonical: string }
-    try {
-      usernameData = validateUsername(name)
-    } catch (error) {
-      if (error instanceof UsernameValidationError) {
-        return c.json({ ok: false, error: error.message }, 400)
-      }
-      throw error
-    }
-    const { canonical: nameCanonical } = usernameData
-
-    // The caller must currently hold this exact active name. One active name
-    // per pubkey (partial unique index on pubkey, status='active').
+    // Resolve ownership against the caller's stored row. Do NOT run claim-time
+    // character validation on /release: legacy vine-import names (underscores,
+    // dots, Unicode) were stored before today's rules and must still be
+    // burnable. One active name per pubkey (partial unique index on pubkey,
+    // status='active').
     const owned = await getUsernameByPubkey(c.env.DB, pubkey)
     if (!owned) {
       // Nothing active to release (e.g. already burned). Idempotent no-op.
       return c.json({ ok: true, released: false, reason: 'no_active_name' })
     }
-    const ownedCanonical = owned.username_canonical || owned.name?.toLowerCase()
-    if (ownedCanonical !== nameCanonical) {
+    const ownedCanonical = (
+      owned.username_canonical ||
+      owned.name ||
+      ''
+    ).toLowerCase()
+    const ownedName = (owned.name || '').toLowerCase()
+    const requested = name.trim().toLowerCase()
+    // Confirm the caller means their own name, matching either the stored
+    // canonical or the stored display (both case-insensitively) so the client
+    // may send either form.
+    if (requested !== ownedCanonical && requested !== ownedName) {
       return c.json({ ok: false, error: 'You do not own that username' }, 403)
     }
 
-    // Burn: permanent, blocks re-registration (recyclable=0). The ownership
-    // check above plus the unique username_canonical invariant ensure this
-    // hits exactly the caller's row, even though revokeUsername matches by
-    // canonical/name rather than pubkey.
-    await revokeUsername(c.env.DB, nameCanonical, true)
+    // Burn the stored canonical: permanent, blocks re-registration
+    // (recyclable=0).
+    await revokeUsername(c.env.DB, ownedCanonical, true)
 
     // Delete from Fastly so the burned name stops resolving at the edge.
     c.executionCtx.waitUntil(
-      deleteUsernameFromFastly(c.env, nameCanonical).then(async (result) => {
+      deleteUsernameFromFastly(c.env, ownedCanonical).then(async (result) => {
         if (!result.success) {
           await enqueueFastlySyncTask(c.env.DB, {
-            username: nameCanonical,
+            username: ownedCanonical,
             action: 'delete',
           })
         }


### PR DESCRIPTION
Backend half of the opt-in "burn my @divine.video username when I delete my account" feature (divinevideo/divine-mobile#6126). The mobile PR that adds the toggle depends on this endpoint.

## What
Adds a public `POST /api/username/release` so a user can permanently give up their own `@divine.video` username. Until now the only way to burn a name was the admin path, so a departing user's handle kept resolving after everything else was gone.

- **Auth:** NIP-98, same as `/claim`; the pubkey comes from the signed header.
- **Ownership:** verifies the authed pubkey currently holds the exact active name in the body before acting. You can only burn your own name.
- **Effect:** `revokeUsername(canonical, burn:true)` (status `burned`, `recyclable=0`) + Fastly de-sync, so the name stops resolving at origin and edge and cannot be re-registered (squatting/impersonation protection).
- **Idempotent:** 200 no-op when the caller owns no active name (e.g. already burned); 403 if they own a different name; 401 on NIP-98 failure.

## Why burn, not revoke
Burn blocks re-registration; revoke would let a squatter re-claim a departed user's handle. Opt-in on the client, gated behind the delete-account confirmation.

## Tests
4 new endpoint tests (burn own name, 403 wrong owner, 200 no-op, 401 auth). Full suite green (350), `tsc --noEmit` clean.

## Deployment
Needs `npm run deploy` (wrangler) to reach production `names.divine.video`, the host the mobile client calls. Safe to deploy ahead of the mobile PR — the endpoint is additive and unused until the toggle ships.
