### PR TITLE
feat(username): preserve names when account deletion cannot finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The Worker owns the username registry, a public reservation and claiming flow, a
 - **ATProto handles** — Links a username to a `did:plc:` identity so `alice.divine.video` resolves as an ATProto handle (served by `divine-router` from the mirrored record).
 - **Admin console** — A React admin UI plus API for reserving, revoking, burning, assigning, restoring, and tagging usernames, with search, stats, and CSV export.
 - **Edge mirror** — Every change is reconciled to Fastly KV via a durable sync queue and an hourly cron, so edge reads stay consistent with the D1 source of truth.
-- **One active name per pubkey** — A partial unique index guarantees each pubkey holds at most one active username; claiming a new one auto-revokes the old one.
+- **Recoverable account deletion** — Username release uses an owner-authenticated prepare/rollback lifecycle and a service-authenticated permanent finalize step.
+- **One owned name per pubkey** — A partial unique index guarantees each pubkey holds at most one active or pending-release username; claiming a new one auto-revokes the old one.
 
 ## Architecture
 
@@ -54,7 +55,8 @@ Admin API routes are guarded on two axes:
 A scheduled handler runs hourly (`0 * * * *`):
 
 1. Expires unconfirmed reservations older than 48 hours.
-2. Reconciles usernames changed in the last six hours, plus anything left in the durable Fastly sync queue, into Fastly KV — syncing active names and deleting revoked/burned ones. Failures are re-queued with bounded retries.
+2. Restores abandoned pending username releases after their recorded 72-hour recovery deadline; expiry never burns a name.
+3. Reconciles usernames changed in the last six hours, plus anything left in the durable Fastly sync queue, into Fastly KV — syncing active names and deleting revoked, burned, or pending-release names. Versioned queue entries prevent an older edge operation from clearing newer desired state.
 
 ## Getting started
 
@@ -149,12 +151,28 @@ All endpoints send permissive CORS headers so the Divine web and Flutter clients
 | `POST` | `/api/username/reserve` | Reserve a name with email + Cashu payment or invite code. |
 | `GET` | `/api/username/confirm` | JSON email-confirmation callback for a reservation token. |
 | `POST` | `/api/username/claim` | Claim a name with NIP-98 auth. |
+| `POST` | `/api/username/release/prepare` | Hide and hold an owned name for an opaque deletion attempt. NIP-98 auth. |
+| `GET` | `/api/username/release/attempt` | Read the caller's latest durable release-attempt state. NIP-98 auth. |
+| `POST` | `/api/username/release/rollback` | Restore a recoverable pending release. NIP-98 auth. |
+| `POST` | `/api/username/release` | Legacy immediate permanent burn; retained while callers migrate, with removal tracked in #78. |
 
 #### POST /api/username/claim
 
 Claim a username by proving key ownership.
 
-**Authentication:** a NIP-98 event (kind `27235`) sent as `Authorization: Nostr <base64-event>`, with a `u` tag matching the request URL, a `method` tag matching `POST`, and a timestamp within 60 seconds.
+**Authentication:** a NIP-98 event (kind `27235`) sent as `Authorization: Nostr <base64-event>`, with a `u` tag matching the request URL, a `method` tag matching `POST`, and a timestamp within 300 seconds.
+
+#### Recoverable release lifecycle
+
+The deletion coordinator supplies one opaque 16–128 character attempt ID across services. Preparing changes the owned row from `active` to `pending-release`; the name stops resolving but remains owned and unavailable to claims. The authenticated owner may roll it back to `active`, or the trusted deletion coordinator may finalize it to non-recyclable `burned`. Replays of the same transition are safe. A finalized attempt cannot be rolled back.
+
+```text
+active --prepare--> pending-release --rollback--------> active / cancelled
+                              |--72h expiry restore---> active / expired-restored
+                              `--service finalize-----> burned / finalized
+```
+
+`POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` with `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>`. Set that credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 
 **Request body:**
 
@@ -279,13 +297,17 @@ Migrations under `migrations/` define and evolve the schema (`0001_initial_schem
 | `username_canonical` | TEXT | Canonical (lowercased, punycode) form used for lookups |
 | `pubkey` | TEXT | Hex Nostr public key |
 | `relays` | TEXT | JSON array of relay hints (max 50) |
-| `status` | TEXT | `active`, `reserved`, `revoked`, `burned`, `pending-confirmation` |
+| `status` | TEXT | `active`, `reserved`, `revoked`, `burned`, `pending-confirmation`, `pending-release` |
 | `recyclable` | INTEGER | Whether a freed name can be reclaimed |
 | `atproto_did` / `atproto_state` | TEXT | ATProto handle linkage |
 | `created_at` / `updated_at` / `claimed_at` / `revoked_at` | INTEGER | Unix timestamps |
 | `reserved_reason` / `admin_notes` | TEXT | Admin metadata |
 
-A partial unique index enforces one `active` name per pubkey.
+A partial unique index enforces one owned (`active` or `pending-release`) name per pubkey.
+
+### username_release_attempts
+
+Durable audit records keyed by opaque deletion-attempt ID. Each record stores the canonical name, owner pubkey, state (`pending`, `cancelled`, `finalized`, or `expired-restored`), timestamps, explicit expiry, and service finalizer identity. Admins can inspect recent attempts through `GET /api/admin/username-release-attempts`.
 
 ### reserved_words
 

--- a/admin-ui/src/components/StatusBadge.tsx
+++ b/admin-ui/src/components/StatusBadge.tsx
@@ -14,10 +14,12 @@ export default function StatusBadge({ status, isRecovered }: StatusBadgeProps) {
     revoked: 'bg-gray-100 text-gray-800',
     burned: 'bg-red-100 text-red-800',
     'pending-confirmation': 'bg-cyan-100 text-cyan-800',
+    'pending-release': 'bg-orange-100 text-orange-800',
     recovered: 'bg-purple-100 text-purple-800'
   }
   const labels: Record<string, string> = {
     'pending-confirmation': 'pending confirmation',
+    'pending-release': 'pending release',
   }
 
   const displayStatus = isRecovered ? 'recovered' : status

