### PR TITLE
chore: keep Worker logs so hourly name sync failures are visible

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,6 +45,17 @@ database_id = "e7e081c4-830d-449c-9de5-d93eaacefb34"
 [triggers]
 crons = ["0 * * * *"]
 
+# Persist console.log / exceptions (including the hourly cron). Sample 100%
+# so the single scheduled run is not dropped.
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+invocation_logs = true
+head_sampling_rate = 1
+
 # Admin UI static assets (run_worker_first so public UI isn't overridden)
 [assets]
 directory = "./admin-ui/dist"


### PR DESCRIPTION
## Summary

The hourly job that copies leftover usernames to Fastly has been crashing, and we could not see why. This worker never stored `console.log` or exception text. This change turns on Cloudflare Workers Logs at 100% sampling so the next crash leaves a readable record.

No user-facing behavior change.

## Motivation

Dashboard analytics showed the hourly run dying (`scriptThrewException`) with no error string. Workers Logs were off (`observability` unset). Without this, we cannot tell whether the run hit a call cap, a Fastly error, or something else.

## Related Issue

None.

## What Changed

Enables Workers Logs in wrangler config, including invocation logs, with sampling at 100% so the single hourly run is not dropped. Tracing stays off.

This config is already live via a script-settings update. The pull request keeps git in sync so the next deploy does not turn logs back off.

## Validation

- [x] I could not run some validation locally, and I explained why below

Config-only. No application tests apply. Did not wait for the next hourly cron to confirm a log line appears.

- [ ] `npm run test:once`
- [ ] `npm run build:admin`
- [ ] relevant local Wrangler validation if applicable

## Manual Test Plan / Notes

After merge (or already, from the live settings patch): open Workers Logs for `divine-name-server` after the next `:00` UTC cron and confirm an invocation record exists, including on failure.

## Visuals / API Examples

- [x] No visual change

## Risks

Logs are kept 7 days. Paid plan includes 20 million events a month. This worker's current volume is well under that. Do not log tokens or raw Fastly bodies in future `console.log`s.

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved