### PR TITLE
refactor(test): centralize execution context mock

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1216,7 +1215,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1353,13 +1351,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
-      "integrity": "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -1399,9 +1400,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1418,13 +1419,12 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001755",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
-      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -1614,9 +1614,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.255",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.255.tgz",
-      "integrity": "sha512-Z9oIp4HrFF/cZkDPMpz2XSuVpc1THDpT4dlmATFlJUIBVCy9Vap5/rIXsASP1CscBacBqhabwh8vLctqBwEerQ==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1943,7 +1943,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2111,11 +2110,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2265,7 +2267,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2435,7 +2436,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2448,7 +2448,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2921,9 +2920,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {
@@ -2964,7 +2963,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -67,6 +67,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1215,6 +1216,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1351,16 +1353,13 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
-      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.29.tgz",
+      "integrity": "sha512-sXdt2elaVnhpDNRDz+1BDx1JQoJRuNk7oVlAlbGiFkLikHCAQiccexF/9e91zVi6RCgqspl04aP+6Cnl9zRLrA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/binary-extensions": {
@@ -1400,9 +1399,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
+      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
       "dev": true,
       "funding": [
         {
@@ -1419,12 +1418,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.8.25",
+        "caniuse-lite": "^1.0.30001754",
+        "electron-to-chromium": "^1.5.249",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.1.4"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
       "dev": true,
       "funding": [
         {
@@ -1614,9 +1614,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
-      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
+      "version": "1.5.255",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.255.tgz",
+      "integrity": "sha512-Z9oIp4HrFF/cZkDPMpz2XSuVpc1THDpT4dlmATFlJUIBVCy9Vap5/rIXsASP1CscBacBqhabwh8vLctqBwEerQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1943,6 +1943,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2110,14 +2111,11 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.53",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
-      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2267,6 +2265,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2436,6 +2435,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2448,6 +2448,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2920,9 +2921,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
-      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
       "dev": true,
       "funding": [
         {
@@ -2963,6 +2964,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -5,6 +5,17 @@ import type { Username } from './queries'
 
 export type MockRecord = Partial<Username> & { name: string; username_canonical: string }
 
+export function createExecutionContext(
+  overrides: Partial<ExecutionContext> = {}
+): ExecutionContext {
+  return {
+    waitUntil: () => {},
+    passThroughOnException: () => {},
+    props: {},
+    ...overrides,
+  } as ExecutionContext
+}
+
 /**
  * Create a fake D1 database backed by in-memory records.
  *

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -1,5 +1,6 @@
-// ABOUTME: Shared D1 fake for tests. Operates on in-memory data with
-// ABOUTME: lighter SQL-shape coupling and no bound-parameter position indexing.
+// ABOUTME: Shared test helpers: execution-context factory and D1 fake. The fake
+// ABOUTME: operates on in-memory data with lighter SQL-shape coupling and no
+// ABOUTME: bound-parameter position indexing.
 
 import type { Username } from './queries'
 

--- a/src/routes/admin-sync.test.ts
+++ b/src/routes/admin-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
+import { createExecutionContext } from '../db/test-helpers'
 
 const { getActiveUsernamesPaginated, countActiveUsernames, getUsernameByName, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, syncBatch, readUsernameFromFastly, syncAndVerifyUsername, deleteUsernameFromFastly } = vi.hoisted(() => ({
   getActiveUsernamesPaginated: vi.fn(),
@@ -37,7 +38,7 @@ function createTestApp() {
   return app
 }
 
-const ctx = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as unknown as ExecutionContext
+const ctx = createExecutionContext()
 
 const baseEnv = {
   DB: {} as D1Database,

--- a/src/routes/admin.test.ts
+++ b/src/routes/admin.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
   mockFetch.mockReset()
 })
 
-import { createFakeD1 } from '../db/test-helpers'
+import { createExecutionContext, createFakeD1 } from '../db/test-helpers'
 
 function createMockDB() {
   return createFakeD1([
@@ -43,7 +43,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -55,7 +55,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -68,7 +68,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&status=active')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -88,7 +88,7 @@ describe('Admin Search Endpoint', () => {
     ])
 
     const req = new Request('http://localhost/admin/usernames/search?q=&status=pending-confirmation')
-    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -102,7 +102,7 @@ describe('Admin Search Endpoint', () => {
 
     const longQuery = 'a'.repeat(101)
     const req = new Request(`http://localhost/admin/usernames/search?q=${longQuery}`)
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -114,7 +114,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -129,7 +129,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&status=invalid')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -141,7 +141,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&sort=weird')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -153,7 +153,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=-1')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -165,7 +165,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=0')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -177,7 +177,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&page=abc')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -189,7 +189,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=-1')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -201,7 +201,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=0')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -213,7 +213,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=test&limit=xyz')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -225,7 +225,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -239,7 +239,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&status=active')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -251,7 +251,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=&page=1&limit=10')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -264,7 +264,7 @@ describe('Admin Search Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/search?q=a')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -288,7 +288,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice,bob,charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -305,7 +305,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice bob charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -321,7 +321,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: ['alice', 'bob', 'charlie'] })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -337,7 +337,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice, bob charlie,dave' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -353,7 +353,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({})
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -369,7 +369,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: '   ' }) // whitespace only
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -386,7 +386,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: tooMany })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -402,7 +402,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice,bob,charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -427,7 +427,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: 'alice_123' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -449,7 +449,7 @@ describe('Admin Bulk Reserve Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ names: '@alice,@bob,@@charlie' })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -516,7 +516,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -531,7 +531,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -546,7 +546,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'not-an-email' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -561,7 +561,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'nonexistent', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(404)
     const json = await res.json() as any
@@ -576,7 +576,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB('reserved'), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB('reserved'), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(409)
     const json = await res.json() as any
@@ -591,7 +591,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(503)
     const json = await res.json() as any
@@ -606,7 +606,7 @@ describe('Admin Notify Assignment Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'testuser', email: 'user@example.com' })
     })
-    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createNotifyMockDB(), SENDGRID_API_KEY: 'test-key', BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -627,7 +627,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://names.divine.video/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(403)
     const json = await res.json() as any
@@ -639,7 +639,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://evil.example.com/api/admin/export/csv')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(403)
     const json = await res.json() as any
@@ -654,7 +654,7 @@ describe('Admin Hostname Auth Guard', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'alice', pubkey: 'a'.repeat(64) })
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(403)
   })
@@ -665,7 +665,7 @@ describe('Admin Hostname Auth Guard', () => {
     const req = new Request('https://names.admin.divine.video/api/admin/usernames/search?q=test', {
       headers: { 'Cf-Access-Jwt-Assertion': 'fake-jwt-for-test' }
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -677,7 +677,7 @@ describe('Admin Hostname Auth Guard', () => {
       const app = createTestApp()
 
       const req = new Request('http://localhost/api/admin/username/testuser')
-      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
       expect(res.status).toBe(200)
       const json = await res.json() as any
@@ -690,7 +690,7 @@ describe('Admin Hostname Auth Guard', () => {
       const app = createTestApp()
 
       const req = new Request('http://localhost/api/admin/username/nonexistent')
-      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
       expect(res.status).toBe(404)
       const json = await res.json() as any
@@ -703,7 +703,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('https://names.admin.divine.video/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(401)
   })
@@ -712,7 +712,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
   })
@@ -721,7 +721,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
 
     expect(res.status).toBe(401)
   })
@@ -730,7 +730,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/api/admin/usernames/search?q=test')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'false' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'false' }, createExecutionContext())
 
     expect(res.status).toBe(401)
   })
@@ -741,7 +741,7 @@ describe('Admin Hostname Auth Guard', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/api/admin/auth/status')
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -783,7 +783,7 @@ describe('OAuth Start Config Validation', () => {
     const app = createTestApp()
     const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
     const env = { ...baseEnv(), KEYCAST_URL: 'http://login.example.com' }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(503)
     const json = await res.json() as any
@@ -794,7 +794,7 @@ describe('OAuth Start Config Validation', () => {
     const app = createTestApp()
     const req = new Request('https://names.admin.divine.video/api/admin/auth/start', { method: 'POST' })
     const env = { ...baseEnv(), KEYCAST_URL: 'https://login.divine.video' }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(200)
   })
@@ -803,7 +803,7 @@ describe('OAuth Start Config Validation', () => {
     const app = createTestApp()
     const req = new Request('http://localhost/api/admin/auth/start', { method: 'POST' })
     const env = { ...baseEnv(), KEYCAST_URL: 'http://localhost:3000' }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(200)
   })
@@ -812,7 +812,7 @@ describe('OAuth Start Config Validation', () => {
     const app = createTestApp()
     const req = new Request('http://localhost/api/admin/auth/start', { method: 'POST' })
     const env = { ...baseEnv(), KEYCAST_URL: 'http://login.localhost:3000' }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(200)
   })
@@ -825,7 +825,7 @@ describe('OAuth Start Config Validation', () => {
       KEYCAST_URL: 'https://login.divine.video',
       OAUTH_CALLBACK_BASE_URL: 'https://evil.example.com',
     }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(503)
     const json = await res.json() as any
@@ -840,7 +840,7 @@ describe('OAuth Start Config Validation', () => {
       KEYCAST_URL: 'http://localhost:3000',
       OAUTH_CALLBACK_BASE_URL: 'http://admin.localhost:8787',
     }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -855,7 +855,7 @@ describe('OAuth Start Config Validation', () => {
       KEYCAST_URL: 'https://login.divine.video',
       OAUTH_CALLBACK_BASE_URL: 'javascript:void(0)',
     }
-    const res = await app.fetch(req, env, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, env, createExecutionContext())
 
     expect(res.status).toBe(503)
   })
@@ -894,7 +894,7 @@ describe('Admin Tag Endpoints', () => {
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
     })
-    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.ok).toBe(true)
@@ -910,13 +910,13 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     // Then remove it
     const res = await app.fetch(new Request('http://localhost/admin/username/kingbach/tags/vip', {
       method: 'DELETE',
       headers: { 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.ok).toBe(true)
@@ -932,17 +932,17 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     await app.fetch(new Request('http://localhost/admin/username/lelepons/tags', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     const res = await app.fetch(new Request('http://localhost/admin/tags', {
       method: 'GET',
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.tags).toContainEqual({ tag: 'vip', count: 2 })
@@ -956,7 +956,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'vip' }),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(404)
   })
 
@@ -968,7 +968,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({}),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.ok).toBe(false)
@@ -983,7 +983,7 @@ describe('Admin Tag Endpoints', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Cf-Access-Authenticated-User-Email': 'matthew@divine.video' },
       body: JSON.stringify({ tag: 'a'.repeat(51) }),
-    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.ok).toBe(false)
@@ -1002,7 +1002,7 @@ describe('Admin Stats Endpoint', () => {
     const app = createTestApp()
 
     const req = new Request('http://localhost/admin/usernames/stats')
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -1031,7 +1031,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'VIP creator account' }),
     })
-    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -1054,7 +1054,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'test' }),
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(404)
   })
@@ -1067,7 +1067,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: { nope: true } }),
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -1082,7 +1082,7 @@ describe('Admin Notes Endpoint', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ admin_notes: 'a'.repeat(5001) }),
     })
-    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB(), BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(400)
     const json = await res.json() as any
@@ -1109,7 +1109,7 @@ describe('Admin Export Endpoint', () => {
     ])
 
     const req = new Request('http://localhost/admin/export/csv?status=pending-confirmation')
-    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
 
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('text/csv')
@@ -1156,7 +1156,7 @@ describe('Fastly sync endpoints', () => {
         FASTLY_STORE_ID: 'test-store',
         BYPASS_LOCAL_AUTH: 'true',
       },
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+      createExecutionContext()
     )
 
     expect(res.status).toBe(200)
@@ -1192,7 +1192,7 @@ describe('Fastly sync endpoints', () => {
         FASTLY_STORE_ID: 'test-store',
         BYPASS_LOCAL_AUTH: 'true',
       },
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+      createExecutionContext()
     )
 
     expect(res.status).toBe(200)
@@ -1224,7 +1224,7 @@ describe('Fastly sync endpoints', () => {
         FASTLY_STORE_ID: 'test-store',
         BYPASS_LOCAL_AUTH: 'true',
       },
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+      createExecutionContext()
     )
 
     expect(res.status).toBe(200)
@@ -1260,7 +1260,7 @@ describe('Fastly sync endpoints', () => {
         FASTLY_STORE_ID: 'test-store',
         BYPASS_LOCAL_AUTH: 'true',
       },
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+      createExecutionContext()
     )
 
     expect(res.status).toBe(200)
@@ -1281,7 +1281,7 @@ describe('POST /api/admin/username/restore', () => {
     return app
   }
 
-  function callRestore(app: Hono<any>, env: any, body: any, ctx: ExecutionContext = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }) {
+  function callRestore(app: Hono<any>, env: any, body: any, ctx: ExecutionContext = createExecutionContext()) {
     const req = new Request('http://localhost/api/admin/username/restore', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -1359,11 +1359,9 @@ describe('POST /api/admin/username/restore', () => {
         atproto_state: null,
       }), { status: 200 }))
     const waitUntilPromises: Promise<unknown>[] = []
-    const ctx = {
+    const ctx = createExecutionContext({
       waitUntil: (promise: Promise<unknown>) => { waitUntilPromises.push(promise) },
-      passThroughOnException: () => {},
-      props: {},
-    } as unknown as ExecutionContext
+    })
 
     const app = createTestApp()
     const res = await callRestore(app, {
@@ -1416,11 +1414,9 @@ describe('POST /api/admin/username/restore', () => {
         atproto_state: null,
       }), { status: 200 }))
     const waitUntilPromises: Promise<unknown>[] = []
-    const ctx = {
+    const ctx = createExecutionContext({
       waitUntil: (promise: Promise<unknown>) => { waitUntilPromises.push(promise) },
-      passThroughOnException: () => {},
-      props: {},
-    } as unknown as ExecutionContext
+    })
 
     const app = createTestApp()
     const res = await callRestore(app, {
@@ -1495,7 +1491,7 @@ describe('POST /api/admin/username/restore', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'abuser', burn: true }),
     })
-    const revokeRes = await app.fetch(revokeReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const revokeRes = await app.fetch(revokeReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(revokeRes.status).toBe(200)
 
     // pubkey must be preserved through burn so moderation can find it
@@ -1504,7 +1500,7 @@ describe('POST /api/admin/username/restore', () => {
     expect(after?.pubkey).toBe(VALID_PUBKEY)
 
     const searchReq = new Request(`http://localhost/api/admin/usernames/search?q=${VALID_PUBKEY}&status=burned`)
-    const searchRes = await app.fetch(searchReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const searchRes = await app.fetch(searchReq, { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
     expect(searchRes.status).toBe(200)
     const json = await searchRes.json() as any
     expect(json.ok).toBe(true)

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import username from './username'
 import nip05 from './nip05'
+import { createExecutionContext } from '../db/test-helpers'
 
 // Mock NIP-98 middleware
 vi.mock('../middleware/nip98', () => ({
@@ -265,11 +266,7 @@ function createTestApp() {
   return app
 }
 
-const mockEnv = {
-  waitUntil: () => {},
-  passThroughOnException: () => {},
-  props: {}
-}
+const mockEnv = createExecutionContext()
 
 describe('Claim → NIP-05 resolution (e2e)', () => {
   beforeEach(async () => {
@@ -413,11 +410,9 @@ describe('Claim → NIP-05 resolution (e2e)', () => {
       headers: { 'Authorization': 'Nostr base64...', 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'dave' })
     })
-    await app.fetch(claimReq, { DB: db }, {
+    await app.fetch(claimReq, { DB: db }, createExecutionContext({
       waitUntil: (p: Promise<any>) => { waitUntilPromises.push(p) },
-      passThroughOnException: () => {},
-      props: {}
-    })
+    }))
 
     // Flush waitUntil promises so Fastly sync mock gets called
     await Promise.all(waitUntilPromises)

--- a/src/routes/internal-atproto.test.ts
+++ b/src/routes/internal-atproto.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import worker from '../index'
 import { syncAndVerifyUsername } from '../utils/fastly-sync'
+import { createExecutionContext } from '../db/test-helpers'
 
 vi.mock('../utils/fastly-sync', () => ({
   syncUsernameToFastly: vi.fn().mockResolvedValue({ success: true }),
@@ -108,7 +109,7 @@ describe('internal atproto sync route', () => {
         FASTLY_API_TOKEN: 'fastly-token',
         FASTLY_STORE_ID: 'store-id',
       } as any,
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+      createExecutionContext()
     )
 
     expect(response.status).toBe(200)
@@ -140,7 +141,7 @@ describe('internal atproto sync route', () => {
         ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
         ATPROTO_SYNC_TOKEN: 'test-sync-token',
       } as any,
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+      createExecutionContext()
     )
 
     expect(response.status).toBe(401)
@@ -168,7 +169,7 @@ describe('internal atproto sync route', () => {
         ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
         ATPROTO_SYNC_TOKEN: 'test-sync-token',
       } as any,
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+      createExecutionContext()
     )
 
     expect(response.status).toBe(404)
@@ -210,7 +211,7 @@ describe('internal atproto sync route', () => {
         ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
         ATPROTO_SYNC_TOKEN: 'test-sync-token',
       } as any,
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+      createExecutionContext()
     )
 
     expect(response.status).toBe(400)
@@ -252,7 +253,7 @@ describe('internal atproto sync route', () => {
         ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
         ATPROTO_SYNC_TOKEN: 'test-sync-token',
       } as any,
-      { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+      createExecutionContext()
     )
 
     expect(response.status).toBe(400)

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import username from './username'
+import { createExecutionContext } from '../db/test-helpers'
 
 // Mock NIP-98 middleware
 vi.mock('../middleware/nip98', () => ({
@@ -314,7 +315,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'MrBeast' })
     })
     
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db }, createExecutionContext())
 
     expect(res.status).toBe(200)
     const json = await res.json() as any
@@ -336,7 +337,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'MrBeast' })
     })
 
-    const res1 = await app.fetch(req1, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res1 = await app.fetch(req1, { DB: db }, createExecutionContext())
     expect(res1.status).toBe(200)
 
     // Second claim: mrbeast (should fail)
@@ -350,7 +351,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'mrbeast' })
     })
 
-    const res2 = await app.fetch(req2, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res2 = await app.fetch(req2, { DB: db }, createExecutionContext())
     expect(res2.status).toBe(409) // Conflict
     const json2 = await res2.json() as any
     expect(json2.error).toBe('That username is already taken')
@@ -371,7 +372,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'MrBeast' })
     })
 
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db }, createExecutionContext())
     // Without the pubkey normalization this is a 409 (treated as a different owner).
     expect(res.status).toBe(200)
   })
@@ -392,7 +393,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'newname' })
     })
 
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db }, createExecutionContext())
 
     expect(res.status).toBe(200)
     expect(db._mockUsernames.find(u => u.username_canonical === 'oldname')?.status).toBe('revoked')
@@ -414,7 +415,7 @@ describe('Username Claiming - Case Insensitive', () => {
       }
     })
 
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
 
     expect(res.status).toBe(204)
     expect(res.headers.get('access-control-allow-methods') || '').toContain('POST')
@@ -428,7 +429,7 @@ describe('Username Claiming - Case Insensitive', () => {
       headers: { 'Origin': 'https://app.divine.video' }
     })
 
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
 
     // Headers.get() joins duplicates with ", " — assert a single "*", not "*, *".
     expect(res.headers.get('access-control-allow-origin')).toBe('*')
@@ -447,7 +448,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'alice_123' })
     })
     
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.error).toContain('underscores')
@@ -465,7 +466,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: '-alice' })
     })
 
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.error).toContain("can't start or end with a hyphen")
@@ -483,7 +484,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'alice-' })
     })
 
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.error).toContain("can't start or end with a hyphen")
@@ -502,7 +503,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'm-r-beast-123' })
     })
     
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db }, createExecutionContext())
     expect(res.status).toBe(200)
     const json = await res.json() as any
     expect(json.name).toBe('m-r-beast-123')
@@ -521,7 +522,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'a' })
     })
 
-    const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: db }, createExecutionContext())
     expect(res.status).toBe(200)
   })
 
@@ -538,7 +539,7 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: longName })
     })
 
-    const res = await app.fetch(req, { DB: createMockDB() }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+    const res = await app.fetch(req, { DB: createMockDB() }, createExecutionContext())
     expect(res.status).toBe(400)
     const json = await res.json() as any
     expect(json.error).toContain('1–63 characters')
@@ -559,7 +560,9 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'oldname' })
     })
 
-    await app.fetch(req1, { DB: db }, { waitUntil: (p: Promise<any>) => { waitUntilCalls.push(p) }, passThroughOnException: () => {}, props: {} })
+    await app.fetch(req1, { DB: db }, createExecutionContext({
+      waitUntil: (p: Promise<any>) => { waitUntilCalls.push(p) },
+    }))
 
     // Second claim: "newname" (same pubkey)
     const { deleteUsernameFromFastly } = await import('../utils/fastly-sync')
@@ -574,7 +577,9 @@ describe('Username Claiming - Case Insensitive', () => {
       body: JSON.stringify({ name: 'newname' })
     })
 
-    const res2 = await app.fetch(req2, { DB: db }, { waitUntil: (p: Promise<any>) => { waitUntilCalls.push(p) }, passThroughOnException: () => {}, props: {} })
+    const res2 = await app.fetch(req2, { DB: db }, createExecutionContext({
+      waitUntil: (p: Promise<any>) => { waitUntilCalls.push(p) },
+    }))
     expect(res2.status).toBe(200)
 
     // Verify deleteUsernameFromFastly was called with the old name
@@ -601,7 +606,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -618,7 +623,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -639,7 +644,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -662,7 +667,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -682,7 +687,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -715,7 +720,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -732,7 +737,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.name).toBe('MrBeast')
@@ -750,7 +755,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(200)
       const json = await res.json() as any
       expect(json.ok).toBe(true)
@@ -766,7 +771,7 @@ describe('Public Username Endpoints', () => {
         method: 'GET'
       })
 
-      const res = await app.fetch(req, { DB: db }, { waitUntil: () => {}, passThroughOnException: () => {}, props: {} })
+      const res = await app.fetch(req, { DB: db }, createExecutionContext())
       expect(res.status).toBe(400)
       const json = await res.json() as any
       expect(json.ok).toBe(false)
@@ -793,7 +798,7 @@ describe('Public Name Reservation', () => {
     return `cashuA${b64}`
   }
 
-  const mockEnv = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+  const mockEnv = createExecutionContext()
 
   describe('POST /reserve - Reserve username with email', () => {
     it('should create a reservation for an available username', async () => {
@@ -1166,7 +1171,7 @@ describe('POST /release - burn own username', () => {
     return app
   }
 
-  const ctx = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} }
+  const ctx = createExecutionContext()
 
   function releaseReq(name: string) {
     return new Request('http://localhost/api/username/release', {

--- a/src/routes/webfinger.test.ts
+++ b/src/routes/webfinger.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import worker from '../index'
-import { createFakeD1, type MockRecord } from '../db/test-helpers'
+import { createExecutionContext, createFakeD1, type MockRecord } from '../db/test-helpers'
 
 // The cron/scheduled path pulls in fastly-sync; mock it so importing the worker
 // doesn't drag in real network code. Route handlers under test don't use it.
@@ -33,7 +33,7 @@ const env = (db: D1Database) => ({
   ASSETS: { fetch: async () => new Response('not found', { status: 404 }) },
 } as any)
 
-const ctx = { waitUntil: () => {}, passThroughOnException: () => {}, props: {} } as ExecutionContext
+const ctx = createExecutionContext()
 
 describe('WebFinger', () => {
   it('returns a valid JRD for a known active username', async () => {


### PR DESCRIPTION
## Summary
- add a shared test helper for Worker execution contexts
- replace duplicated route-test context literals with the helper
- keep custom waitUntil collection in the few tests that assert async side effects

## Motivation
Refs #69. This prepares the worker test suite for dependency maintenance without mixing test cleanup into the dependency update.

## Validation
- npx tsc --noEmit
- npm run test:once

## Notes
No product behavior change.