--- a/admin-ui/src/pages/Dashboard.tsx
+++ b/admin-ui/src/pages/Dashboard.tsx
@@ -170,6 +170,7 @@ export default function Dashboard() {
             { label: 'Active', value: stats.totals.active, tone: 'bg-green-50 border-green-200 text-green-900' },
             { label: 'Reserved', value: stats.totals.reserved, tone: 'bg-yellow-50 border-yellow-200 text-yellow-900' },
             { label: 'Pending Confirm.', value: stats.totals.pending_confirmation, tone: 'bg-cyan-50 border-cyan-200 text-cyan-900' },
+            { label: 'Pending Release', value: stats.totals.pending_release, tone: 'bg-orange-50 border-orange-200 text-orange-900' },
             { label: 'With Notes', value: stats.metadata.with_notes, tone: 'bg-blue-50 border-blue-200 text-blue-900' },
             { label: 'With Tags', value: stats.metadata.with_tags, tone: 'bg-indigo-50 border-indigo-200 text-indigo-900' },
             { label: 'Untagged', value: stats.metadata.untagged, tone: 'bg-orange-50 border-orange-200 text-orange-900' },
@@ -220,6 +221,7 @@ export default function Dashboard() {
               <option value="active">Active</option>
               <option value="reserved">Reserved</option>
               <option value="pending-confirmation">Pending Confirmation</option>
+              <option value="pending-release">Pending Release</option>
               <option value="recovered">Recovered (Vine)</option>
               <option value="revoked">Revoked</option>
               <option value="burned">Burned</option>

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,6 +1,6 @@
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
 export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
-export type UsernameStatus = 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
+export type UsernameStatus = 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'pending-release'
 
 export interface TagDetail {
   tag: string
@@ -139,6 +139,7 @@ export interface UsernameStats {
     revoked: number
     burned: number
     pending_confirmation: number
+    pending_release: number
   }
   metadata: {
     with_notes: number

--- a/migrations/0012_add_release_attempts.sql
+++ b/migrations/0012_add_release_attempts.sql
@@ -1,0 +1,31 @@
+-- ABOUTME: Adds recoverable username-release attempts and versioned Fastly reconciliation.
+-- ABOUTME: Enforces one owned (active or pending-release) username per pubkey.
+
+DROP INDEX IF EXISTS idx_usernames_pubkey_active;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_usernames_pubkey_owned
+  ON usernames(LOWER(pubkey))
+  WHERE pubkey IS NOT NULL AND status IN ('active', 'pending-release');
+
+CREATE TABLE IF NOT EXISTS username_release_attempts (
+  attempt_id TEXT PRIMARY KEY,
+  username_canonical TEXT NOT NULL,
+  pubkey TEXT NOT NULL,
+  state TEXT NOT NULL CHECK(state IN ('pending', 'cancelled', 'finalized', 'expired-restored')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  cancelled_at INTEGER,
+  finalized_at INTEGER,
+  finalized_by TEXT,
+  FOREIGN KEY (username_canonical) REFERENCES usernames(username_canonical)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_release_attempts_pending_pubkey
+  ON username_release_attempts(LOWER(pubkey)) WHERE state = 'pending';
+CREATE INDEX IF NOT EXISTS idx_release_attempts_username
+  ON username_release_attempts(username_canonical);
+CREATE INDEX IF NOT EXISTS idx_release_attempts_state_expires
+  ON username_release_attempts(state, expires_at);
+
+ALTER TABLE fastly_sync_queue ADD COLUMN generation INTEGER NOT NULL DEFAULT 0;

--- a/migrations/0012_add_release_attempts.sql
+++ b/migrations/0012_add_release_attempts.sql
@@ -1,11 +1,16 @@
 -- ABOUTME: Adds recoverable username-release attempts and versioned Fastly reconciliation.
 -- ABOUTME: Enforces one owned (active or pending-release) username per pubkey.
 
-DROP INDEX IF EXISTS idx_usernames_pubkey_active;
-
+-- Create the replacement before dropping the old guard. This index re-keys on
+-- LOWER(pubkey), which the case-sensitive index it replaces did not enforce, so
+-- legacy rows differing only by pubkey case make the CREATE fail. In that order
+-- the migration aborts with the old guard still in place; the other way round it
+-- would leave usernames with no one-name-per-pubkey constraint at all.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_usernames_pubkey_owned
   ON usernames(LOWER(pubkey))
   WHERE pubkey IS NOT NULL AND status IN ('active', 'pending-release');
+
+DROP INDEX IF EXISTS idx_usernames_pubkey_active;
 
 CREATE TABLE IF NOT EXISTS username_release_attempts (
   attempt_id TEXT PRIMARY KEY,

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Verifies the migration chain applies cleanly and fails safely.
+// ABOUTME: The one-owned-name-per-pubkey guard must never be dropped without a replacement.
+
+import { describe, expect, it } from 'vitest'
+import {
+  applyMigrations,
+  createSqlite,
+  createSqliteD1,
+  migrationSql,
+  pubkeyIndexNames,
+  sqliteAvailable,
+} from './sqlite-test-helpers'
+
+const RELEASE_MIGRATION = '0012_add_release_attempts'
+
+describe.skipIf(!sqliteAvailable())('migration chain', () => {
+  it('applies cleanly and leaves exactly one owned-name guard', () => {
+    const { sqlite } = createSqliteD1()
+    expect(pubkeyIndexNames(sqlite)).toEqual(['idx_usernames_pubkey_owned'])
+  })
+
+  it('keeps a uniqueness guard when legacy rows collide only by pubkey case', () => {
+    const sqlite = createSqlite()
+    applyMigrations(sqlite, { stopBefore: RELEASE_MIGRATION })
+
+    // The pre-0012 index keys on raw `pubkey`, so it permits two active rows
+    // whose keys differ only in case. queries.ts notes legacy rows may hold
+    // mixed-case hex pubkeys, so production can look like this.
+    sqlite.exec(`
+      INSERT INTO usernames (name, username_canonical, pubkey, status, recyclable, created_at, updated_at)
+      VALUES ('bob','bob','ABCDEF','active',1,1,1), ('carol','carol','abcdef','active',1,1,1)
+    `)
+
+    // 0012 re-keys the index on LOWER(pubkey), which those rows violate. The
+    // migration must fail with the old guard intact rather than dropping it
+    // first and leaving the table with no uniqueness constraint at all.
+    expect(() => sqlite.exec(migrationSql(RELEASE_MIGRATION))).toThrow(/UNIQUE constraint failed/)
+    expect(pubkeyIndexNames(sqlite)).toEqual(['idx_usernames_pubkey_active'])
+  })
+})

--- a/src/db/node-builtins.d.ts
+++ b/src/db/node-builtins.d.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Minimal declarations for the Node built-ins used by SQLite test helpers.
+// ABOUTME: tsconfig pins `types` to workers-types, so @types/node is deliberately absent.
+
+// The Worker runtime has none of these. Declaring just the surface the test
+// helpers touch keeps `tsc --noEmit` clean without pulling ambient Node globals
+// into the project and shadowing Cloudflare's.
+
+declare module 'node:fs' {
+  export function readdirSync(path: string): string[]
+  export function readFileSync(path: string, encoding: string): string
+}
+
+declare module 'node:module' {
+  export function createRequire(path: string): (id: string) => unknown
+}
+
+declare module 'node:url' {
+  export function fileURLToPath(url: string | URL): string
+}
+
+interface ImportMeta {
+  url: string
+}

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for database query functions
 // ABOUTME: Validates search functionality with fake D1 database
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { searchUsernames, claimUsername, assignUsername, createReservation, reserveUsername, revokeUsername, restoreUsername, addTag, removeTag, getTagsForUsername, getTagDetailsForUsername, getTagsForUsernames, getAllTags, getUsernameByName, getUsernameStats, updateAdminNotes, getActiveUsernamesPaginated, countActiveUsernames, enqueueFastlySyncTask, getQueuedFastlySyncTasks, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchParams, type Username } from './queries'
 import { createFakeD1, type MockRecord } from './test-helpers'
 
@@ -949,8 +949,15 @@ describe('Fastly sync queue helpers', () => {
     expect(db._rows.find((row) => row.username_canonical === 'user-0')?.attempt_count).toBe(2)
     expect(db._rows.find((row) => row.username_canonical === 'user-0')?.last_error).toBe('second')
 
+    const batchSpy = vi.spyOn(db as unknown as { batch: (statements: unknown[]) => Promise<unknown> }, 'batch')
+
     await clearFastlySyncTasks(db, db._rows.map((row) => ({ username: row.username_canonical, generation: row.generation || 1 })))
     expect(db._rows).toHaveLength(0)
+
+    // Generation scoping needs one predicate per task, but they still travel
+    // together: 501 deletes are two chunked batches, not 501 round trips.
+    expect(batchSpy).toHaveBeenCalledTimes(2)
+    expect(batchSpy.mock.calls.map(([statements]) => (statements as unknown[]).length)).toEqual([500, 1])
   })
 })
 

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -192,10 +192,11 @@ describe('claimUsername', () => {
         sqlStatements.push(sql)
         return {
           bind: (..._params: any[]) => ({
-            run: async () => ({ success: true }),
+            run: async () => ({ success: true, meta: { changes: 1 } }),
           }),
         }
       },
+      batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
     } as unknown as D1Database
 
     await claimUsername(mockDB, 'TestUser', 'testuser', 'abc123', null)
@@ -212,10 +213,11 @@ describe('claimUsername', () => {
         sqlStatements.push(sql)
         return {
           bind: (..._params: any[]) => ({
-            run: async () => ({ success: true }),
+            run: async () => ({ success: true, meta: { changes: 1 } }),
           }),
         }
       },
+      batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
     } as unknown as D1Database
 
     await claimUsername(mockDB, 'TestUser', 'testuser', 'abc123', null)
@@ -537,6 +539,7 @@ function createStatefulMockDB(initialRecords: Partial<Username>[] = []) {
         },
       }
     },
+    batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
   } as unknown as D1Database & { _records: Partial<Username>[] }
 }
 
@@ -745,10 +748,11 @@ type QueueRow = {
   last_attempt_at: number | null
   attempt_count: number
   last_error: string | null
+  generation?: number
 }
 
 function createFastlyQueueMock(initialRows: QueueRow[] = []) {
-  const rows = [...initialRows]
+  const rows = initialRows.map(row => ({ ...row, generation: row.generation ?? 1 }))
 
   return {
     _rows: rows,
@@ -768,6 +772,7 @@ function createFastlyQueueMock(initialRows: QueueRow[] = []) {
                 last_attempt_at: null,
                 attempt_count: 0,
                 last_error: null,
+                generation: 1,
               })
               return { success: true, meta: { changes: 1 } }
             }
@@ -777,6 +782,7 @@ function createFastlyQueueMock(initialRows: QueueRow[] = []) {
             existing.payload_json = payloadJson
             existing.updated_at = updatedAt
             if (changed) {
+              existing.generation = (existing.generation || 1) + 1
               existing.queued_at = queuedAt
               existing.last_attempt_at = null
               existing.attempt_count = 0
@@ -791,6 +797,13 @@ function createFastlyQueueMock(initialRows: QueueRow[] = []) {
               if (usernames.has(rows[i].username_canonical)) rows.splice(i, 1)
             }
             return { success: true, meta: { changes: 1 } }
+          }
+
+          if (sql.includes('DELETE FROM fastly_sync_queue WHERE username_canonical = ? AND generation = ?')) {
+            const [username, generation] = params
+            const index = rows.findIndex(row => row.username_canonical === username && row.generation === generation)
+            if (index >= 0) rows.splice(index, 1)
+            return { success: true, meta: { changes: index >= 0 ? 1 : 0 } }
           }
 
           if (sql.includes('UPDATE fastly_sync_queue') && sql.includes('attempt_count = attempt_count + 1')) {
@@ -829,6 +842,16 @@ function createFastlyQueueMock(initialRows: QueueRow[] = []) {
 }
 
 describe('Fastly sync queue helpers', () => {
+  it('does not clear a newer desired-state generation after an older operation succeeds', async () => {
+    const db = createFastlyQueueMock([{
+      username_canonical: 'alice', action: 'delete', payload_json: null, queued_at: 100, updated_at: 100,
+      last_attempt_at: null, attempt_count: 0, last_error: null, generation: 2,
+    }])
+    await clearFastlySyncTasks(db, [{ username: 'alice', generation: 1 }])
+    expect(db._rows).toHaveLength(1)
+    await clearFastlySyncTasks(db, [{ username: 'alice', generation: 2 }])
+    expect(db._rows).toHaveLength(0)
+  })
   it('enqueueFastlySyncTask preserves attempt metadata for unchanged queued work', async () => {
     const db = createFastlyQueueMock([{
       username_canonical: 'alice',
@@ -926,7 +949,7 @@ describe('Fastly sync queue helpers', () => {
     expect(db._rows.find((row) => row.username_canonical === 'user-0')?.attempt_count).toBe(2)
     expect(db._rows.find((row) => row.username_canonical === 'user-0')?.last_error).toBe('second')
 
-    await clearFastlySyncTasks(db, db._rows.map((row) => row.username_canonical))
+    await clearFastlySyncTasks(db, db._rows.map((row) => ({ username: row.username_canonical, generation: row.generation || 1 })))
     expect(db._rows).toHaveLength(0)
   })
 })

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -268,13 +268,17 @@ export async function finalizeReleaseAttempt(
     return { outcome: 'replayed', attempt: existing, username: currentUsername }
   }
   if (existing.state !== 'pending') return { outcome: 'conflict', attempt: existing }
+  if (existing.expires_at <= now) return { outcome: 'conflict', attempt: existing }
 
   const burn = db.prepare(
     `UPDATE usernames
      SET status = 'burned', recyclable = 0, revoked_at = ?, updated_at = ?
      WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'pending-release'
-       AND EXISTS (SELECT 1 FROM username_release_attempts WHERE attempt_id = ? AND state = 'pending')`
-  ).bind(now, now, existing.username_canonical, existing.pubkey, attemptId)
+       AND EXISTS (
+         SELECT 1 FROM username_release_attempts
+         WHERE attempt_id = ? AND state = 'pending' AND expires_at > ?
+       )`
+  ).bind(now, now, existing.username_canonical, existing.pubkey, attemptId, now)
   const finishAttempt = db.prepare(
     `UPDATE username_release_attempts
      SET state = 'finalized', updated_at = ?, finalized_at = ?, finalized_by = ?

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -540,10 +540,24 @@ export async function clearFastlySyncTasks(
 ): Promise<void> {
   if (tasks.length === 0) return
 
-  for (const task of tasks) {
-    await db.prepare(
+  // Generation scoping needs a predicate per task, so this can no longer be one
+  // IN (...) delete. Send them together anyway: the hourly cron reads up to 5000
+  // queued tasks, and one round trip each would dominate the run.
+  const statements = tasks.map((task) =>
+    db.prepare(
       'DELETE FROM fastly_sync_queue WHERE username_canonical = ? AND generation = ?'
-    ).bind(task.username, task.generation).run()
+    ).bind(task.username, task.generation)
+  )
+
+  if (typeof (db as { batch?: unknown }).batch === 'function') {
+    for (let i = 0; i < statements.length; i += 500) {
+      await db.batch(statements.slice(i, i + 500))
+    }
+    return
+  }
+
+  for (const statement of statements) {
+    await statement.run()
   }
 }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -14,7 +14,7 @@ export interface Username {
   pubkey: string | null
   email: string | null
   relays: string | null
-  status: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation'
+  status: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'pending-release'
   recyclable: number
   created_at: number
   updated_at: number
@@ -46,7 +46,7 @@ export interface ReservationToken {
 
 export interface SearchParams {
   query: string
-  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'recovered'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'pending-release' | 'recovered'
   tag?: string
   sort?: SearchSort
   page?: number
@@ -64,11 +64,27 @@ export interface SearchResult {
 }
 
 export interface FastlySyncQueueTask extends SyncItem {
+  generation: number
   queued_at: number
   updated_at: number
   last_attempt_at: number | null
   attempt_count: number
   last_error: string | null
+}
+
+export type ReleaseAttemptState = 'pending' | 'cancelled' | 'finalized' | 'expired-restored'
+
+export interface UsernameReleaseAttempt {
+  attempt_id: string
+  username_canonical: string
+  pubkey: string
+  state: ReleaseAttemptState
+  created_at: number
+  updated_at: number
+  expires_at: number
+  cancelled_at: number | null
+  finalized_at: number | null
+  finalized_by: string | null
 }
 
 export interface RestoreUsernameResult {
@@ -112,6 +128,193 @@ export async function getUsernameByPubkey(
   return result
 }
 
+export async function getReleaseAttemptById(
+  db: D1Database,
+  attemptId: string
+): Promise<UsernameReleaseAttempt | null> {
+  return db.prepare(
+    'SELECT * FROM username_release_attempts WHERE attempt_id = ?'
+  ).bind(attemptId).first<UsernameReleaseAttempt>()
+}
+
+export async function getLatestReleaseAttemptByPubkey(
+  db: D1Database,
+  pubkey: string
+): Promise<UsernameReleaseAttempt | null> {
+  return db.prepare(
+    `SELECT * FROM username_release_attempts
+     WHERE LOWER(pubkey) = LOWER(?)
+     ORDER BY created_at DESC, attempt_id DESC LIMIT 1`
+  ).bind(pubkey).first<UsernameReleaseAttempt>()
+}
+
+export type ReleaseTransitionResult =
+  | { outcome: 'transitioned' | 'replayed'; attempt: UsernameReleaseAttempt; username: Username }
+  | { outcome: 'conflict'; attempt?: UsernameReleaseAttempt }
+  | { outcome: 'not_found'; attempt?: UsernameReleaseAttempt }
+
+export async function prepareReleaseAttempt(
+  db: D1Database,
+  pubkey: string,
+  usernameCanonical: string,
+  attemptId: string,
+  expiresAt: number,
+  now = Math.floor(Date.now() / 1000)
+): Promise<ReleaseTransitionResult> {
+  const existing = await getReleaseAttemptById(db, attemptId)
+  if (existing) {
+    if (existing.pubkey.toLowerCase() !== pubkey.toLowerCase() || existing.username_canonical !== usernameCanonical) {
+      return { outcome: 'conflict' }
+    }
+    const username = await getUsernameByName(db, usernameCanonical)
+    if (existing.state === 'pending' && username?.status === 'pending-release') {
+      return { outcome: 'replayed', attempt: existing, username }
+    }
+    return { outcome: 'conflict', attempt: existing }
+  }
+
+  const insertAttempt = db.prepare(
+    `INSERT OR IGNORE INTO username_release_attempts (
+       attempt_id, username_canonical, pubkey, state, created_at, updated_at, expires_at
+     )
+     SELECT ?, username_canonical, pubkey, 'pending', ?, ?, ?
+     FROM usernames
+     WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'active'`
+  ).bind(attemptId, now, now, expiresAt, usernameCanonical, pubkey)
+  const markPending = db.prepare(
+    `UPDATE usernames
+     SET status = 'pending-release', updated_at = ?
+     WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'active'
+       AND EXISTS (
+         SELECT 1 FROM username_release_attempts
+         WHERE attempt_id = ? AND username_canonical = ?
+           AND LOWER(pubkey) = LOWER(?) AND state = 'pending'
+       )`
+  ).bind(now, usernameCanonical, pubkey, attemptId, usernameCanonical, pubkey)
+
+  const [insertResult, updateResult] = await db.batch([insertAttempt, markPending])
+  const attempt = await getReleaseAttemptById(db, attemptId)
+  const username = await getUsernameByName(db, usernameCanonical)
+  if (!insertResult.meta?.changes || !updateResult.meta?.changes) {
+    if (attempt && attempt.pubkey.toLowerCase() === pubkey.toLowerCase() &&
+        attempt.username_canonical === usernameCanonical && attempt.state === 'pending' &&
+        username?.status === 'pending-release') {
+      return { outcome: 'replayed', attempt, username }
+    }
+    const pendingForPubkey = await getLatestReleaseAttemptByPubkey(db, pubkey)
+    return pendingForPubkey?.state === 'pending' || attempt ? { outcome: 'conflict', attempt: attempt || undefined } : { outcome: 'not_found' }
+  }
+  if (!attempt || !username) return { outcome: 'not_found' }
+  return { outcome: 'transitioned', attempt, username }
+}
+
+export async function rollbackReleaseAttempt(
+  db: D1Database,
+  pubkey: string,
+  usernameCanonical: string,
+  attemptId: string,
+  terminalState: 'cancelled' | 'expired-restored' = 'cancelled',
+  now = Math.floor(Date.now() / 1000)
+): Promise<ReleaseTransitionResult> {
+  const existing = await getReleaseAttemptById(db, attemptId)
+  if (!existing) return { outcome: 'not_found' }
+  if (existing.pubkey.toLowerCase() !== pubkey.toLowerCase() || existing.username_canonical !== usernameCanonical) {
+    return { outcome: 'conflict' }
+  }
+  const currentUsername = await getUsernameByName(db, usernameCanonical)
+  if (existing.state === terminalState && currentUsername?.status === 'active') {
+    return { outcome: 'replayed', attempt: existing, username: currentUsername }
+  }
+  if (existing.state !== 'pending') return { outcome: 'conflict', attempt: existing }
+
+  const restore = db.prepare(
+    `UPDATE usernames SET status = 'active', revoked_at = NULL, updated_at = ?
+     WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'pending-release'
+       AND EXISTS (SELECT 1 FROM username_release_attempts WHERE attempt_id = ? AND state = 'pending')`
+  ).bind(now, usernameCanonical, pubkey, attemptId)
+  const finishAttempt = db.prepare(
+    `UPDATE username_release_attempts
+     SET state = ?, updated_at = ?, cancelled_at = ?
+     WHERE attempt_id = ? AND state = 'pending'
+       AND EXISTS (SELECT 1 FROM usernames WHERE username_canonical = ? AND status = 'active')`
+  ).bind(terminalState, now, now, attemptId, usernameCanonical)
+  const [restoreResult, attemptResult] = await db.batch([restore, finishAttempt])
+  const attempt = await getReleaseAttemptById(db, attemptId)
+  const username = await getUsernameByName(db, usernameCanonical)
+  if (!restoreResult.meta?.changes || !attemptResult.meta?.changes) {
+    if (attempt?.state === terminalState && username?.status === 'active') {
+      return { outcome: 'replayed', attempt, username }
+    }
+    return { outcome: 'conflict', attempt: attempt || undefined }
+  }
+  if (!attempt || !username) return { outcome: 'conflict' }
+  return { outcome: 'transitioned', attempt, username }
+}
+
+export async function finalizeReleaseAttempt(
+  db: D1Database,
+  attemptId: string,
+  finalizedBy: string,
+  now = Math.floor(Date.now() / 1000)
+): Promise<ReleaseTransitionResult> {
+  const existing = await getReleaseAttemptById(db, attemptId)
+  if (!existing) return { outcome: 'not_found' }
+  const currentUsername = await getUsernameByName(db, existing.username_canonical)
+  if (existing.state === 'finalized' && currentUsername?.status === 'burned') {
+    return { outcome: 'replayed', attempt: existing, username: currentUsername }
+  }
+  if (existing.state !== 'pending') return { outcome: 'conflict', attempt: existing }
+
+  const burn = db.prepare(
+    `UPDATE usernames
+     SET status = 'burned', recyclable = 0, revoked_at = ?, updated_at = ?
+     WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'pending-release'
+       AND EXISTS (SELECT 1 FROM username_release_attempts WHERE attempt_id = ? AND state = 'pending')`
+  ).bind(now, now, existing.username_canonical, existing.pubkey, attemptId)
+  const finishAttempt = db.prepare(
+    `UPDATE username_release_attempts
+     SET state = 'finalized', updated_at = ?, finalized_at = ?, finalized_by = ?
+     WHERE attempt_id = ? AND state = 'pending'
+       AND EXISTS (SELECT 1 FROM usernames WHERE username_canonical = ? AND status = 'burned')`
+  ).bind(now, now, finalizedBy, attemptId, existing.username_canonical)
+  const [burnResult, attemptResult] = await db.batch([burn, finishAttempt])
+  const attempt = await getReleaseAttemptById(db, attemptId)
+  const username = await getUsernameByName(db, existing.username_canonical)
+  if (!burnResult.meta?.changes || !attemptResult.meta?.changes) {
+    if (attempt?.state === 'finalized' && username?.status === 'burned') {
+      return { outcome: 'replayed', attempt, username }
+    }
+    return { outcome: 'conflict', attempt: attempt || undefined }
+  }
+  if (!attempt || !username) return { outcome: 'conflict' }
+  return { outcome: 'transitioned', attempt, username }
+}
+
+export async function getStaleReleaseAttempts(
+  db: D1Database,
+  now = Math.floor(Date.now() / 1000),
+  limit = 100
+): Promise<UsernameReleaseAttempt[]> {
+  const result = await db.prepare(
+    `SELECT * FROM username_release_attempts
+     WHERE state = 'pending' AND expires_at <= ?
+     ORDER BY expires_at ASC LIMIT ?`
+  ).bind(now, limit).all<UsernameReleaseAttempt>()
+  return result.results
+}
+
+export async function listReleaseAttempts(
+  db: D1Database,
+  state?: ReleaseAttemptState,
+  limit = 100
+): Promise<UsernameReleaseAttempt[]> {
+  const statement = state
+    ? db.prepare(`SELECT * FROM username_release_attempts WHERE state = ? ORDER BY updated_at DESC LIMIT ?`).bind(state, limit)
+    : db.prepare(`SELECT * FROM username_release_attempts ORDER BY updated_at DESC LIMIT ?`).bind(limit)
+  const result = await statement.all<UsernameReleaseAttempt>()
+  return result.results
+}
+
 export async function claimUsername(
   db: D1Database,
   nameDisplay: string,
@@ -122,18 +325,28 @@ export async function claimUsername(
   const now = Math.floor(Date.now() / 1000)
   const relaysJson = relays ? JSON.stringify(relays) : null
 
-  // First, revoke any existing active username for this pubkey.
-  // Legacy rows may contain mixed-case hex pubkeys, so match case-insensitively.
-  await db.prepare(
+  // Keep the release and claim in one D1 transaction. The EXISTS predicate is
+  // repeated in both statements so an unavailable (including pending-release)
+  // target can never cause the caller's current name to be revoked.
+  const releaseCurrent = db.prepare(
     `UPDATE usernames
      SET status = 'revoked',
          revoked_at = ?,
          updated_at = ?
-     WHERE LOWER(pubkey) = LOWER(?) AND status = 'active'`
-  ).bind(now, now, pubkey).run()
+     WHERE LOWER(pubkey) = LOWER(?) AND status = 'active'
+       AND username_canonical != ?
+       AND (
+         NOT EXISTS (SELECT 1 FROM usernames WHERE username_canonical = ?)
+         OR EXISTS (
+           SELECT 1 FROM usernames
+           WHERE username_canonical = ?
+             AND (status = 'revoked' OR (status = 'active' AND LOWER(pubkey) = LOWER(?)))
+         )
+       )`
+  ).bind(now, now, pubkey, nameCanonical, nameCanonical, nameCanonical, pubkey)
 
   // Then insert or update the new username using canonical for uniqueness
-  await db.prepare(
+  const claimTarget = db.prepare(
     `INSERT INTO usernames (name, username_display, username_canonical, pubkey, relays, status, claim_source, created_at, updated_at, claimed_at)
      VALUES (?, ?, ?, ?, ?, 'active', 'self-service', ?, ?, ?)
      ON CONFLICT(username_canonical) DO UPDATE SET
@@ -146,8 +359,15 @@ export async function claimUsername(
        created_by = NULL,
        revoked_at = NULL,
        updated_at = excluded.updated_at,
-       claimed_at = excluded.claimed_at`
-  ).bind(nameCanonical, nameDisplay, nameCanonical, pubkey, relaysJson, now, now, now).run()
+       claimed_at = excluded.claimed_at
+     WHERE usernames.status = 'revoked'
+        OR (usernames.status = 'active' AND LOWER(usernames.pubkey) = LOWER(excluded.pubkey))`
+  ).bind(nameCanonical, nameDisplay, nameCanonical, pubkey, relaysJson, now, now, now)
+
+  const [, claimResult] = await db.batch([releaseCurrent, claimTarget])
+  if (!claimResult.meta || claimResult.meta.changes === 0) {
+    throw new Error('USERNAME_NOT_CLAIMABLE')
+  }
 }
 
 export async function getActiveUsernamesPaginated(
@@ -188,7 +408,7 @@ export async function getUsernamesUpdatedSince(
   sinceEpoch: number
 ): Promise<Username[]> {
   const result = await db.prepare(
-    `SELECT * FROM usernames WHERE updated_at >= ? AND status IN ('active', 'revoked', 'burned')`
+    `SELECT * FROM usernames WHERE updated_at >= ? AND status IN ('active', 'revoked', 'burned', 'pending-release')`
   ).bind(sinceEpoch).all<Username>()
 
   return result.results
@@ -203,8 +423,8 @@ export async function enqueueFastlySyncTask(
 
   await db.prepare(
     `INSERT INTO fastly_sync_queue (
-       username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error
-     ) VALUES (?, ?, ?, ?, ?, NULL, 0, NULL)
+       username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error, generation
+     ) VALUES (?, ?, ?, ?, ?, NULL, 0, NULL, 1)
      ON CONFLICT(username_canonical) DO UPDATE SET
        action = excluded.action,
        payload_json = excluded.payload_json,
@@ -215,6 +435,12 @@ export async function enqueueFastlySyncTask(
          ELSE fastly_sync_queue.queued_at
        END,
        updated_at = excluded.updated_at,
+       generation = CASE
+         WHEN fastly_sync_queue.action != excluded.action
+           OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
+         THEN fastly_sync_queue.generation + 1
+         ELSE fastly_sync_queue.generation
+       END,
        last_attempt_at = CASE
          WHEN fastly_sync_queue.action != excluded.action
            OR COALESCE(fastly_sync_queue.payload_json, '') != COALESCE(excluded.payload_json, '')
@@ -241,7 +467,7 @@ export async function getQueuedFastlySyncTasks(
   limit = 1000
 ): Promise<FastlySyncQueueTask[]> {
   const result = await db.prepare(
-    `SELECT username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error
+    `SELECT username_canonical, action, payload_json, queued_at, updated_at, last_attempt_at, attempt_count, last_error, generation
      FROM fastly_sync_queue
      ORDER BY updated_at ASC
      LIMIT ?`
@@ -254,6 +480,7 @@ export async function getQueuedFastlySyncTasks(
     last_attempt_at: number | null
     attempt_count: number
     last_error: string | null
+    generation: number
   }>()
 
   return result.results.map((row) => ({
@@ -265,21 +492,54 @@ export async function getQueuedFastlySyncTasks(
     last_attempt_at: row.last_attempt_at,
     attempt_count: row.attempt_count,
     last_error: row.last_error,
+    generation: row.generation,
   }))
+}
+
+export async function getQueuedFastlySyncTask(
+  db: D1Database,
+  usernameCanonical: string
+): Promise<FastlySyncQueueTask | null> {
+  const tasks = await db.prepare(
+    `SELECT username_canonical, action, payload_json, queued_at, updated_at,
+            last_attempt_at, attempt_count, last_error, generation
+     FROM fastly_sync_queue WHERE username_canonical = ?`
+  ).bind(usernameCanonical).all<{
+    username_canonical: string
+    action: 'sync' | 'delete'
+    payload_json: string | null
+    queued_at: number
+    updated_at: number
+    last_attempt_at: number | null
+    attempt_count: number
+    last_error: string | null
+    generation: number
+  }>()
+  const row = tasks.results[0]
+  if (!row) return null
+  return {
+    username: row.username_canonical,
+    action: row.action,
+    data: row.payload_json ? JSON.parse(row.payload_json) as UsernameKVData : undefined,
+    queued_at: row.queued_at,
+    updated_at: row.updated_at,
+    last_attempt_at: row.last_attempt_at,
+    attempt_count: row.attempt_count,
+    last_error: row.last_error,
+    generation: row.generation,
+  }
 }
 
 export async function clearFastlySyncTasks(
   db: D1Database,
-  usernames: string[]
+  tasks: Array<{ username: string; generation: number }>
 ): Promise<void> {
-  if (usernames.length === 0) return
+  if (tasks.length === 0) return
 
-  for (let i = 0; i < usernames.length; i += 500) {
-    const chunk = usernames.slice(i, i + 500)
-    const placeholders = chunk.map(() => '?').join(', ')
+  for (const task of tasks) {
     await db.prepare(
-      `DELETE FROM fastly_sync_queue WHERE username_canonical IN (${placeholders})`
-    ).bind(...chunk).run()
+      'DELETE FROM fastly_sync_queue WHERE username_canonical = ? AND generation = ?'
+    ).bind(task.username, task.generation).run()
   }
 }
 
@@ -673,7 +933,7 @@ export async function deleteReservedWord(
 
 export async function exportUsernamesByStatus(
   db: D1Database,
-  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'recovered'
+  status?: 'active' | 'reserved' | 'revoked' | 'burned' | 'pending-confirmation' | 'pending-release' | 'recovered'
 ): Promise<Username[]> {
   if (status === 'recovered') {
     const result = await db.prepare(
@@ -936,6 +1196,7 @@ export interface UsernameStats {
     revoked: number
     burned: number
     pending_confirmation: number
+    pending_release: number
   }
   metadata: {
     with_notes: number
@@ -966,6 +1227,7 @@ export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
          SUM(CASE WHEN u.status = 'revoked' THEN 1 ELSE 0 END) AS revoked_count,
          SUM(CASE WHEN u.status = 'burned' THEN 1 ELSE 0 END) AS burned_count,
          SUM(CASE WHEN u.status = 'pending-confirmation' THEN 1 ELSE 0 END) AS pending_confirmation_count,
+         SUM(CASE WHEN u.status = 'pending-release' THEN 1 ELSE 0 END) AS pending_release_count,
          SUM(CASE WHEN u.admin_notes IS NOT NULL AND TRIM(u.admin_notes) != '' THEN 1 ELSE 0 END) AS with_notes_count,
          SUM(CASE WHEN tagged.username_id IS NOT NULL THEN 1 ELSE 0 END) AS with_tags_count,
          SUM(CASE WHEN tagged.username_id IS NULL THEN 1 ELSE 0 END) AS untagged_count,
@@ -988,6 +1250,7 @@ export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
       revoked_count: number
       burned_count: number
       pending_confirmation_count: number
+      pending_release_count: number
       with_notes_count: number
       with_tags_count: number
       untagged_count: number
@@ -1009,6 +1272,7 @@ export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
     revoked_count: 0,
     burned_count: 0,
     pending_confirmation_count: 0,
+    pending_release_count: 0,
     with_notes_count: 0,
     with_tags_count: 0,
     untagged_count: 0,
@@ -1027,6 +1291,7 @@ export async function getUsernameStats(db: D1Database): Promise<UsernameStats> {
       revoked: stats.revoked_count,
       burned: stats.burned_count,
       pending_confirmation: stats.pending_confirmation_count,
+      pending_release: stats.pending_release_count,
     },
     metadata: {
       with_notes: stats.with_notes_count,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -141,10 +141,14 @@ export async function getLatestReleaseAttemptByPubkey(
   db: D1Database,
   pubkey: string
 ): Promise<UsernameReleaseAttempt | null> {
+  // A pubkey has at most one pending attempt (partial unique index), and callers
+  // gate on that state. created_at is whole seconds, so a cancel-and-retry inside
+  // one second ties and falls through to attempt_id, which is client-chosen and
+  // could surface the cancelled attempt instead. Rank pending first.
   return db.prepare(
     `SELECT * FROM username_release_attempts
      WHERE LOWER(pubkey) = LOWER(?)
-     ORDER BY created_at DESC, attempt_id DESC LIMIT 1`
+     ORDER BY (state = 'pending') DESC, created_at DESC, attempt_id DESC LIMIT 1`
   ).bind(pubkey).first<UsernameReleaseAttempt>()
 }
 

--- a/src/db/release-attempts-sqlite.test.ts
+++ b/src/db/release-attempts-sqlite.test.ts
@@ -58,6 +58,26 @@ describe.skipIf(!sqliteAvailable())('release attempts against real SQLite', () =
     expect((await getUsernameByName(db, 'alice'))?.status).toBe('pending-release')
   })
 
+  it('reports the pending attempt when a cancelled one shares its timestamp', async () => {
+    const { db } = withOwnedName()
+    // created_at is whole seconds, so a cancel-and-retry inside one second
+    // leaves two attempts with the same value. Attempt ids are opaque and
+    // client-chosen, so the cancelled one can sort after the live one.
+    const cancelled = 'delete-attempt-zzzzzzzz'
+    const pending = 'delete-attempt-aaaaaaaa'
+
+    await prepareReleaseAttempt(db, OWNER, 'alice', cancelled, 999, 100)
+    await rollbackReleaseAttempt(db, OWNER, 'alice', cancelled, 'cancelled', 100)
+    expect((await prepareReleaseAttempt(db, OWNER, 'alice', pending, 999, 100)).outcome).toBe('transitioned')
+
+    // /claim gates on this lookup reporting 'pending'. If it returns the
+    // cancelled attempt instead, the claim proceeds and collides with the
+    // pending-release row on idx_usernames_pubkey_owned.
+    const latest = await getLatestReleaseAttemptByPubkey(db, OWNER)
+    expect(latest?.attempt_id).toBe(pending)
+    expect(latest?.state).toBe('pending')
+  })
+
   it('leaves the name untouched when the caller does not own it', async () => {
     const { db } = withOwnedName()
     const result = await prepareReleaseAttempt(db, OTHER, 'alice', ATTEMPT, 999, 100)

--- a/src/db/release-attempts-sqlite.test.ts
+++ b/src/db/release-attempts-sqlite.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Runs the release-attempt state machine against the real migrated schema.
+// ABOUTME: Covers the partial unique indexes and cross-statement predicates a fake cannot.
+
+import { describe, expect, it } from 'vitest'
+import {
+  finalizeReleaseAttempt,
+  getLatestReleaseAttemptByPubkey,
+  prepareReleaseAttempt,
+  rollbackReleaseAttempt,
+  getUsernameByName,
+} from './queries'
+import { createSqliteD1, seedUsername, sqliteAvailable } from './sqlite-test-helpers'
+
+const OWNER = 'a'.repeat(64)
+const OTHER = 'b'.repeat(64)
+const ATTEMPT = 'delete-attempt-00000001'
+
+function withOwnedName() {
+  const { db, sqlite } = createSqliteD1()
+  seedUsername(sqlite, { name: 'Alice', canonical: 'alice', pubkey: OWNER, status: 'active' })
+  return { db, sqlite }
+}
+
+describe.skipIf(!sqliteAvailable())('release attempts against real SQLite', () => {
+  it('prepares, replays, and rolls back the same row', async () => {
+    const { db } = withOwnedName()
+
+    const prepared = await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)
+    expect(prepared.outcome).toBe('transitioned')
+    expect((await getUsernameByName(db, 'alice'))?.status).toBe('pending-release')
+
+    expect((await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)).outcome).toBe('replayed')
+
+    const rolledBack = await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'cancelled', 200)
+    expect(rolledBack.outcome).toBe('transitioned')
+    expect((await getUsernameByName(db, 'alice'))?.status).toBe('active')
+  })
+
+  it('finalizes to a non-recyclable burn that cannot be rolled back', async () => {
+    const { db } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)
+
+    expect((await finalizeReleaseAttempt(db, ATTEMPT, 'coordinator', 200)).outcome).toBe('transitioned')
+    const burned = await getUsernameByName(db, 'alice')
+    expect(burned?.status).toBe('burned')
+    expect(burned?.recyclable).toBe(0)
+
+    expect((await finalizeReleaseAttempt(db, ATTEMPT, 'coordinator', 201)).outcome).toBe('replayed')
+    expect((await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT)).outcome).toBe('conflict')
+  })
+
+  it('rejects a non-owner rollback and a second pending attempt', async () => {
+    const { db } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)
+
+    expect((await rollbackReleaseAttempt(db, OTHER, 'alice', ATTEMPT)).outcome).toBe('conflict')
+    expect((await prepareReleaseAttempt(db, OWNER, 'alice', 'delete-attempt-00000002', 999, 100)).outcome).toBe('conflict')
+    expect((await getUsernameByName(db, 'alice'))?.status).toBe('pending-release')
+  })
+
+  it('leaves the name untouched when the caller does not own it', async () => {
+    const { db } = withOwnedName()
+    const result = await prepareReleaseAttempt(db, OTHER, 'alice', ATTEMPT, 999, 100)
+
+    expect(result.outcome).toBe('not_found')
+    expect((await getUsernameByName(db, 'alice'))?.status).toBe('active')
+    expect(await getLatestReleaseAttemptByPubkey(db, OTHER)).toBeNull()
+  })
+})

--- a/src/db/release-attempts-sqlite.test.ts
+++ b/src/db/release-attempts-sqlite.test.ts
@@ -49,6 +49,14 @@ describe.skipIf(!sqliteAvailable())('release attempts against real SQLite', () =
     expect((await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT)).outcome).toBe('conflict')
   })
 
+  it('does not finalize after the recovery deadline', async () => {
+    const { db } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 200, 100)
+
+    expect((await finalizeReleaseAttempt(db, ATTEMPT, 'coordinator', 200)).outcome).toBe('conflict')
+    expect((await getUsernameByName(db, 'alice'))?.status).toBe('pending-release')
+  })
+
   it('rejects a non-owner rollback and a second pending attempt', async () => {
     const { db } = withOwnedName()
     await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)

--- a/src/db/release-attempts.test.ts
+++ b/src/db/release-attempts.test.ts
@@ -1,0 +1,119 @@
+// ABOUTME: Exercises release-attempt database transitions as one transactional state machine.
+// ABOUTME: Verifies ownership, idempotency, terminal exclusion, and exact-name restoration.
+
+import { describe, expect, it } from 'vitest'
+import { finalizeReleaseAttempt, prepareReleaseAttempt, rollbackReleaseAttempt, type UsernameReleaseAttempt } from './queries'
+
+function createReleaseDB() {
+  const username: any = {
+    id: 1, name: 'Alice', username_display: 'Alice', username_canonical: 'alice', pubkey: 'a'.repeat(64),
+    status: 'active', recyclable: 1, created_at: 1, updated_at: 1, revoked_at: null,
+  }
+  const attempts = new Map<string, UsernameReleaseAttempt>()
+  const db = {
+    prepare(sql: string) {
+      let params: any[] = []
+      return {
+        bind(...values: any[]) {
+          params = values
+          return {
+            first: async () => {
+              if (sql.includes('WHERE attempt_id = ?')) return attempts.get(params[0]) || null
+              if (sql.includes('FROM username_release_attempts') && sql.includes('LOWER(pubkey)')) {
+                const matching = [...attempts.values()].filter(a => a.pubkey.toLowerCase() === params[0].toLowerCase())
+                return matching[matching.length - 1] || null
+              }
+              if (sql.includes('FROM usernames')) return username.username_canonical === params[0] || username.name === params[1] ? username : null
+              return null
+            },
+            all: async () => ({ results: [] }),
+            run: async () => {
+              if (sql.includes('INSERT OR IGNORE INTO username_release_attempts')) {
+                const [attemptId, createdAt, updatedAt, expiresAt, canonical, pubkey] = params
+                const pendingForOwner = [...attempts.values()].some(a => a.pubkey.toLowerCase() === pubkey.toLowerCase() && a.state === 'pending')
+                if (attempts.has(attemptId) || pendingForOwner || username.status !== 'active' || canonical !== username.username_canonical || pubkey.toLowerCase() !== username.pubkey.toLowerCase()) {
+                  return { success: true, meta: { changes: 0 } }
+                }
+                attempts.set(attemptId, {
+                  attempt_id: attemptId, username_canonical: canonical, pubkey: username.pubkey, state: 'pending',
+                  created_at: createdAt, updated_at: updatedAt, expires_at: expiresAt,
+                  cancelled_at: null, finalized_at: null, finalized_by: null,
+                })
+                return { success: true, meta: { changes: 1 } }
+              }
+              if (sql.includes("SET status = 'pending-release'")) {
+                const [updatedAt, canonical, pubkey, attemptId] = params
+                const attempt = attempts.get(attemptId)
+                if (username.status !== 'active' || canonical !== username.username_canonical || pubkey.toLowerCase() !== username.pubkey.toLowerCase() || attempt?.state !== 'pending') return { success: true, meta: { changes: 0 } }
+                username.status = 'pending-release'; username.updated_at = updatedAt
+                return { success: true, meta: { changes: 1 } }
+              }
+              if (sql.includes("UPDATE usernames SET status = 'active'")) {
+                const [updatedAt, canonical, pubkey, attemptId] = params
+                const attempt = attempts.get(attemptId)
+                if (username.status !== 'pending-release' || canonical !== username.username_canonical || pubkey.toLowerCase() !== username.pubkey.toLowerCase() || attempt?.state !== 'pending') return { success: true, meta: { changes: 0 } }
+                username.status = 'active'; username.updated_at = updatedAt; username.revoked_at = null
+                return { success: true, meta: { changes: 1 } }
+              }
+              if (sql.includes('SET state = ?, updated_at')) {
+                const [state, updatedAt, cancelledAt, attemptId] = params
+                const attempt = attempts.get(attemptId)
+                if (attempt?.state !== 'pending' || username.status !== 'active') return { success: true, meta: { changes: 0 } }
+                attempt.state = state; attempt.updated_at = updatedAt; attempt.cancelled_at = cancelledAt
+                return { success: true, meta: { changes: 1 } }
+              }
+              if (sql.includes("SET status = 'burned'")) {
+                const [revokedAt, updatedAt, canonical, pubkey, attemptId] = params
+                const attempt = attempts.get(attemptId)
+                if (username.status !== 'pending-release' || canonical !== username.username_canonical || pubkey.toLowerCase() !== username.pubkey.toLowerCase() || attempt?.state !== 'pending') return { success: true, meta: { changes: 0 } }
+                username.status = 'burned'; username.recyclable = 0; username.revoked_at = revokedAt; username.updated_at = updatedAt
+                return { success: true, meta: { changes: 1 } }
+              }
+              if (sql.includes("SET state = 'finalized'")) {
+                const [updatedAt, finalizedAt, finalizedBy, attemptId] = params
+                const attempt = attempts.get(attemptId)
+                if (attempt?.state !== 'pending' || username.status !== 'burned') return { success: true, meta: { changes: 0 } }
+                attempt.state = 'finalized'; attempt.updated_at = updatedAt; attempt.finalized_at = finalizedAt; attempt.finalized_by = finalizedBy
+                return { success: true, meta: { changes: 1 } }
+              }
+              return { success: true, meta: { changes: 0 } }
+            },
+          }
+        },
+      }
+    },
+    batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
+  } as unknown as D1Database
+  return { db, username, attempts }
+}
+
+describe('release-attempt database state machine', () => {
+  it('prepares and idempotently restores the exact row', async () => {
+    const { db, username } = createReleaseDB()
+    const prepared = await prepareReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000001', 500, 100)
+    expect(prepared.outcome).toBe('transitioned')
+    expect(username.status).toBe('pending-release')
+    const replay = await prepareReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000001', 500, 100)
+    expect(replay.outcome).toBe('replayed')
+    const rolledBack = await rollbackReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000001', 'cancelled', 200)
+    expect(rolledBack.outcome).toBe('transitioned')
+    expect(username).toMatchObject({ name: 'Alice', username_canonical: 'alice', status: 'active' })
+    expect((await rollbackReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000001', 'cancelled', 201)).outcome).toBe('replayed')
+  })
+
+  it('allows exactly one terminal transition and makes finalization permanent', async () => {
+    const { db, username } = createReleaseDB()
+    await prepareReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000002', 500, 100)
+    expect((await finalizeReleaseAttempt(db, 'delete-attempt-00000002', 'coordinator', 200)).outcome).toBe('transitioned')
+    expect(username).toMatchObject({ status: 'burned', recyclable: 0 })
+    expect((await finalizeReleaseAttempt(db, 'delete-attempt-00000002', 'coordinator', 201)).outcome).toBe('replayed')
+    expect((await rollbackReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000002')).outcome).toBe('conflict')
+  })
+
+  it('rejects non-owners and a second pending attempt', async () => {
+    const { db, username } = createReleaseDB()
+    await prepareReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000003', 500, 100)
+    expect((await rollbackReleaseAttempt(db, 'b'.repeat(64), 'alice', 'delete-attempt-00000003')).outcome).toBe('conflict')
+    expect((await prepareReleaseAttempt(db, username.pubkey, 'alice', 'delete-attempt-00000004', 500, 100)).outcome).toBe('conflict')
+  })
+})

--- a/src/db/sqlite-test-helpers.ts
+++ b/src/db/sqlite-test-helpers.ts
@@ -1,0 +1,161 @@
+// ABOUTME: Runs the real migration chain in an in-memory SQLite database and
+// ABOUTME: exposes it through the D1 surface, so query SQL is executed, not mocked.
+
+// Node built-ins are declared in ./node-builtins.d.ts — see the note there.
+import { readdirSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+
+const MIGRATIONS_DIR = fileURLToPath(new URL('../../migrations/', import.meta.url))
+
+type SqliteHandle = {
+  exec(sql: string): void
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown
+    all(...params: unknown[]): unknown[]
+    run(...params: unknown[]): { changes: number | bigint; lastInsertRowid: number | bigint }
+  }
+  close(): void
+}
+type DatabaseSyncCtor = new (path: string) => SqliteHandle
+
+export type SqliteDb = SqliteHandle
+
+let cachedCtor: DatabaseSyncCtor | null | undefined
+
+/**
+ * `node:sqlite` landed in Node 22.5. Suites that need a real database gate on
+ * `sqliteAvailable()` so they skip cleanly on older runtimes.
+ */
+function loadDatabaseSync(): DatabaseSyncCtor | null {
+  if (cachedCtor === undefined) {
+    try {
+      const load = createRequire(import.meta.url)
+      cachedCtor = (load('node:sqlite') as { DatabaseSync: DatabaseSyncCtor }).DatabaseSync
+    } catch {
+      cachedCtor = null
+    }
+  }
+  return cachedCtor
+}
+
+export function sqliteAvailable(): boolean {
+  return loadDatabaseSync() !== null
+}
+
+/** Migration filenames in the order `wrangler d1 migrations apply` runs them. */
+export function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR).filter((file) => file.endsWith('.sql')).sort()
+}
+
+/** Raw SQL of the migration whose filename starts with `prefix`. */
+export function migrationSql(prefix: string): string {
+  const file = migrationFiles().find((name) => name.startsWith(prefix))
+  if (!file) throw new Error(`No migration matching ${prefix}`)
+  return readFileSync(MIGRATIONS_DIR + file, 'utf8')
+}
+
+/** Empty database with foreign keys on, matching D1. */
+export function createSqlite(): SqliteDb {
+  const DatabaseSync = loadDatabaseSync()
+  if (!DatabaseSync) throw new Error('node:sqlite is unavailable')
+  const sqlite = new DatabaseSync(':memory:')
+  sqlite.exec('PRAGMA foreign_keys = ON')
+  return sqlite
+}
+
+/**
+ * Apply migrations in order. `stopBefore` halts immediately before the named
+ * file so a test can seed pre-migration rows and then apply that migration
+ * against them.
+ */
+export function applyMigrations(db: SqliteDb, options: { stopBefore?: string } = {}): void {
+  for (const file of migrationFiles()) {
+    if (options.stopBefore && file.startsWith(options.stopBefore)) return
+    db.exec(readFileSync(MIGRATIONS_DIR + file, 'utf8'))
+  }
+}
+
+/** Index names currently guarding one owned name per pubkey. */
+export function pubkeyIndexNames(db: SqliteDb): string[] {
+  return db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_usernames_pubkey%'")
+    .all()
+    .map((row) => (row as { name: string }).name)
+}
+
+function toNumber(value: number | bigint): number {
+  return typeof value === 'bigint' ? Number(value) : value
+}
+
+function isRead(sql: string): boolean {
+  return /^\s*(SELECT|WITH|PRAGMA)/i.test(sql)
+}
+
+/**
+ * Wrap a SQLite handle in the subset of the D1 API the query layer uses.
+ * `batch` mirrors D1: one transaction, statements executed in order, so a
+ * later statement observes an earlier one's writes.
+ */
+export function asD1(db: SqliteDb): D1Database {
+  function execute(sql: string, params: unknown[]) {
+    const statement = db.prepare(sql)
+    if (isRead(sql)) return { rows: statement.all(...params), meta: { changes: 0, last_row_id: 0 } }
+    const result = statement.run(...params)
+    return {
+      rows: [] as unknown[],
+      meta: { changes: toNumber(result.changes), last_row_id: toNumber(result.lastInsertRowid) },
+    }
+  }
+
+  function prepare(sql: string, params: unknown[] = []): D1PreparedStatement {
+    return {
+      bind: (...next: unknown[]) => prepare(sql, next),
+      first: async () => execute(sql, params).rows[0] ?? null,
+      all: async () => {
+        const { rows, meta } = execute(sql, params)
+        return { results: rows, success: true, meta }
+      },
+      run: async () => {
+        const { rows, meta } = execute(sql, params)
+        return { results: rows, success: true, meta }
+      },
+      raw: async () => execute(sql, params).rows,
+    } as unknown as D1PreparedStatement
+  }
+
+  return {
+    prepare: (sql: string) => prepare(sql),
+    batch: async (statements: D1PreparedStatement[]) => {
+      db.exec('BEGIN')
+      try {
+        const results = []
+        for (const statement of statements) results.push(await statement.run())
+        db.exec('COMMIT')
+        return results
+      } catch (error) {
+        db.exec('ROLLBACK')
+        throw error
+      }
+    },
+  } as unknown as D1Database
+}
+
+/** Fresh in-memory database with the full migration chain applied. */
+export function createSqliteD1(): { db: D1Database; sqlite: SqliteDb } {
+  const sqlite = createSqlite()
+  applyMigrations(sqlite)
+  return { db: asD1(sqlite), sqlite }
+}
+
+/** Insert a `usernames` row with test-friendly defaults. */
+export function seedUsername(
+  sqlite: SqliteDb,
+  row: { name: string; canonical?: string; pubkey?: string | null; status?: string; recyclable?: number }
+): void {
+  const canonical = row.canonical ?? row.name.toLowerCase()
+  sqlite.prepare(
+    `INSERT INTO usernames (name, username_display, username_canonical, pubkey, status, recyclable, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, 100, 100)`
+  ).run(row.name, row.name, canonical, row.pubkey ?? null, row.status ?? 'active', row.recyclable ?? 1)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import admin from './routes/admin'
 // Auth routes are mounted inside admin.ts (same Hono app, exempt from auth middleware)
 import publicRoutes from './routes/public'
 import internalAtproto from './routes/internal-atproto'
-import { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures } from './db/queries'
+import internalDeletion from './routes/internal-deletion'
+import { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, getStaleReleaseAttempts, rollbackReleaseAttempt } from './db/queries'
 import { syncBatch, parseRelayHints, type UsernameKVData } from './utils/fastly-sync'
 
 type Bindings = {
@@ -21,6 +22,7 @@ type Bindings = {
   FASTLY_API_TOKEN?: string
   FASTLY_STORE_ID?: string
   ATPROTO_SYNC_TOKEN?: string
+  DELETION_COORDINATOR_TOKEN?: string
   KEYCAST_URL?: string
   KEYCAST_CLIENT_ID?: string
   AP_ACTOR_BASE_URL?: string
@@ -64,6 +66,7 @@ app.route('/api/admin', admin)
 
 // Internal service API (service-authenticated bearer token)
 app.route('/api/internal', internalAtproto)
+app.route('/api/internal', internalDeletion)
 
 // NIP-05
 app.route('', nip05)
@@ -110,6 +113,22 @@ export default {
       console.log(`Cron: expired ${expired} stale pending-confirmation reservations`)
     }
 
+    const staleReleaseAttempts = await getStaleReleaseAttempts(env.DB)
+    let restoredReleaseAttempts = 0
+    for (const attempt of staleReleaseAttempts) {
+      const result = await rollbackReleaseAttempt(
+        env.DB,
+        attempt.pubkey,
+        attempt.username_canonical,
+        attempt.attempt_id,
+        'expired-restored'
+      )
+      if (result.outcome === 'transitioned' || result.outcome === 'replayed') restoredReleaseAttempts += 1
+    }
+    if (restoredReleaseAttempts > 0) {
+      console.log(`Cron: restored ${restoredReleaseAttempts} expired username release attempts`)
+    }
+
     // Six-hour overlap covers delayed cron firings while the durable queue
     // preserves retries for anything that still fails after bounded Fastly retries.
     const sixHoursAgo = Math.floor(Date.now() / 1000) - (6 * 60 * 60)
@@ -139,7 +158,7 @@ export default {
             atproto_state: user.atproto_state,
           },
         })
-      } else if (user.status === 'revoked' || user.status === 'burned') {
+      } else if (user.status === 'revoked' || user.status === 'burned' || user.status === 'pending-release') {
         itemsByUsername.set(user.username_canonical || user.name, {
           username: user.username_canonical || user.name,
           action: 'delete',
@@ -149,7 +168,16 @@ export default {
 
     const items = Array.from(itemsByUsername.values())
     const results = await syncBatch(env, items, { concurrency: 10 })
-    await clearFastlySyncTasks(env.DB, results.successes.map(result => result.username))
+    const queuedByUsername = new Map(queuedTasks.map(task => [task.username, task]))
+    const completedQueuedTasks = results.successes.flatMap(result => {
+      const queued = queuedByUsername.get(result.username)
+      const attempted = itemsByUsername.get(result.username)
+      if (!queued || !attempted) return []
+      const sameAction = queued.action === attempted.action
+      const samePayload = JSON.stringify(queued.data || null) === JSON.stringify(attempted.data || null)
+      return sameAction && samePayload ? [{ username: queued.username, generation: queued.generation }] : []
+    })
+    await clearFastlySyncTasks(env.DB, completedQueuedTasks)
     for (const failure of results.failures) {
       const item = itemsByUsername.get(failure.username)
       if (item) {

--- a/src/middleware/service-auth.ts
+++ b/src/middleware/service-auth.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Provides fail-closed bearer-token authentication for internal service routes.
+// ABOUTME: Keeps service credentials least-privileged by selecting a route-specific binding.
+
+import type { MiddlewareHandler } from 'hono'
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const encoder = new TextEncoder()
+  const leftBytes = encoder.encode(left)
+  const rightBytes = encoder.encode(right)
+  let difference = leftBytes.length ^ rightBytes.length
+  const length = Math.max(leftBytes.length, rightBytes.length)
+  for (let i = 0; i < length; i += 1) {
+    difference |= (leftBytes[i] || 0) ^ (rightBytes[i] || 0)
+  }
+  return difference === 0
+}
+
+export function requireServiceToken(
+  binding: string,
+  serviceLabel: string
+): MiddlewareHandler<{ Bindings: Record<string, unknown> }> {
+  return async (c, next) => {
+    const configured = c.env[binding]
+    if (typeof configured !== 'string' || configured.length === 0) {
+      return c.json({ ok: false, error: `${serviceLabel} token is not configured` }, 503)
+    }
+
+    const auth = c.req.header('Authorization') || ''
+    if (!auth.startsWith('Bearer ') || !constantTimeEqual(auth.slice('Bearer '.length), configured)) {
+      return c.json({ ok: false, error: 'Unauthorized' }, 401)
+    }
+    await next()
+  }
+}

--- a/src/routes/admin-release-guard.test.ts
+++ b/src/routes/admin-release-guard.test.ts
@@ -1,0 +1,74 @@
+// ABOUTME: Admin writes must not collide with a name its owner is mid-release on.
+// ABOUTME: Runs against the real schema so the owned-name unique index is enforced.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import admin from './admin'
+import { prepareReleaseAttempt } from '../db/queries'
+import { createExecutionContext } from '../db/test-helpers'
+import { createSqliteD1, seedUsername, sqliteAvailable } from '../db/sqlite-test-helpers'
+
+vi.mock('../utils/email', () => ({
+  sendAssignmentNotificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendReservationConfirmationEmail: vi.fn().mockResolvedValue(undefined),
+}))
+
+const OWNER = 'a'.repeat(64)
+
+function app() {
+  const instance = new Hono<{ Bindings: { DB: D1Database; BYPASS_LOCAL_AUTH?: string } }>()
+  instance.route('/api/admin', admin)
+  return instance
+}
+
+/** A pubkey whose only owned name is mid-release, plus a free name to move it to. */
+async function ownerMidRelease() {
+  const { db, sqlite } = createSqliteD1()
+  seedUsername(sqlite, { name: 'alice', pubkey: OWNER, status: 'active' })
+  seedUsername(sqlite, { name: 'bob', pubkey: null, status: 'revoked' })
+  const prepared = await prepareReleaseAttempt(db, OWNER, 'alice', 'delete-attempt-00000001', 999, 100)
+  expect(prepared.outcome).toBe('transitioned')
+  return db
+}
+
+function post(path: string, body: object) {
+  return new Request(`http://localhost/api/admin${path}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  })
+}
+
+describe.skipIf(!sqliteAvailable())('admin writes against an owner mid-release', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
+  })
+
+  it('refuses to assign a second name to that owner', async () => {
+    const db = await ownerMidRelease()
+    const res = await app().fetch(post('/username/assign', { name: 'bob', pubkey: OWNER }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
+
+    expect(res.status).toBe(409)
+    expect((await res.json() as { error: string }).error).toMatch(/pending release/i)
+  })
+
+  it('refuses to restore a second name to that owner', async () => {
+    const db = await ownerMidRelease()
+    const res = await app().fetch(post('/username/restore', { name: 'bob', pubkey: OWNER }), { DB: db, BYPASS_LOCAL_AUTH: 'true' }, createExecutionContext())
+
+    expect(res.status).toBe(409)
+    expect((await res.json() as { error: string }).error).toMatch(/pending release/i)
+  })
+
+  it('reports a bulk assign to that owner as a per-name failure', async () => {
+    const db = await ownerMidRelease()
+    const res = await app().fetch(
+      post('/username/assign-bulk', { assignments: [{ name: 'bob', pubkey: OWNER }] }),
+      { DB: db, BYPASS_LOCAL_AUTH: 'true' },
+      createExecutionContext()
+    )
+
+    expect(res.status).toBe(200)
+    const [result] = (await res.json() as { results: Array<{ success: boolean; error?: string }> }).results
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/pending release/i)
+  })
+})

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,14 +5,14 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, restoreUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, type SearchSort } from '../db/queries'
+import { reserveUsername, revokeUsername, restoreUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, getQueuedFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, listReleaseAttempts, type ReleaseAttemptState, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername, usernameKVDataMatches } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
 const MAX_ADMIN_NOTES_LENGTH = 5000
-const VALID_ADMIN_STATUSES = ['active', 'reserved', 'revoked', 'burned', 'pending-confirmation', 'recovered'] as const
+const VALID_ADMIN_STATUSES = ['active', 'reserved', 'revoked', 'burned', 'pending-confirmation', 'pending-release', 'recovered'] as const
 type AdminStatusFilter = (typeof VALID_ADMIN_STATUSES)[number]
 
 /** Convert a 64-char hex pubkey to npub bech32 format */
@@ -191,6 +191,19 @@ admin.get('/usernames/stats', async (c) => {
     return c.json({ ok: true, ...stats })
   } catch (error) {
     console.error('Username stats error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+admin.get('/username-release-attempts', async (c) => {
+  try {
+    const state = c.req.query('state') as ReleaseAttemptState | undefined
+    const validStates: ReleaseAttemptState[] = ['pending', 'cancelled', 'finalized', 'expired-restored']
+    if (state && !validStates.includes(state)) return c.json({ ok: false, error: 'Invalid state parameter' }, 400)
+    const attempts = await listReleaseAttempts(c.env.DB, state)
+    return c.json({ ok: true, attempts })
+  } catch (error) {
+    console.error('Release attempt list error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })
@@ -463,6 +476,9 @@ admin.post('/username/revoke', async (c) => {
     if (!existing) {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
+    if (existing.status === 'pending-release') {
+      return c.json({ ok: false, error: 'Username has a pending release attempt; roll it back or finalize it first' }, 409)
+    }
 
     await revokeUsername(c.env.DB, usernameData.canonical, burn)
 
@@ -639,6 +655,10 @@ admin.post('/username/assign', async (c) => {
     }
 
     const createdBy = (c.get('adminEmail' as never) as string) || null
+    const existing = await getUsernameByName(c.env.DB, usernameData.canonical)
+    if (existing?.status === 'pending-release') {
+      return c.json({ ok: false, error: 'Username has a pending release attempt; roll it back or finalize it first' }, 409)
+    }
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
 
     // Sync to Fastly KV with read-back verification
@@ -725,6 +745,10 @@ admin.post('/username/assign-bulk', async (c) => {
         // Check if already exists
         const existing = await getUsernameByName(c.env.DB, usernameData.canonical)
         if (existing) {
+          if (existing.status === 'pending-release') {
+            results.push({ name, success: false, error: 'Username has a pending release attempt', status: existing.status })
+            continue
+          }
           if (existing.pubkey === normalizedPubkey) {
             // Already assigned to this pubkey
             results.push({ name, pubkey: normalizedPubkey, success: true, status: 'already_assigned' })
@@ -894,8 +918,15 @@ admin.post('/sync/fastly', async (c) => {
     }))
 
     const results = await syncBatch(c.env, items, { concurrency: 10 })
-    await clearFastlySyncTasks(c.env.DB, results.successes.map(result => result.username))
     const itemsByUsername = new Map(items.map((item) => [item.username, item]))
+    const completedQueuedTasks = (await Promise.all(results.successes.map(async result => {
+      const queued = await getQueuedFastlySyncTask(c.env.DB, result.username)
+      const attempted = itemsByUsername.get(result.username)
+      if (!queued || !attempted || queued.action !== attempted.action ||
+          JSON.stringify(queued.data || null) !== JSON.stringify(attempted.data || null)) return null
+      return { username: queued.username, generation: queued.generation }
+    }))).filter((task): task is { username: string; generation: number } => task !== null)
+    await clearFastlySyncTasks(c.env.DB, completedQueuedTasks)
     for (const failure of results.failures) {
       const item = itemsByUsername.get(failure.username)
       if (item) {
@@ -1073,7 +1104,7 @@ admin.get('/username/:name/nip05-status', async (c) => {
       })
     }
 
-    if (!['active', 'revoked', 'burned'].includes(existing.status)) {
+    if (!['active', 'revoked', 'burned', 'pending-release'].includes(existing.status)) {
       return c.json({
         ok: true,
         status: 'not_applicable',
@@ -1090,7 +1121,7 @@ admin.get('/username/:name/nip05-status', async (c) => {
       return c.json({ ok: true, status: 'error', detail: fastly.error })
     }
 
-    if (existing.status === 'revoked' || existing.status === 'burned') {
+    if (existing.status === 'revoked' || existing.status === 'burned' || existing.status === 'pending-release') {
       if (!fastly.data) {
         return c.json({ ok: true, status: 'missing' })
       }
@@ -1167,7 +1198,7 @@ admin.post('/username/:name/sync-to-fastly', async (c) => {
       return c.json({ ok: false, error: 'Username not found' }, 404)
     }
 
-    if (existing.status === 'burned' || existing.status === 'revoked') {
+    if (existing.status === 'burned' || existing.status === 'revoked' || existing.status === 'pending-release') {
       const deleteResult = await deleteUsernameFromFastly(c.env, canonical)
       if (!deleteResult.success) {
         await enqueueFastlySyncTask(c.env.DB, {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -5,15 +5,28 @@ import { Hono } from 'hono'
 import { getCookie } from 'hono/cookie'
 import { bech32 } from '@scure/base'
 import { getSession } from '../auth/keycast-oauth'
-import { reserveUsername, revokeUsername, restoreUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, getQueuedFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, listReleaseAttempts, type ReleaseAttemptState, type SearchSort } from '../db/queries'
+import { reserveUsername, revokeUsername, restoreUsername, assignUsername, getUsernameByName, searchUsernames, getReservedWords, addReservedWord, deleteReservedWord, exportUsernamesByStatus, getActiveUsernamesPaginated, countActiveUsernames, addTag, removeTag, getTagDetailsForUsername, getTagsForUsername, getTagsForUsernames, getAllTags, getUsernameStats, updateAdminNotes, enqueueFastlySyncTask, getQueuedFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, getLatestReleaseAttemptByPubkey, listReleaseAttempts, type ReleaseAttemptState, type SearchSort } from '../db/queries'
 import { validateUsername, UsernameValidationError, validateAndNormalizePubkey, PubkeyValidationError } from '../utils/validation'
 import { syncUsernameToFastly, deleteUsernameFromFastly, syncBatch, parseRelayHints, readUsernameFromFastly, syncAndVerifyUsername, usernameKVDataMatches } from '../utils/fastly-sync'
 import { sendAssignmentNotificationEmail } from '../utils/email'
 import authRoutes from './auth'
 
 const MAX_ADMIN_NOTES_LENGTH = 5000
+const PENDING_RELEASE_OWNER_ERROR =
+  'That pubkey has a pending release attempt; roll it back or finalize it first'
+
 const VALID_ADMIN_STATUSES = ['active', 'reserved', 'revoked', 'burned', 'pending-confirmation', 'pending-release', 'recovered'] as const
 type AdminStatusFilter = (typeof VALID_ADMIN_STATUSES)[number]
+
+/**
+ * True while the pubkey is mid-release. The owned-name unique index counts
+ * `pending-release` rows, but the release statements in assignUsername and
+ * restoreUsername only revoke `active` ones, so writing a second name for this
+ * owner would violate the index instead of returning a usable error.
+ */
+async function hasPendingRelease(db: D1Database, pubkey: string): Promise<boolean> {
+  return (await getLatestReleaseAttemptByPubkey(db, pubkey))?.state === 'pending'
+}
 
 /** Convert a 64-char hex pubkey to npub bech32 format */
 function hexToNpub(hex: string): string {
@@ -555,6 +568,10 @@ admin.post('/username/restore', async (c) => {
       }, 409)
     }
 
+    if (await hasPendingRelease(c.env.DB, normalizedPubkey)) {
+      return c.json({ ok: false, error: PENDING_RELEASE_OWNER_ERROR }, 409)
+    }
+
     const restoredBy = (c.get('adminEmail' as never) as string) || null
     const restoreResult = await restoreUsername(
       c.env.DB,
@@ -659,6 +676,9 @@ admin.post('/username/assign', async (c) => {
     if (existing?.status === 'pending-release') {
       return c.json({ ok: false, error: 'Username has a pending release attempt; roll it back or finalize it first' }, 409)
     }
+    if (await hasPendingRelease(c.env.DB, normalizedPubkey)) {
+      return c.json({ ok: false, error: PENDING_RELEASE_OWNER_ERROR }, 409)
+    }
     await assignUsername(c.env.DB, usernameData.display, usernameData.canonical, normalizedPubkey, 'admin', createdBy)
 
     // Sync to Fastly KV with read-back verification
@@ -741,6 +761,11 @@ admin.post('/username/assign-bulk', async (c) => {
 
         // Validate pubkey
         const normalizedPubkey = validateAndNormalizePubkey(pubkey)
+
+        if (await hasPendingRelease(c.env.DB, normalizedPubkey)) {
+          results.push({ name, success: false, error: PENDING_RELEASE_OWNER_ERROR })
+          continue
+        }
 
         // Check if already exists
         const existing = await getUsernameByName(c.env.DB, usernameData.canonical)

--- a/src/routes/claim-nip05.e2e.test.ts
+++ b/src/routes/claim-nip05.e2e.test.ts
@@ -254,6 +254,8 @@ function createE2EMockDB(initialUsernames: Partial<MockUsername>[] = []) {
       }
     },
 
+    batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
+
     // Expose the live array so tests can assert on DB state
     _mockUsernames: mockUsernames,
   } as unknown as D1Database & { _mockUsernames: MockUsername[] }

--- a/src/routes/internal-atproto.ts
+++ b/src/routes/internal-atproto.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { enqueueFastlySyncTask, getUsernameByName } from '../db/queries'
 import { parseRelayHints, syncAndVerifyUsername } from '../utils/fastly-sync'
+import { requireServiceToken } from '../middleware/service-auth'
 
 type Bindings = {
   DB: D1Database
@@ -13,24 +14,7 @@ type AtprotoState = 'pending' | 'ready' | 'failed' | 'disabled' | null
 
 const internalAtproto = new Hono<{ Bindings: Bindings }>()
 
-internalAtproto.use('*', async (c, next) => {
-  const configured = c.env.ATPROTO_SYNC_TOKEN
-  if (!configured) {
-    return c.json({ ok: false, error: 'ATProto sync token is not configured' }, 503)
-  }
-
-  const auth = c.req.header('Authorization') || ''
-  if (!auth.startsWith('Bearer ')) {
-    return c.json({ ok: false, error: 'Unauthorized' }, 401)
-  }
-
-  const token = auth.slice('Bearer '.length)
-  if (token !== configured) {
-    return c.json({ ok: false, error: 'Unauthorized' }, 401)
-  }
-
-  await next()
-})
+internalAtproto.use('/username/set-atproto', requireServiceToken('ATPROTO_SYNC_TOKEN', 'ATProto sync'))
 
 internalAtproto.post('/username/set-atproto', async (c) => {
   try {

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -69,4 +69,15 @@ describe('internal deletion finalization', () => {
     expect(response.status).toBe(409)
     expect(await response.json()).toMatchObject({ code: 'attempt_cancelled' })
   })
+
+  it('does not finalize a pending attempt after its recovery deadline', async () => {
+    mocks.finalizeReleaseAttempt.mockResolvedValue({
+      outcome: 'conflict',
+      attempt: { ...attempt, state: 'pending', expires_at: Math.floor(Date.now() / 1000) - 1 },
+    })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(request(), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ code: 'attempt_expired' })
+  })
 })

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -1,0 +1,72 @@
+// ABOUTME: Covers service-authenticated terminal username-release finalization.
+// ABOUTME: Verifies least-privilege auth and idempotent terminal behavior.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { createExecutionContext } from '../db/test-helpers'
+
+const mocks = vi.hoisted(() => ({ finalizeReleaseAttempt: vi.fn(), reconcileUsernameFastly: vi.fn() }))
+vi.mock('../db/queries', async () => ({
+  ...await vi.importActual<typeof import('../db/queries')>('../db/queries'),
+  finalizeReleaseAttempt: mocks.finalizeReleaseAttempt,
+}))
+vi.mock('../utils/username-fastly-reconcile', () => ({ reconcileUsernameFastly: mocks.reconcileUsernameFastly }))
+
+import internalDeletion from './internal-deletion'
+import worker from '../index'
+
+const attempt = {
+  attempt_id: 'delete-attempt-00000001', username_canonical: 'alice', pubkey: 'a'.repeat(64), state: 'finalized',
+  created_at: 1, updated_at: 2, expires_at: 3, cancelled_at: null, finalized_at: 2, finalized_by: 'deletion-coordinator',
+}
+const username = { username_canonical: 'alice', name: 'alice', status: 'burned' }
+
+function request(token = 'secret') {
+  return new Request('http://localhost/api/internal/username/release/finalize', {
+    method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ attempt_id: attempt.attempt_id }),
+  })
+}
+
+describe('internal deletion finalization', () => {
+  beforeEach(() => { vi.clearAllMocks(); mocks.reconcileUsernameFastly.mockResolvedValue(undefined) })
+
+  it('fails closed when the coordinator token is missing', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(request(), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(503)
+  })
+
+  it('rejects another service credential', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(request('atproto-token'), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(401)
+  })
+
+  it('finalizes and safely replays the same attempt', async () => {
+    mocks.finalizeReleaseAttempt.mockResolvedValue({ outcome: 'replayed', attempt, username })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(request(), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ state: 'finalized' })
+  })
+
+  it('does not require the unrelated ATProto credential when mounted in the worker', async () => {
+    mocks.finalizeReleaseAttempt.mockResolvedValue({ outcome: 'replayed', attempt, username })
+    const response = await worker.fetch(request(), {
+      DB: {} as D1Database,
+      DELETION_COORDINATOR_TOKEN: 'secret',
+      ATPROTO_SYNC_TOKEN: 'different-secret',
+      ASSETS: { fetch: async () => new Response('', { status: 404 }) },
+    }, createExecutionContext())
+    expect(response.status).toBe(200)
+  })
+
+  it('does not finalize a cancelled or expired-restored attempt', async () => {
+    mocks.finalizeReleaseAttempt.mockResolvedValue({ outcome: 'conflict', attempt: { ...attempt, state: 'expired-restored' } })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(request(), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ code: 'attempt_cancelled' })
+  })
+})

--- a/src/routes/internal-deletion.ts
+++ b/src/routes/internal-deletion.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Finalizes recoverable username releases for the trusted deletion coordinator.
+// ABOUTME: Keeps permanent burns behind a dedicated least-privilege service credential.
+
+import { Hono } from 'hono'
+import { finalizeReleaseAttempt } from '../db/queries'
+import { requireServiceToken } from '../middleware/service-auth'
+import { reconcileUsernameFastly } from '../utils/username-fastly-reconcile'
+
+type Bindings = {
+  DB: D1Database
+  DELETION_COORDINATOR_TOKEN?: string
+  FASTLY_API_TOKEN?: string
+  FASTLY_STORE_ID?: string
+}
+
+const internalDeletion = new Hono<{ Bindings: Bindings }>()
+internalDeletion.use('/username/release/finalize', requireServiceToken('DELETION_COORDINATOR_TOKEN', 'Deletion coordinator'))
+
+internalDeletion.post('/username/release/finalize', async (c) => {
+  try {
+    const body = await c.req.json<{ attempt_id?: unknown }>()
+    if (typeof body.attempt_id !== 'string' || body.attempt_id.length < 16 || body.attempt_id.length > 128) {
+      return c.json({ ok: false, error: 'A valid attempt_id is required' }, 400)
+    }
+    const result = await finalizeReleaseAttempt(c.env.DB, body.attempt_id, 'deletion-coordinator')
+    if (result.outcome === 'not_found') return c.json({ ok: false, error: 'Release attempt not found' }, 404)
+    if (result.outcome === 'conflict') {
+      const code = result.attempt?.state === 'cancelled' || result.attempt?.state === 'expired-restored'
+        ? 'attempt_cancelled'
+        : 'attempt_conflict'
+      return c.json({ ok: false, error: 'Release attempt cannot be finalized', code }, 409)
+    }
+    await reconcileUsernameFastly(c.env, result.attempt.username_canonical)
+    return c.json({ ok: true, attempt_id: result.attempt.attempt_id, state: 'finalized' })
+  } catch (error) {
+    console.error('Finalize release error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+export default internalDeletion

--- a/src/routes/internal-deletion.ts
+++ b/src/routes/internal-deletion.ts
@@ -25,9 +25,11 @@ internalDeletion.post('/username/release/finalize', async (c) => {
     const result = await finalizeReleaseAttempt(c.env.DB, body.attempt_id, 'deletion-coordinator')
     if (result.outcome === 'not_found') return c.json({ ok: false, error: 'Release attempt not found' }, 404)
     if (result.outcome === 'conflict') {
-      const code = result.attempt?.state === 'cancelled' || result.attempt?.state === 'expired-restored'
-        ? 'attempt_cancelled'
-        : 'attempt_conflict'
+      const code = result.attempt?.state === 'pending' && result.attempt.expires_at <= Math.floor(Date.now() / 1000)
+        ? 'attempt_expired'
+        : result.attempt?.state === 'cancelled' || result.attempt?.state === 'expired-restored'
+          ? 'attempt_cancelled'
+          : 'attempt_conflict'
       return c.json({ ok: false, error: 'Release attempt cannot be finalized', code }, 409)
     }
     await reconcileUsernameFastly(c.env, result.attempt.username_canonical)

--- a/src/routes/username-release.test.ts
+++ b/src/routes/username-release.test.ts
@@ -1,0 +1,107 @@
+// ABOUTME: Covers the owner-authenticated recoverable username-release API.
+// ABOUTME: Verifies idempotency, privacy, eligibility, and terminal-state errors.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Hono } from 'hono'
+import { createExecutionContext } from '../db/test-helpers'
+
+const mocks = vi.hoisted(() => ({
+  verifyNip98Event: vi.fn(),
+  getUsernameByPubkey: vi.fn(),
+  getLatestReleaseAttemptByPubkey: vi.fn(),
+  getReleaseAttemptById: vi.fn(),
+  prepareReleaseAttempt: vi.fn(),
+  rollbackReleaseAttempt: vi.fn(),
+  reconcileUsernameFastly: vi.fn(),
+}))
+
+vi.mock('../middleware/nip98', () => ({ verifyNip98Event: mocks.verifyNip98Event }))
+vi.mock('../db/queries', async () => ({
+  ...await vi.importActual<typeof import('../db/queries')>('../db/queries'),
+  getUsernameByPubkey: mocks.getUsernameByPubkey,
+  getLatestReleaseAttemptByPubkey: mocks.getLatestReleaseAttemptByPubkey,
+  getReleaseAttemptById: mocks.getReleaseAttemptById,
+  prepareReleaseAttempt: mocks.prepareReleaseAttempt,
+  rollbackReleaseAttempt: mocks.rollbackReleaseAttempt,
+}))
+vi.mock('../utils/username-fastly-reconcile', () => ({ reconcileUsernameFastly: mocks.reconcileUsernameFastly }))
+
+import username from './username'
+
+const pubkey = 'a'.repeat(64)
+const attemptId = 'delete-attempt-00000001'
+const usernameRow = {
+  name: 'Alice', username_display: 'Alice', username_canonical: 'alice', pubkey, status: 'pending-release',
+}
+const pendingAttempt = {
+  attempt_id: attemptId, username_canonical: 'alice', pubkey, state: 'pending',
+  created_at: 100, updated_at: 100, expires_at: 200, cancelled_at: null, finalized_at: null, finalized_by: null,
+}
+
+function app() {
+  const instance = new Hono<{ Bindings: { DB: D1Database } }>()
+  instance.route('/api/username', username)
+  return instance
+}
+
+function post(path: string, body: object) {
+  return new Request(`http://localhost/api/username${path}`, {
+    method: 'POST', headers: { Authorization: 'Nostr test', 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  })
+}
+
+describe('recoverable username release routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.verifyNip98Event.mockResolvedValue(pubkey)
+    mocks.getLatestReleaseAttemptByPubkey.mockResolvedValue(null)
+    mocks.getReleaseAttemptById.mockResolvedValue(null)
+    mocks.reconcileUsernameFastly.mockResolvedValue(undefined)
+  })
+
+  it('prepares an owned active name and returns the durable attempt', async () => {
+    mocks.getUsernameByPubkey.mockResolvedValue({ ...usernameRow, status: 'active' })
+    mocks.prepareReleaseAttempt.mockResolvedValue({ outcome: 'transitioned', attempt: pendingAttempt, username: usernameRow })
+    const response = await app().fetch(post('/release/prepare', { name: 'Alice', attempt_id: attemptId }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ attempt_id: attemptId, state: 'pending', name: 'Alice' })
+    expect(mocks.reconcileUsernameFastly).toHaveBeenCalledWith(expect.anything(), 'alice')
+  })
+
+  it('rejects a different pending attempt without exposing its identifier', async () => {
+    mocks.getUsernameByPubkey.mockResolvedValue(null)
+    mocks.getLatestReleaseAttemptByPubkey.mockResolvedValue(pendingAttempt)
+    const response = await app().fetch(post('/release/prepare', { name: 'alice', attempt_id: 'delete-attempt-00000002' }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(409)
+    expect(JSON.stringify(await response.json())).not.toContain(attemptId)
+  })
+
+  it('returns caller-scoped attempt state after reinstall', async () => {
+    mocks.getLatestReleaseAttemptByPubkey.mockResolvedValue(pendingAttempt)
+    const request = new Request('http://localhost/api/username/release/attempt', { headers: { Authorization: 'Nostr test' } })
+    const response = await app().fetch(request, { DB: {} as D1Database }, createExecutionContext())
+    expect(await response.json()).toMatchObject({ found: true, attempt_id: attemptId, state: 'pending' })
+  })
+
+  it('returns cancelled for a rollback replay', async () => {
+    mocks.rollbackReleaseAttempt.mockResolvedValue({
+      outcome: 'replayed', attempt: { ...pendingAttempt, state: 'cancelled' }, username: { ...usernameRow, status: 'active' },
+    })
+    const response = await app().fetch(post('/release/rollback', { name: 'alice', attempt_id: attemptId }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ state: 'cancelled' })
+  })
+
+  it('never permits rollback after finalization', async () => {
+    mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'conflict', attempt: { ...pendingAttempt, state: 'finalized' } })
+    const response = await app().fetch(post('/release/rollback', { name: 'alice', attempt_id: attemptId }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ code: 'already_finalized' })
+  })
+
+  it('bounds opaque attempt identifiers', async () => {
+    const response = await app().fetch(post('/release/prepare', { name: 'alice', attempt_id: 'short' }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(400)
+    expect(mocks.prepareReleaseAttempt).not.toHaveBeenCalled()
+  })
+})

--- a/src/routes/username-release.test.ts
+++ b/src/routes/username-release.test.ts
@@ -76,6 +76,14 @@ describe('recoverable username release routes', () => {
     expect(JSON.stringify(await response.json())).not.toContain(attemptId)
   })
 
+  it('rejects a prepare replay when the submitted name does not match the stored attempt', async () => {
+    mocks.getUsernameByPubkey.mockResolvedValue(null)
+    mocks.getLatestReleaseAttemptByPubkey.mockResolvedValue(pendingAttempt)
+    const response = await app().fetch(post('/release/prepare', { name: 'bob', attempt_id: attemptId }), { DB: {} as D1Database }, createExecutionContext())
+    expect(response.status).toBe(403)
+    expect(mocks.prepareReleaseAttempt).not.toHaveBeenCalled()
+  })
+
   it('returns caller-scoped attempt state after reinstall', async () => {
     mocks.getLatestReleaseAttemptByPubkey.mockResolvedValue(pendingAttempt)
     const request = new Request('http://localhost/api/username/release/attempt', { headers: { Authorization: 'Nostr test' } })

--- a/src/routes/username.test.ts
+++ b/src/routes/username.test.ts
@@ -37,6 +37,9 @@ function createMockDB(initialUsernames: any[] = []) {
           boundParams = params
           return {
             first: async () => {
+              if (sql.includes('FROM username_release_attempts')) {
+                return null
+              }
               // Spent Cashu proof lookup
               if (sql.includes('FROM spent_cashu_proofs WHERE proof_secret = ?')) {
                 const secret = boundParams[0]
@@ -281,6 +284,7 @@ function createMockDB(initialUsernames: any[] = []) {
         }
       }
     },
+    batch: async (statements: Array<{ run: () => Promise<any> }>) => Promise.all(statements.map(statement => statement.run())),
     // Expose internals for test assertions
     _mockUsernames: mockUsernames,
     _mockReservationTokens: mockReservationTokens
@@ -662,6 +666,18 @@ describe('Public Username Endpoints', () => {
       expect(json.reason).toBe('Username is already taken')
     })
 
+    it('does not disclose that an unavailable name has a pending release', async () => {
+      const app = createTestApp()
+      const db = createMockDB([{
+        id: 1, name: 'alice', username_display: 'alice', username_canonical: 'alice',
+        pubkey: 'a'.repeat(64), status: 'pending-release', reservation_expires_at: null
+      }])
+      const res = await app.fetch(new Request('http://localhost/api/username/check/alice'), { DB: db }, createExecutionContext())
+      expect(await res.json()).toEqual(expect.objectContaining({ available: false, code: 'taken', reason: 'Username is already taken' }))
+      const secondResponse = await app.fetch(new Request('http://localhost/api/username/check/alice'), { DB: db }, createExecutionContext())
+      expect(JSON.stringify(await secondResponse.json())).not.toContain('pending-release')
+    })
+
     it('should normalize active username pubkey to lowercase', async () => {
       const app = createTestApp()
       const ownerPubkeyUpper = 'A'.repeat(64)
@@ -930,6 +946,20 @@ describe('Public Name Reservation', () => {
       const json = await res.json() as any
       expect(json.ok).toBe(false)
       expect(json.error).toContain('already taken')
+    })
+
+    it('fails closed when reserving a pending-release username', async () => {
+      const app = createTestApp()
+      const db = createMockDB([{
+        id: 1, name: 'alice', username_display: 'alice', username_canonical: 'alice',
+        pubkey: 'a'.repeat(64), status: 'pending-release', reservation_expires_at: null
+      }])
+      const req = new Request('http://localhost/api/username/reserve', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'alice', email: 'alice@example.com' })
+      })
+      const res = await app.fetch(req, { DB: db }, mockEnv)
+      expect(res.status).toBe(409)
     })
 
     it('should reject reservation of a confirmed-reserved username', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -637,7 +637,8 @@ username.post('/release/prepare', async (c) => {
       }
     }
     const canonical = (owned?.username_canonical || owned?.name || latest?.username_canonical || requested).toLowerCase()
-    if (owned && requested !== canonical && requested !== owned.name.toLowerCase()) {
+    const display = (owned?.username_display || owned?.name || '').toLowerCase()
+    if (requested !== canonical && (!owned || requested !== display)) {
       return c.json({ ok: false, error: 'You do not own that username' }, 403)
     }
 

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Public endpoints: GET /check/:name, GET /by-pubkey/:pubkey, POST /reserve, GET /confirm
 // ABOUTME: Authenticated: POST /claim, POST /release (NIP-98 auth - works for both custodial and non-custodial users)
 
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { cors } from 'hono/cors'
 import { verifyNip98Event } from '../middleware/nip98'
 import { validateUsername, validateRelays, UsernameValidationError, RelayValidationError } from '../utils/validation'
@@ -19,6 +19,10 @@ import {
   findSpentProofs,
   storeSpentProofs,
   enqueueFastlySyncTask,
+  getLatestReleaseAttemptByPubkey,
+  getReleaseAttemptById,
+  prepareReleaseAttempt,
+  rollbackReleaseAttempt,
 } from '../db/queries'
 import { syncAndVerifyUsername, deleteUsernameFromFastly } from '../utils/fastly-sync'
 import { sendReservationConfirmationEmail } from '../utils/email'
@@ -31,6 +35,7 @@ import {
   CashuValidationError
 } from '../utils/cashu'
 import { getRegistrationPrice } from '../utils/pricing'
+import { reconcileUsernameFastly } from '../utils/username-fastly-reconcile'
 
 type Bindings = {
   DB: D1Database
@@ -104,6 +109,17 @@ username.get('/check/:name', async (c) => {
           available: true,
           name: usernameData.display,
           canonical: usernameData.canonical
+        }, 200, { 'Access-Control-Allow-Origin': '*' })
+      }
+
+      if (existing.status === 'pending-release') {
+        return c.json({
+          ok: true,
+          available: false,
+          name: usernameData.display,
+          canonical: usernameData.canonical,
+          code: 'taken',
+          reason: 'Username is already taken'
         }, 200, { 'Access-Control-Allow-Origin': '*' })
       }
 
@@ -260,6 +276,9 @@ username.post('/reserve', async (c) => {
         }
         if (existing.status === 'pending-confirmation') {
           return c.json({ ok: false, error: 'Username is pending email confirmation' }, 409, { 'Access-Control-Allow-Origin': '*' })
+        }
+        if (existing.status !== 'revoked') {
+          return c.json({ ok: false, error: 'Username is unavailable' }, 409, { 'Access-Control-Allow-Origin': '*' })
         }
       }
       // Expired pending-confirmation or revoked: allow re-reservation
@@ -424,6 +443,31 @@ username.get('/confirm', async (c) => {
 // availability check. /release already used 300s for this; /claim is the
 // same signer path. Replay is still bound to method, URL, and payload hash.
 const KEYCAST_NIP98_MAX_AGE_SECONDS = 300
+const RELEASE_ATTEMPT_ID_PATTERN = /^[A-Za-z0-9._~-]{16,128}$/
+
+async function authenticateReleaseRequest(c: Context<{ Bindings: Bindings }>, bodyText: string): Promise<string> {
+  return (await verifyNip98Event(
+    c.req.raw.headers,
+    c.req.method,
+    new URL(c.req.url).toString(),
+    bodyText,
+    KEYCAST_NIP98_MAX_AGE_SECONDS
+  )).toLowerCase()
+}
+
+function parseReleaseAttemptBody(bodyText: string): { name: string; attemptId: string } | null {
+  let body: unknown
+  try {
+    body = JSON.parse(bodyText)
+  } catch {
+    return null
+  }
+  if (typeof body !== 'object' || body === null) return null
+  const { name, attempt_id } = body as { name?: unknown; attempt_id?: unknown }
+  if (typeof name !== 'string' || name.trim().length === 0) return null
+  if (typeof attempt_id !== 'string' || !RELEASE_ATTEMPT_ID_PATTERN.test(attempt_id)) return null
+  return { name, attemptId: attempt_id }
+}
 
 username.post('/claim', async (c) => {
   try {
@@ -478,6 +522,11 @@ username.post('/claim', async (c) => {
       return c.json({ ok: false, error: 'Username is reserved' }, 403)
     }
 
+    const releaseAttempt = await getLatestReleaseAttemptByPubkey(c.env.DB, pubkey)
+    if (releaseAttempt?.state === 'pending') {
+      return c.json({ ok: false, error: 'Username release is pending', code: 'release_pending' }, 409)
+    }
+
     // Check if name exists (using canonical for lookup)
     const existing = await getUsernameByName(c.env.DB, nameCanonical)
     if (existing) {
@@ -493,7 +542,9 @@ username.post('/claim', async (c) => {
       if (existing.status === 'pending-confirmation') {
         return c.json({ ok: false, error: 'Username is pending email confirmation' }, 409)
       }
-      // If revoked and recyclable, allow claim (continue below)
+      if (existing.status !== 'revoked' && !(existing.status === 'active' && existing.pubkey?.toLowerCase() === pubkey)) {
+        return c.json({ ok: false, error: 'Username is unavailable' }, 409)
+      }
     }
 
     // Check if pubkey already has an active username
@@ -561,11 +612,110 @@ username.post('/claim', async (c) => {
     if (error instanceof Error && error.name === 'Nip98Error') {
       return c.json({ ok: false, error: error.message }, 401)
     }
+    if (error instanceof Error && error.message === 'USERNAME_NOT_CLAIMABLE') {
+      return c.json({ ok: false, error: 'Username is unavailable' }, 409)
+    }
     console.error('Claim error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
   }
 })
 
+username.post('/release/prepare', async (c) => {
+  try {
+    const bodyText = await c.req.text()
+    const pubkey = await authenticateReleaseRequest(c, bodyText)
+    const body = parseReleaseAttemptBody(bodyText)
+    if (!body) return c.json({ ok: false, error: 'name and a valid attempt_id are required' }, 400)
+
+    const requested = body.name.trim().toLowerCase()
+    const owned = await getUsernameByPubkey(c.env.DB, pubkey)
+    let latest = null
+    if (!owned) {
+      latest = await getLatestReleaseAttemptByPubkey(c.env.DB, pubkey)
+      if (latest?.state === 'pending' && latest.attempt_id !== body.attemptId) {
+        return c.json({ ok: false, error: 'A different release attempt is already pending', code: 'attempt_conflict' }, 409)
+      }
+    }
+    const canonical = (owned?.username_canonical || owned?.name || latest?.username_canonical || requested).toLowerCase()
+    if (owned && requested !== canonical && requested !== owned.name.toLowerCase()) {
+      return c.json({ ok: false, error: 'You do not own that username' }, 403)
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const result = await prepareReleaseAttempt(c.env.DB, pubkey, canonical, body.attemptId, now + 72 * 60 * 60, now)
+    if (result.outcome === 'conflict') {
+      return c.json({ ok: false, error: 'Release attempt conflicts with existing state', code: 'attempt_conflict' }, 409)
+    }
+    if (result.outcome === 'not_found') {
+      return c.json({ ok: false, error: 'No eligible active username found', code: 'not_eligible' }, 409)
+    }
+    await reconcileUsernameFastly(c.env, canonical)
+    return c.json({
+      ok: true,
+      attempt_id: result.attempt.attempt_id,
+      name: result.username.username_display || result.username.name,
+      state: result.attempt.state,
+      expires_at: result.attempt.expires_at,
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'Nip98Error') return c.json({ ok: false, error: error.message }, 401)
+    console.error('Prepare release error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+username.get('/release/attempt', async (c) => {
+  try {
+    const pubkey = await authenticateReleaseRequest(c, '')
+    const attempt = await getLatestReleaseAttemptByPubkey(c.env.DB, pubkey)
+    if (!attempt) return c.json({ ok: true, found: false })
+    return c.json({
+      ok: true,
+      found: true,
+      attempt_id: attempt.attempt_id,
+      name: attempt.username_canonical,
+      state: attempt.state,
+      created_at: attempt.created_at,
+      expires_at: attempt.expires_at,
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'Nip98Error') return c.json({ ok: false, error: error.message }, 401)
+    console.error('Release attempt lookup error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+username.post('/release/rollback', async (c) => {
+  try {
+    const bodyText = await c.req.text()
+    const pubkey = await authenticateReleaseRequest(c, bodyText)
+    const body = parseReleaseAttemptBody(bodyText)
+    if (!body) return c.json({ ok: false, error: 'name and a valid attempt_id are required' }, 400)
+    const requested = body.name.trim().toLowerCase()
+    const attempt = await getReleaseAttemptById(c.env.DB, body.attemptId)
+    const canonical = attempt?.username_canonical || requested
+    if (attempt && attempt.pubkey.toLowerCase() === pubkey && requested !== canonical) {
+      const stored = await getUsernameByName(c.env.DB, canonical)
+      const display = (stored?.username_display || stored?.name || '').toLowerCase()
+      if (requested !== display) return c.json({ ok: false, error: 'Release attempt conflicts with existing state', code: 'attempt_conflict' }, 409)
+    }
+    const result = await rollbackReleaseAttempt(c.env.DB, pubkey, canonical, body.attemptId)
+    if (result.outcome === 'not_found') return c.json({ ok: false, error: 'Release attempt not found' }, 404)
+    if (result.outcome === 'conflict') {
+      const code = result.attempt?.state === 'finalized' ? 'already_finalized' : 'attempt_conflict'
+      return c.json({ ok: false, error: 'Release attempt cannot be rolled back', code }, 409)
+    }
+    await reconcileUsernameFastly(c.env, canonical)
+    return c.json({ ok: true, attempt_id: result.attempt.attempt_id, name: canonical, state: 'cancelled' })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'Nip98Error') return c.json({ ok: false, error: error.message }, 401)
+    console.error('Rollback release error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+// TODO(#78): Remove this immediate-burn compatibility endpoint after clients
+// migrate to the recoverable release lifecycle above.
 username.post('/release', async (c) => {
   try {
     // Read raw body text first (needed for NIP-98 payload verification)

--- a/src/utils/username-fastly-reconcile.ts
+++ b/src/utils/username-fastly-reconcile.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Reconciles one username from authoritative D1 state to Fastly KV.
+// ABOUTME: Detects out-of-order transitions and preserves newer queued generations.
+
+import {
+  clearFastlySyncTasks,
+  enqueueFastlySyncTask,
+  getQueuedFastlySyncTask,
+  getUsernameByName,
+  markFastlySyncTaskFailures,
+} from '../db/queries'
+import { deleteUsernameFromFastly, parseRelayHints, syncAndVerifyUsername, type FastlyEnv, type SyncItem } from './fastly-sync'
+
+type ReconcileEnv = FastlyEnv & { DB: D1Database }
+
+function desiredItem(username: Awaited<ReturnType<typeof getUsernameByName>>, canonical: string): SyncItem {
+  if (username?.status === 'active' && username.pubkey) {
+    return {
+      username: canonical,
+      action: 'sync',
+      data: {
+        pubkey: username.pubkey,
+        relays: parseRelayHints(username.relays),
+        status: 'active',
+        atproto_did: username.atproto_did,
+        atproto_state: username.atproto_state,
+      },
+    }
+  }
+  return { username: canonical, action: 'delete' }
+}
+
+function sameDesiredState(left: SyncItem, right: SyncItem): boolean {
+  return left.action === right.action && JSON.stringify(left.data || null) === JSON.stringify(right.data || null)
+}
+
+export async function reconcileUsernameFastly(env: ReconcileEnv, canonical: string): Promise<void> {
+  let lastError = 'Fastly state changed during reconciliation'
+  for (let pass = 0; pass < 3; pass += 1) {
+    const before = desiredItem(await getUsernameByName(env.DB, canonical), canonical)
+    await enqueueFastlySyncTask(env.DB, before)
+    const queued = await getQueuedFastlySyncTask(env.DB, canonical)
+
+    let operationSucceeded = false
+    if (before.action === 'sync' && before.data) {
+      const result = await syncAndVerifyUsername(env, canonical, before.data)
+      operationSucceeded = result.success && result.verified
+      if (!operationSucceeded) lastError = result.error || 'Fastly sync verification failed'
+    } else {
+      const result = await deleteUsernameFromFastly(env, canonical)
+      operationSucceeded = result.success
+      if (!operationSucceeded) lastError = result.error || 'Fastly delete failed'
+    }
+
+    const after = desiredItem(await getUsernameByName(env.DB, canonical), canonical)
+    if (sameDesiredState(before, after)) {
+      if (queued && operationSucceeded) {
+        await clearFastlySyncTasks(env.DB, [{ username: canonical, generation: queued.generation }])
+      } else if (queued) {
+        await markFastlySyncTaskFailures(env.DB, [{ username: canonical, error: lastError }])
+      }
+      return
+    }
+  }
+
+  const latest = desiredItem(await getUsernameByName(env.DB, canonical), canonical)
+  await enqueueFastlySyncTask(env.DB, latest)
+}

--- a/tests/atproto-cron-sync.test.ts
+++ b/tests/atproto-cron-sync.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Username } from '../src/db/queries'
 
-const { getUsernamesUpdatedSince, expireStaleReservations, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, syncBatch } = vi.hoisted(() => ({
+const { getUsernamesUpdatedSince, expireStaleReservations, getStaleReleaseAttempts, rollbackReleaseAttempt, getQueuedFastlySyncTasks, enqueueFastlySyncTask, clearFastlySyncTasks, markFastlySyncTaskFailures, syncBatch } = vi.hoisted(() => ({
   getUsernamesUpdatedSince: vi.fn<() => Promise<Username[]>>(),
   expireStaleReservations: vi.fn<() => Promise<number>>(),
+  getStaleReleaseAttempts: vi.fn<() => Promise<any[]>>(),
+  rollbackReleaseAttempt: vi.fn(),
   getQueuedFastlySyncTasks: vi.fn<() => Promise<any[]>>(),
   enqueueFastlySyncTask: vi.fn<() => Promise<void>>(),
   clearFastlySyncTasks: vi.fn<() => Promise<void>>(),
@@ -17,6 +19,8 @@ vi.mock('../src/db/queries', async () => {
     ...actual,
     getUsernamesUpdatedSince,
     expireStaleReservations,
+    getStaleReleaseAttempts,
+    rollbackReleaseAttempt,
     getQueuedFastlySyncTasks,
     enqueueFastlySyncTask,
     clearFastlySyncTasks,
@@ -38,6 +42,7 @@ describe('ATProto cron sync payloads', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     expireStaleReservations.mockResolvedValue(0)
+    getStaleReleaseAttempts.mockResolvedValue([])
     getQueuedFastlySyncTasks.mockResolvedValue([])
     syncBatch.mockResolvedValue({ synced: 1, deleted: 0, failed: 0, errors: [], successes: [], failures: [] })
   })
@@ -151,6 +156,32 @@ describe('ATProto cron sync payloads', () => {
     )
   })
 
+  it('maps pending releases to delete and restores expired attempts before reconciliation', async () => {
+    const attempt = {
+      attempt_id: 'delete-attempt-00000001', username_canonical: 'alice', pubkey: 'a'.repeat(64),
+      state: 'pending', created_at: 1, updated_at: 1, expires_at: 2,
+      cancelled_at: null, finalized_at: null, finalized_by: null,
+    }
+    getStaleReleaseAttempts.mockResolvedValue([attempt])
+    rollbackReleaseAttempt.mockResolvedValue({ outcome: 'transitioned', attempt: { ...attempt, state: 'expired-restored' }, username: {} })
+    getUsernamesUpdatedSince.mockResolvedValue([{
+      id: 7, name: 'pending-user', username_display: 'pending-user', username_canonical: 'pending-user',
+      pubkey: 'b'.repeat(64), email: null, relays: null, status: 'pending-release', recyclable: 1,
+      created_at: 0, updated_at: 0, claimed_at: 0, revoked_at: null, reserved_reason: null,
+      admin_notes: null, admin_notes_updated_by: null, admin_notes_updated_at: null,
+      reservation_email: null, confirmation_token: null, reservation_expires_at: null,
+      subscription_expires_at: null, claim_source: 'self-service', created_by: null,
+      atproto_did: null, atproto_state: null,
+    }])
+    await worker.scheduled(
+      {} as ScheduledEvent,
+      { DB: {} as D1Database, ASSETS: { fetch: async () => new Response('', { status: 404 }) } },
+      { waitUntil: () => {}, passThroughOnException: () => {} } as ExecutionContext
+    )
+    expect(rollbackReleaseAttempt).toHaveBeenCalledWith(expect.anything(), attempt.pubkey, 'alice', attempt.attempt_id, 'expired-restored')
+    expect(syncBatch).toHaveBeenCalledWith(expect.anything(), [{ username: 'pending-user', action: 'delete' }], { concurrency: 10 })
+  })
+
   it('filters out active users without pubkeys', async () => {
     getUsernamesUpdatedSince.mockResolvedValue([
       {
@@ -236,6 +267,7 @@ describe('ATProto cron sync payloads', () => {
         last_attempt_at: 110,
         attempt_count: 2,
         last_error: 'old error',
+        generation: 3,
       },
       {
         username: 'burned-user',
@@ -245,6 +277,7 @@ describe('ATProto cron sync payloads', () => {
         last_attempt_at: 100,
         attempt_count: 1,
         last_error: 'delete error',
+        generation: 2,
       },
     ])
     getUsernamesUpdatedSince.mockResolvedValue([
@@ -311,7 +344,7 @@ describe('ATProto cron sync payloads', () => {
       ]),
       { concurrency: 10 }
     )
-    expect(clearFastlySyncTasks).toHaveBeenCalledWith(expect.anything(), ['burned-user'])
+    expect(clearFastlySyncTasks).toHaveBeenCalledWith(expect.anything(), [{ username: 'burned-user', generation: 2 }])
     expect(enqueueFastlySyncTask).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,7 @@ routes = [
 # NAME_PRICE_SATS: minimum sat amount required to reserve a name (default: 1000)
 # INVITE_FAUCET_URL: base URL of the invite code faucet service (e.g. "https://faucet.example.com")
 # Set via wrangler secret put SENDGRID_API_KEY
+# Recoverable username-release finalization: wrangler secret put DELETION_COORDINATOR_TOKEN
 [vars]
 KEYCAST_URL = "https://login.divine.video"
 KEYCAST_CLIENT_ID = "divine-name-server"


### PR DESCRIPTION
## Problem

Account deletion permanently burned a member's `@divine.video` name before relay and key-service deletion had finished. If a later service failed or the app exited, the account could survive while its name was lost permanently.

## Why this fix

This adds a server-enforced prepare / rollback / finalize lifecycle keyed by one opaque deletion-attempt ID. Prepare keeps ownership in a non-resolving, non-claimable state; rollback restores the same row; only a separately authenticated deletion coordinator can finalize the permanent burn. Conditional D1 transactions and unique ownership indexes decide every transition, while generation-aware Fastly reconciliation prevents an older edge operation from clearing or overwriting newer desired state. Abandoned attempts restore automatically after their recorded 72-hour deadline and never age into a burn.

Example owner request:

```json
{ "name": "alice", "attempt_id": "delete-attempt-00000001" }
```

Example status response:

```json
{ "ok": true, "found": true, "attempt_id": "delete-attempt-00000001", "name": "alice", "state": "pending", "created_at": 1787191200, "expires_at": 1787450400 }
```

## Deliberately unchanged

- The legacy immediate-burn endpoint remains available while clients migrate; removal is tracked by #78.
- Public by-pubkey lookup still returns active names only, and public availability responses do not disclose that deletion is pending.
- Pending state is represented by deleting the Fastly key, so no matching edge-worker schema change is required.
- The admin UI change is limited to a pending-release count, badge, and status filter; release-attempt audit records are available through the protected admin API.

## Migration and operations

Migration `0012_add_release_attempts.sql` adds the durable audit table, broadens the one-name ownership index to active and pending-release rows, and versions Fastly queue entries. Deployment also requires a new `DELETION_COORDINATOR_TOKEN` Worker secret distinct from the ATProto token.

## Verification

- `npm run test:once` — 373 tests passed
- `npx tsc --noEmit`
- `npm run build:admin`
- `npx wrangler d1 migrations apply divine-name-server-db --local` — full chain applied; repeat reports no pending migrations
- `git diff --check`

Closes #77.
Refs #78.