### PR TITLE
fix(username): stop claims failing when remote signing takes over a minute

### DIFF
--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -321,6 +321,13 @@ describe('Username Claiming - Case Insensitive', () => {
     const json = await res.json() as any
     expect(json.ok).toBe(true)
     expect(json.name).toBe('MrBeast') // Display name preserved
+    expect(verifyNip98Event).toHaveBeenCalledWith(
+      expect.anything(),
+      'POST',
+      'http://localhost/api/username/claim',
+      JSON.stringify({ name: 'MrBeast' }),
+      300
+    )
   })
 
   it('should prevent case-insensitive collisions', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -418,6 +418,13 @@ username.get('/confirm', async (c) => {
   }
 })
 
+// Keycast remote-signer RPC + clock skew: mobile stamps created_at before
+// sign_event, which can take tens of seconds. The default 60s NIP-98 window
+// then 401s with "Event timestamp too old or in future" after a successful
+// availability check. /release already used 300s for this; /claim is the
+// same signer path. Replay is still bound to method, URL, and payload hash.
+const KEYCAST_NIP98_MAX_AGE_SECONDS = 300
+
 username.post('/claim', async (c) => {
   try {
     // Read raw body text first (needed for NIP-98 payload verification)
@@ -432,7 +439,8 @@ username.post('/claim', async (c) => {
       c.req.raw.headers,
       'POST',
       url.toString(),
-      bodyText
+      bodyText,
+      KEYCAST_NIP98_MAX_AGE_SECONDS
     )).toLowerCase()
 
     // Parse request body
@@ -564,14 +572,10 @@ username.post('/release', async (c) => {
     const bodyText = await c.req.text()
 
     const url = new URL(c.req.url)
-    // Wider NIP-98 timestamp window than the default 60s: for vine-import
-    // users /release is often their first-ever NIP-98 call, and the mobile
-    // client stamps created_at before a remote-signer RPC that can take up to
-    // ~30s; with clock skew a 60s window yields systematic 401s that trap the
-    // whole account deletion. Safe to widen here because /release is idempotent
-    // (re-burning an already-burned name is a no-op) and self-scoped (only ever
-    // acts on the signer's own single active name).
-    const releaseNip98MaxAgeSeconds = 300
+    // Same 300s NIP-98 window as /claim (KEYCAST_NIP98_MAX_AGE_SECONDS).
+    // For vine-import users /release is often their first-ever NIP-98 call.
+    // Safe to widen: /release is idempotent (re-burning is a no-op) and
+    // self-scoped (only the signer's own active name).
     // Lowercase for parity with /claim; getUsernameByPubkey compares
     // case-insensitively, so this is defensive normalization.
     const pubkey = (
@@ -580,7 +584,7 @@ username.post('/release', async (c) => {
         'POST',
         url.toString(),
         bodyText,
-        releaseNip98MaxAgeSeconds
+        KEYCAST_NIP98_MAX_AGE_SECONDS
       )
     ).toLowerCase()
 


### PR DESCRIPTION
## Summary

People can check a username, see it available, then get "Failed to claim username" on Save. The signed request is valid. The server rejects it because it is older than 60 seconds.

This gives claim the same 5-minute signing window release already has.

## Motivation

The mobile app stamps the request time, then waits on Keycast (remote signer) before POST `/api/username/claim`. That wait plus clock skew regularly exceeds 60 seconds. Availability GET succeeds. Claim returns 401 `Event timestamp too old or in future`. Profile save then aborts before publishing the kind 0 profile, so display name and avatar never go out if a username was included.

Release was already widened to 300 seconds for this same signer path.

## Related Issue

None.

## What Changed

`POST /api/username/claim` now accepts NIP-98 (signed HTTP auth) events up to 300 seconds old, same as `/release`. Signature, event id, URL, method, and payload hash checks are unchanged.

The mobile app still has a separate bug where it can keep a pre-sign timestamp on the event. That is not this change.

## Validation

- [x] `npm run test:once` (`src/routes/username.test.ts`, 48 passed)
- [ ] `npm run build:admin`
- [ ] relevant local Wrangler validation if applicable

Admin UI and Wrangler deploy were not needed for this route change.

## Manual Test Plan / Notes

After deploy: from the production app, pick an available name and Save after a Keycast sign that takes more than a few seconds. Expect 200 from `/api/username/claim`, not 401 timestamp.

## Visuals / API Examples

- [x] No visual change

Claim still returns the same JSON. Only the auth time window changes (60s to 300s).

## Risks

A stolen signed claim can be replayed for 5 minutes instead of 1. Replay still has to match method, absolute URL, and payload hash, so it can only repeat that same claim.

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved