### PR TITLE
feat(account): expose deletion release coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Admin sessions are established via the Keycast OAuth flow under `/api/admin/auth
 
 `POST /api/internal/username/set-atproto` — service-to-service variant of the ATProto linking endpoint, authenticated with the `ATPROTO_SYNC_TOKEN` bearer token.
 
+The deletion coordinator endpoints under `/api/internal/username/release/` are authenticated with `DELETION_COORDINATOR_TOKEN`; their status, rollback, and finalize contracts are documented in [Recoverable release lifecycle](#recoverable-release-lifecycle).
+
 ## Database schema
 
 Migrations under `migrations/` define and evolve the schema (`0001_initial_schema.sql` onward). The core tables:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ All endpoints send permissive CORS headers so the Divine web and Flutter clients
 | `POST` | `/api/username/claim` | Claim a name with NIP-98 auth. |
 | `POST` | `/api/username/release/prepare` | Hide and hold an owned name for an opaque deletion attempt. NIP-98 auth. |
 | `GET` | `/api/username/release/attempt` | Read the caller's latest durable release-attempt state. NIP-98 auth. |
-| `POST` | `/api/username/release/rollback` | Restore a recoverable pending release. NIP-98 auth. |
+| `POST` | `/api/username/release/rollback` | Restore a recoverable release and return its stored terminal state. NIP-98 auth. |
 | `POST` | `/api/username/release` | Legacy immediate permanent burn; retained while callers migrate, with removal tracked in #78. |
 
 #### POST /api/username/claim
@@ -161,24 +161,6 @@ All endpoints send permissive CORS headers so the Divine web and Flutter clients
 Claim a username by proving key ownership.
 
 **Authentication:** a NIP-98 event (kind `27235`) sent as `Authorization: Nostr <base64-event>`, with a `u` tag matching the request URL, a `method` tag matching `POST`, and a timestamp within 300 seconds.
-
-#### Recoverable release lifecycle
-
-The deletion coordinator supplies one opaque 16–128 character attempt ID across services. Preparing changes the owned row from `active` to `pending-release`; the name stops resolving but remains owned and unavailable to claims. The authenticated owner may roll it back to `active`, or the trusted deletion coordinator may finalize it to non-recyclable `burned`. Replays of the same transition are safe. A finalized attempt cannot be rolled back.
-
-```text
-active --prepare--> pending-release --rollback--------> active / cancelled
-                              |--72h expiry restore---> active / expired-restored
-                              `--service finalize-----> burned / finalized
-```
-
-The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations. All three resolve the owning pubkey and name from the stored attempt, so a caller cannot substitute its own ownership data:
-
-- `GET /api/internal/username/release/attempt/:attemptId` returns the attempt's `state`, `username`, `pubkey`, and `expires_at`, so the coordinator can check the account binding and the recovery deadline itself. `404` when the attempt is unknown.
-- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. It also succeeds idempotently when the same owner and name were already restored by cancellation or the 72h expiry sweeper. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` for another incompatible state.
-- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, `attempt_cancelled` once it was rolled back, or `attempt_conflict` when the held name is no longer `pending-release` — an owner rollback that lands between the coordinator's read and its write reaches this case with the attempt still `pending` and unexpired.
-
-Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 
 **Request body:**
 
@@ -209,6 +191,24 @@ Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is 
 ```
 
 **Errors:** `400` invalid username/relays · `401` bad NIP-98 signature · `403` reserved or burned · `409` claimed by another pubkey · `500` internal error.
+
+#### Recoverable release lifecycle
+
+The deletion coordinator supplies one opaque 16–128 character attempt ID across services. Preparing changes the owned row from `active` to `pending-release`; the name stops resolving but remains owned and unavailable to claims. The authenticated owner may roll it back to `active`, or the trusted deletion coordinator may finalize it to non-recyclable `burned`. Replays of the same transition are safe. A finalized attempt cannot be rolled back.
+
+```text
+active --prepare--> pending-release --rollback--------> active / cancelled
+                              |--72h expiry restore---> active / expired-restored
+                              `--service finalize-----> burned / finalized
+```
+
+The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations. All three resolve the owning pubkey and name from the stored attempt, so a caller cannot substitute its own ownership data:
+
+- `GET /api/internal/username/release/attempt/:attemptId` returns the attempt's `state`, `username`, `pubkey`, and `expires_at`, so the coordinator can check the account binding and the recovery deadline itself. `404` when the attempt is unknown.
+- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. It also succeeds idempotently when the same owner and name were already restored by cancellation or the 72h expiry sweeper. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` for another incompatible state.
+- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, `attempt_cancelled` once it was rolled back, or `attempt_conflict` when the held name is no longer `pending-release` — an owner rollback that lands between the coordinator's read and its write reaches this case with the attempt still `pending` and unexpired.
+
+Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 
 #### POST /api/username/reserve
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN
 
 - `GET /api/internal/username/release/attempt/:attemptId` returns the attempt's `state`, `username`, `pubkey`, and `expires_at`, so the coordinator can check the account binding and the recovery deadline itself. `404` when the attempt is unknown.
 - `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. It also succeeds idempotently when the same owner and name were already restored by cancellation or the 72h expiry sweeper. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` for another incompatible state.
-- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, or `attempt_cancelled` once it was rolled back.
+- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, `attempt_cancelled` once it was rolled back, or `attempt_conflict` when the held name is no longer `pending-release` — an owner rollback that lands between the coordinator's read and its write reaches this case with the attempt still `pending` and unexpired.
 
 Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ active --prepare--> pending-release --rollback--------> active / cancelled
 The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations. All three resolve the owning pubkey and name from the stored attempt, so a caller cannot substitute its own ownership data:
 
 - `GET /api/internal/username/release/attempt/:attemptId` returns the attempt's `state`, `username`, `pubkey`, and `expires_at`, so the coordinator can check the account binding and the recovery deadline itself. `404` when the attempt is unknown.
-- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` when the attempt is no longer pending — including an attempt the 72h expiry sweeper already restored.
+- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. It also succeeds idempotently when the same owner and name were already restored by cancellation or the 72h expiry sweeper. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` for another incompatible state.
 - `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, or `attempt_cancelled` once it was rolled back.
 
 Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,13 @@ active --prepare--> pending-release --rollback--------> active / cancelled
                               `--service finalize-----> burned / finalized
 ```
 
-`POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` with `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>`. Set that credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
+The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations:
+
+- `GET /api/internal/username/release/attempt/:attemptId` verifies the account binding, pending state, and expiry.
+- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }` and confirms the name is restored before cancellation.
+- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name.
+
+Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 
 **Request body:**
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ active --prepare--> pending-release --rollback--------> active / cancelled
                               `--service finalize-----> burned / finalized
 ```
 
-The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations:
+The deletion coordinator uses `Authorization: Bearer <DELETION_COORDINATOR_TOKEN>` for three internal operations. All three resolve the owning pubkey and name from the stored attempt, so a caller cannot substitute its own ownership data:
 
-- `GET /api/internal/username/release/attempt/:attemptId` verifies the account binding, pending state, and expiry.
-- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }` and confirms the name is restored before cancellation.
-- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name.
+- `GET /api/internal/username/release/attempt/:attemptId` returns the attempt's `state`, `username`, `pubkey`, and `expires_at`, so the coordinator can check the account binding and the recovery deadline itself. `404` when the attempt is unknown.
+- `POST /api/internal/username/release/rollback` accepts `{ "attempt_id": "..." }`, restores the held name to `active`, and cancels the attempt. `409` with `attempt_finalized` once the name is burned, or `attempt_conflict` when the attempt is no longer pending — including an attempt the 72h expiry sweeper already restored.
+- `POST /api/internal/username/release/finalize` accepts `{ "attempt_id": "..." }` and permanently burns the held name. `409` with `attempt_expired` past the recovery deadline, or `attempt_cancelled` once it was rolled back.
 
 Set the credential with `wrangler secret put DELETION_COORDINATOR_TOKEN`; it is intentionally separate from `ATPROTO_SYNC_TOKEN`.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "vitest",
     "test:once": "vitest run",
+    "typecheck": "tsc --noEmit",
     "build:admin": "cd admin-ui && npm run build",
     "dev": "wrangler dev",
     "deploy": "npm run build:admin && wrangler deploy",

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -226,7 +226,9 @@ export async function rollbackReleaseAttempt(
     return { outcome: 'conflict' }
   }
   const currentUsername = await getUsernameByName(db, usernameCanonical)
-  if (existing.state === terminalState && currentUsername?.status === 'active') {
+  if ((existing.state === 'cancelled' || existing.state === 'expired-restored') &&
+      currentUsername?.status === 'active' &&
+      currentUsername.pubkey?.toLowerCase() === existing.pubkey.toLowerCase()) {
     return { outcome: 'replayed', attempt: existing, username: currentUsername }
   }
   if (existing.state !== 'pending') return { outcome: 'conflict', attempt: existing }
@@ -240,13 +242,18 @@ export async function rollbackReleaseAttempt(
     `UPDATE username_release_attempts
      SET state = ?, updated_at = ?, cancelled_at = ?
      WHERE attempt_id = ? AND state = 'pending'
-       AND EXISTS (SELECT 1 FROM usernames WHERE username_canonical = ? AND status = 'active')`
-  ).bind(terminalState, now, now, attemptId, usernameCanonical)
+       AND EXISTS (
+         SELECT 1 FROM usernames
+         WHERE username_canonical = ? AND LOWER(pubkey) = LOWER(?) AND status = 'active'
+       )`
+  ).bind(terminalState, now, now, attemptId, usernameCanonical, pubkey)
   const [restoreResult, attemptResult] = await db.batch([restore, finishAttempt])
   const attempt = await getReleaseAttemptById(db, attemptId)
   const username = await getUsernameByName(db, usernameCanonical)
   if (!restoreResult.meta?.changes || !attemptResult.meta?.changes) {
-    if (attempt?.state === terminalState && username?.status === 'active') {
+    if ((attempt?.state === 'cancelled' || attempt?.state === 'expired-restored') &&
+        username?.status === 'active' &&
+        username.pubkey?.toLowerCase() === attempt.pubkey.toLowerCase()) {
       return { outcome: 'replayed', attempt, username }
     }
     return { outcome: 'conflict', attempt: attempt || undefined }

--- a/src/db/release-attempts-sqlite.test.ts
+++ b/src/db/release-attempts-sqlite.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   finalizeReleaseAttempt,
+  getReleaseAttemptById,
   getLatestReleaseAttemptByPubkey,
   prepareReleaseAttempt,
   rollbackReleaseAttempt,
@@ -34,6 +35,43 @@ describe.skipIf(!sqliteAvailable())('release attempts against real SQLite', () =
     const rolledBack = await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'cancelled', 200)
     expect(rolledBack.outcome).toBe('transitioned')
     expect((await getUsernameByName(db, 'alice'))?.status).toBe('active')
+
+    expect((await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT)).outcome).toBe('replayed')
+  })
+
+  it('treats an expiry restoration as an idempotent rollback success', async () => {
+    const { db } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 200, 100)
+    await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'expired-restored', 200)
+
+    const replay = await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'cancelled', 201)
+
+    expect(replay.outcome).toBe('replayed')
+    if (replay.outcome !== 'replayed') throw new Error('Expected an idempotent expiry restoration replay')
+    expect(replay.attempt?.state).toBe('expired-restored')
+    expect(replay.username).toMatchObject({ status: 'active', pubkey: OWNER })
+  })
+
+  it('does not replay a restored attempt when the username belongs to another pubkey', async () => {
+    const { db, sqlite } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 200, 100)
+    await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'expired-restored', 200)
+    sqlite.prepare('UPDATE usernames SET pubkey = ? WHERE username_canonical = ?').run(OTHER, 'alice')
+
+    const replay = await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'cancelled', 201)
+
+    expect(replay.outcome).toBe('conflict')
+  })
+
+  it('does not finish a pending attempt against another pubkey active row', async () => {
+    const { db, sqlite } = withOwnedName()
+    await prepareReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 999, 100)
+    sqlite.prepare("UPDATE usernames SET status = 'active', pubkey = ? WHERE username_canonical = ?").run(OTHER, 'alice')
+
+    const result = await rollbackReleaseAttempt(db, OWNER, 'alice', ATTEMPT, 'cancelled', 201)
+
+    expect(result.outcome).toBe('conflict')
+    expect((await getReleaseAttemptById(db, ATTEMPT))?.state).toBe('pending')
   })
 
   it('finalizes to a non-recyclable burn that cannot be rolled back', async () => {

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -142,6 +142,7 @@ describe('internal deletion reconciliation', () => {
     expect(mocks.rollbackReleaseAttempt).toHaveBeenCalledWith(
       expect.anything(), attempt.pubkey, 'alice', attempt.attempt_id,
     )
+    expect(mocks.reconcileUsernameFastly).toHaveBeenCalledWith(expect.anything(), 'alice')
     expect(await response.json()).toMatchObject({ state: 'cancelled', pubkey: attempt.pubkey })
   })
 
@@ -207,6 +208,20 @@ describe('internal deletion reconciliation', () => {
     ), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
     expect(response.status).toBe(409)
     expect(await response.json()).toMatchObject({ code: 'attempt_finalized' })
+  })
+
+  it('returns attempt_conflict for another incompatible rollback state', async () => {
+    const pending = { ...attempt, state: 'pending' }
+    mocks.getReleaseAttemptById.mockResolvedValue(pending)
+    mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'conflict', attempt: pending })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(
+      rollbackRequest('secret'),
+      { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' },
+      createExecutionContext(),
+    )
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ code: 'attempt_conflict' })
   })
 
   it('rejects unauthenticated status and rollback calls', async () => {

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Covers service-authenticated terminal username-release finalization.
+// ABOUTME: Covers service-authenticated username-release status, rollback, and finalization.
 // ABOUTME: Verifies least-privilege auth and idempotent terminal behavior.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -32,6 +32,20 @@ function request(token = 'secret') {
   return new Request('http://localhost/api/internal/username/release/finalize', {
     method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ attempt_id: attempt.attempt_id }),
+  })
+}
+
+function attemptRequest(token?: string) {
+  return new Request(`http://localhost/api/internal/username/release/attempt/${attempt.attempt_id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+}
+
+function rollbackRequest(token?: string, body: unknown = { attempt_id: attempt.attempt_id }) {
+  return new Request('http://localhost/api/internal/username/release/rollback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: JSON.stringify(body),
   })
 }
 
@@ -145,5 +159,65 @@ describe('internal deletion reconciliation', () => {
     ), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
     expect(response.status).toBe(409)
     expect(await response.json()).toMatchObject({ code: 'attempt_finalized' })
+  })
+
+  it('rejects unauthenticated status and rollback calls', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const env = { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }
+    expect((await app.fetch(attemptRequest(), env, createExecutionContext())).status).toBe(401)
+    expect((await app.fetch(rollbackRequest(), env, createExecutionContext())).status).toBe(401)
+    expect(mocks.getReleaseAttemptById).not.toHaveBeenCalled()
+    expect(mocks.rollbackReleaseAttempt).not.toHaveBeenCalled()
+  })
+
+  it('rejects another service credential on status and rollback', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const env = { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret', ATPROTO_SYNC_TOKEN: 'atproto-token' }
+    expect((await app.fetch(attemptRequest('atproto-token'), env, createExecutionContext())).status).toBe(401)
+    expect((await app.fetch(rollbackRequest('atproto-token'), env, createExecutionContext())).status).toBe(401)
+  })
+
+  it('fails closed on status and rollback when the coordinator token is missing', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const env = { DB: {} as D1Database }
+    expect((await app.fetch(attemptRequest('secret'), env, createExecutionContext())).status).toBe(503)
+    expect((await app.fetch(rollbackRequest('secret'), env, createExecutionContext())).status).toBe(503)
+  })
+
+  it('serves the nested status path when mounted in the worker', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue({ ...attempt, state: 'pending' })
+    const response = await worker.fetch(attemptRequest('secret'), {
+      DB: {} as D1Database,
+      DELETION_COORDINATOR_TOKEN: 'secret',
+      ATPROTO_SYNC_TOKEN: 'different-secret',
+      ASSETS: { fetch: async () => new Response('', { status: 404 }) },
+    }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ attempt_id: attempt.attempt_id, state: 'pending' })
+  })
+
+  it('ignores caller-supplied ownership fields and binds to the stored attempt', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue({ ...attempt, state: 'pending' })
+    mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'transitioned', attempt: { ...attempt, state: 'cancelled' }, username: { ...username, status: 'active' } })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(rollbackRequest('secret', {
+      attempt_id: attempt.attempt_id, pubkey: 'b'.repeat(64), name: 'mallory', username: 'mallory',
+    }), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(mocks.rollbackReleaseAttempt).toHaveBeenCalledWith(
+      expect.anything(), attempt.pubkey, 'alice', attempt.attempt_id,
+    )
+  })
+
+  it('rejects an attempt id outside the opaque length bounds', async () => {
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const env = { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }
+    const status = await app.fetch(new Request(
+      'http://localhost/api/internal/username/release/attempt/tooshort',
+      { headers: { Authorization: 'Bearer secret' } },
+    ), env, createExecutionContext())
+    expect(status.status).toBe(400)
+    expect((await app.fetch(rollbackRequest('secret', { attempt_id: 'tooshort' }), env, createExecutionContext())).status).toBe(400)
+    expect(mocks.getReleaseAttemptById).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -145,6 +145,54 @@ describe('internal deletion reconciliation', () => {
     expect(await response.json()).toMatchObject({ state: 'cancelled', pubkey: attempt.pubkey })
   })
 
+  it.each(['cancelled', 'expired-restored'] as const)(
+    'returns 200 when rollback replays an already-%s restoration',
+    async (state) => {
+      const restored = { ...attempt, state }
+      mocks.getReleaseAttemptById.mockResolvedValue(restored)
+      mocks.rollbackReleaseAttempt.mockResolvedValue({
+        outcome: 'replayed',
+        attempt: restored,
+        username: { ...username, status: 'active' },
+      })
+      const app = new Hono(); app.route('/api/internal', internalDeletion)
+
+      const response = await app.fetch(
+        rollbackRequest('secret'),
+        { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' },
+        createExecutionContext(),
+      )
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({ state, pubkey: attempt.pubkey })
+    },
+  )
+
+  it('returns 404 for an unknown status attempt', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue(null)
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(
+      attemptRequest('secret'),
+      { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' },
+      createExecutionContext(),
+    )
+    expect(response.status).toBe(404)
+    expect(await response.json()).toMatchObject({ code: 'attempt_not_found' })
+  })
+
+  it('returns 404 for an unknown rollback attempt', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue(null)
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(
+      rollbackRequest('secret'),
+      { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' },
+      createExecutionContext(),
+    )
+    expect(response.status).toBe(404)
+    expect(await response.json()).toMatchObject({ code: 'attempt_not_found' })
+    expect(mocks.rollbackReleaseAttempt).not.toHaveBeenCalled()
+  })
+
   it('does not roll back a finalized attempt', async () => {
     mocks.getReleaseAttemptById.mockResolvedValue(attempt)
     mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'conflict', attempt })

--- a/src/routes/internal-deletion.test.ts
+++ b/src/routes/internal-deletion.test.ts
@@ -5,10 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Hono } from 'hono'
 import { createExecutionContext } from '../db/test-helpers'
 
-const mocks = vi.hoisted(() => ({ finalizeReleaseAttempt: vi.fn(), reconcileUsernameFastly: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  finalizeReleaseAttempt: vi.fn(),
+  getReleaseAttemptById: vi.fn(),
+  rollbackReleaseAttempt: vi.fn(),
+  reconcileUsernameFastly: vi.fn(),
+}))
 vi.mock('../db/queries', async () => ({
   ...await vi.importActual<typeof import('../db/queries')>('../db/queries'),
   finalizeReleaseAttempt: mocks.finalizeReleaseAttempt,
+  getReleaseAttemptById: mocks.getReleaseAttemptById,
+  rollbackReleaseAttempt: mocks.rollbackReleaseAttempt,
 }))
 vi.mock('../utils/username-fastly-reconcile', () => ({ reconcileUsernameFastly: mocks.reconcileUsernameFastly }))
 
@@ -79,5 +86,64 @@ describe('internal deletion finalization', () => {
     const response = await app.fetch(request(), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
     expect(response.status).toBe(409)
     expect(await response.json()).toMatchObject({ code: 'attempt_expired' })
+  })
+})
+
+describe('internal deletion reconciliation', () => {
+  beforeEach(() => { vi.clearAllMocks(); mocks.reconcileUsernameFastly.mockResolvedValue(undefined) })
+
+  it('returns the account binding and deadline for coordinator verification', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue({ ...attempt, state: 'pending' })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(new Request(
+      `http://localhost/api/internal/username/release/attempt/${attempt.attempt_id}`,
+      { headers: { Authorization: 'Bearer secret' } },
+    ), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      ok: true,
+      attempt_id: attempt.attempt_id,
+      state: 'pending',
+      username: 'alice',
+      pubkey: 'a'.repeat(64),
+      expires_at: 3,
+    })
+  })
+
+  it('rolls back by attempt id and confirms the restored state', async () => {
+    const pending = { ...attempt, state: 'pending' }
+    const cancelled = { ...attempt, state: 'cancelled' }
+    mocks.getReleaseAttemptById.mockResolvedValue(pending)
+    mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'transitioned', attempt: cancelled, username: { ...username, status: 'active' } })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(new Request(
+      'http://localhost/api/internal/username/release/rollback',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ attempt_id: attempt.attempt_id }),
+      },
+    ), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(200)
+    expect(mocks.rollbackReleaseAttempt).toHaveBeenCalledWith(
+      expect.anything(), attempt.pubkey, 'alice', attempt.attempt_id,
+    )
+    expect(await response.json()).toMatchObject({ state: 'cancelled', pubkey: attempt.pubkey })
+  })
+
+  it('does not roll back a finalized attempt', async () => {
+    mocks.getReleaseAttemptById.mockResolvedValue(attempt)
+    mocks.rollbackReleaseAttempt.mockResolvedValue({ outcome: 'conflict', attempt })
+    const app = new Hono(); app.route('/api/internal', internalDeletion)
+    const response = await app.fetch(new Request(
+      'http://localhost/api/internal/username/release/rollback',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer secret', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ attempt_id: attempt.attempt_id }),
+      },
+    ), { DB: {} as D1Database, DELETION_COORDINATOR_TOKEN: 'secret' }, createExecutionContext())
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ code: 'attempt_finalized' })
   })
 })

--- a/src/routes/internal-deletion.ts
+++ b/src/routes/internal-deletion.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Finalizes recoverable username releases for the trusted deletion coordinator.
-// ABOUTME: Keeps permanent burns behind a dedicated least-privilege service credential.
+// ABOUTME: Reconciles recoverable username releases for the trusted deletion coordinator.
+// ABOUTME: Keeps status, rollback, and permanent burns behind one least-privilege credential.
 
 import { Hono } from 'hono'
-import { finalizeReleaseAttempt } from '../db/queries'
+import { finalizeReleaseAttempt, getReleaseAttemptById, rollbackReleaseAttempt } from '../db/queries'
 import { requireServiceToken } from '../middleware/service-auth'
 import { reconcileUsernameFastly } from '../utils/username-fastly-reconcile'
 
@@ -14,12 +14,69 @@ type Bindings = {
 }
 
 const internalDeletion = new Hono<{ Bindings: Bindings }>()
-internalDeletion.use('/username/release/finalize', requireServiceToken('DELETION_COORDINATOR_TOKEN', 'Deletion coordinator'))
+internalDeletion.use('/username/release/*', requireServiceToken('DELETION_COORDINATOR_TOKEN', 'Deletion coordinator'))
+
+function parseAttemptId(value: unknown): string | null {
+  return typeof value === 'string' && value.length >= 16 && value.length <= 128 ? value : null
+}
+
+function attemptResponse(attempt: Awaited<ReturnType<typeof getReleaseAttemptById>>) {
+  if (!attempt) return null
+  return {
+    ok: true,
+    attempt_id: attempt.attempt_id,
+    state: attempt.state,
+    username: attempt.username_canonical,
+    pubkey: attempt.pubkey,
+    expires_at: attempt.expires_at,
+  }
+}
+
+internalDeletion.get('/username/release/attempt/:attemptId', async (c) => {
+  const attemptId = parseAttemptId(c.req.param('attemptId'))
+  if (!attemptId) return c.json({ ok: false, error: 'A valid attempt_id is required' }, 400)
+  try {
+    const attempt = await getReleaseAttemptById(c.env.DB, attemptId)
+    if (!attempt) return c.json({ ok: false, error: 'Release attempt not found', code: 'attempt_not_found' }, 404)
+    return c.json(attemptResponse(attempt)!)
+  } catch (error) {
+    console.error('Read release attempt error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
+
+internalDeletion.post('/username/release/rollback', async (c) => {
+  try {
+    const body = await c.req.json<{ attempt_id?: unknown }>()
+    const attemptId = parseAttemptId(body.attempt_id)
+    if (!attemptId) return c.json({ ok: false, error: 'A valid attempt_id is required' }, 400)
+    const attempt = await getReleaseAttemptById(c.env.DB, attemptId)
+    if (!attempt) return c.json({ ok: false, error: 'Release attempt not found', code: 'attempt_not_found' }, 404)
+    const result = await rollbackReleaseAttempt(
+      c.env.DB,
+      attempt.pubkey,
+      attempt.username_canonical,
+      attempt.attempt_id,
+    )
+    if (result.outcome === 'conflict') {
+      const code = result.attempt?.state === 'finalized' ? 'attempt_finalized' : 'attempt_conflict'
+      return c.json({ ok: false, error: 'Release attempt cannot be rolled back', code }, 409)
+    }
+    if (result.outcome === 'not_found') {
+      return c.json({ ok: false, error: 'Release attempt not found', code: 'attempt_not_found' }, 404)
+    }
+    await reconcileUsernameFastly(c.env, result.attempt.username_canonical)
+    return c.json(attemptResponse(result.attempt)!)
+  } catch (error) {
+    console.error('Rollback release error:', error)
+    return c.json({ ok: false, error: 'Internal server error' }, 500)
+  }
+})
 
 internalDeletion.post('/username/release/finalize', async (c) => {
   try {
     const body = await c.req.json<{ attempt_id?: unknown }>()
-    if (typeof body.attempt_id !== 'string' || body.attempt_id.length < 16 || body.attempt_id.length > 128) {
+    if (!parseAttemptId(body.attempt_id)) {
       return c.json({ ok: false, error: 'A valid attempt_id is required' }, 400)
     }
     const result = await finalizeReleaseAttempt(c.env.DB, body.attempt_id, 'deletion-coordinator')

--- a/src/routes/internal-deletion.ts
+++ b/src/routes/internal-deletion.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Keeps status, rollback, and permanent burns behind one least-privilege credential.
 
 import { Hono } from 'hono'
-import { finalizeReleaseAttempt, getReleaseAttemptById, rollbackReleaseAttempt } from '../db/queries'
+import { type UsernameReleaseAttempt, finalizeReleaseAttempt, getReleaseAttemptById, rollbackReleaseAttempt } from '../db/queries'
 import { requireServiceToken } from '../middleware/service-auth'
 import { reconcileUsernameFastly } from '../utils/username-fastly-reconcile'
 
@@ -20,8 +20,7 @@ function parseAttemptId(value: unknown): string | null {
   return typeof value === 'string' && value.length >= 16 && value.length <= 128 ? value : null
 }
 
-function attemptResponse(attempt: Awaited<ReturnType<typeof getReleaseAttemptById>>) {
-  if (!attempt) return null
+function attemptResponse(attempt: UsernameReleaseAttempt) {
   return {
     ok: true,
     attempt_id: attempt.attempt_id,
@@ -38,7 +37,7 @@ internalDeletion.get('/username/release/attempt/:attemptId', async (c) => {
   try {
     const attempt = await getReleaseAttemptById(c.env.DB, attemptId)
     if (!attempt) return c.json({ ok: false, error: 'Release attempt not found', code: 'attempt_not_found' }, 404)
-    return c.json(attemptResponse(attempt)!)
+    return c.json(attemptResponse(attempt))
   } catch (error) {
     console.error('Read release attempt error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
@@ -66,7 +65,7 @@ internalDeletion.post('/username/release/rollback', async (c) => {
       return c.json({ ok: false, error: 'Release attempt not found', code: 'attempt_not_found' }, 404)
     }
     await reconcileUsernameFastly(c.env, result.attempt.username_canonical)
-    return c.json(attemptResponse(result.attempt)!)
+    return c.json(attemptResponse(result.attempt))
   } catch (error) {
     console.error('Rollback release error:', error)
     return c.json({ ok: false, error: 'Internal server error' }, 500)
@@ -76,10 +75,11 @@ internalDeletion.post('/username/release/rollback', async (c) => {
 internalDeletion.post('/username/release/finalize', async (c) => {
   try {
     const body = await c.req.json<{ attempt_id?: unknown }>()
-    if (!parseAttemptId(body.attempt_id)) {
+    const attemptId = parseAttemptId(body.attempt_id)
+    if (!attemptId) {
       return c.json({ ok: false, error: 'A valid attempt_id is required' }, 400)
     }
-    const result = await finalizeReleaseAttempt(c.env.DB, body.attempt_id, 'deletion-coordinator')
+    const result = await finalizeReleaseAttempt(c.env.DB, attemptId, 'deletion-coordinator')
     if (result.outcome === 'not_found') return c.json({ ok: false, error: 'Release attempt not found' }, 404)
     if (result.outcome === 'conflict') {
       const code = result.attempt?.state === 'pending' && result.attempt.expires_at <= Math.floor(Date.now() / 1000)

--- a/src/routes/username-release.test.ts
+++ b/src/routes/username-release.test.ts
@@ -91,13 +91,13 @@ describe('recoverable username release routes', () => {
     expect(await response.json()).toMatchObject({ found: true, attempt_id: attemptId, state: 'pending' })
   })
 
-  it('returns cancelled for a rollback replay', async () => {
+  it.each(['cancelled', 'expired-restored'] as const)('returns the stored %s state for a rollback replay', async (state) => {
     mocks.rollbackReleaseAttempt.mockResolvedValue({
-      outcome: 'replayed', attempt: { ...pendingAttempt, state: 'cancelled' }, username: { ...usernameRow, status: 'active' },
+      outcome: 'replayed', attempt: { ...pendingAttempt, state }, username: { ...usernameRow, status: 'active' },
     })
     const response = await app().fetch(post('/release/rollback', { name: 'alice', attempt_id: attemptId }), { DB: {} as D1Database }, createExecutionContext())
     expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({ state: 'cancelled' })
+    expect(await response.json()).toMatchObject({ state })
   })
 
   it('never permits rollback after finalization', async () => {

--- a/src/routes/username.ts
+++ b/src/routes/username.ts
@@ -707,7 +707,7 @@ username.post('/release/rollback', async (c) => {
       return c.json({ ok: false, error: 'Release attempt cannot be rolled back', code }, 409)
     }
     await reconcileUsernameFastly(c.env, canonical)
-    return c.json({ ok: true, attempt_id: result.attempt.attempt_id, name: canonical, state: 'cancelled' })
+    return c.json({ ok: true, attempt_id: result.attempt.attempt_id, name: canonical, state: result.attempt.state })
   } catch (error) {
     if (error instanceof Error && error.name === 'Nip98Error') return c.json({ ok: false, error: error.message }, 401)
     console.error('Rollback release error:', error)


### PR DESCRIPTION
## Problem

Funnelcake needs to verify and cancel a pending username release without trusting ownership data supplied by a client. It also needs cancellation to finish cleanly when the 72-hour Name Server sweeper has already restored the username; treating that completed restoration as a conflict permanently strands the downstream cancellation workflow.

## Why this fix

This adds service-authenticated status and rollback endpoints alongside finalization. Every operation resolves the pubkey and canonical username from the stored release attempt. Rollback treats both an earlier cancellation and an expiry restoration as idempotent success only when the active username still belongs to the attempt pubkey, including at the database transition boundary.

The database transition requires the active username row to match the attempt pubkey, so a reassigned name cannot terminalize an older attempt. The public rollback response also reports the stored terminal state (`cancelled` or `expired-restored`) instead of rewriting an expiry restoration as cancellation.

The coordinator can therefore complete cancellation after the sweeper wins the race without allowing caller-supplied ownership fields or a reassigned username to satisfy the rollback.

## Deliberately unchanged

- Finalized attempts remain permanent and cannot be rolled back.
- Expired pending attempts still cannot be finalized.
- Pull-request CI gating remains tracked separately in #67.
- No visual change.

## Validation

- `npm run typecheck`
- `npm run test:once` - 404 tests passed across 20 files, including the real migrated SQLite suite

## Deployment dependency

Deploy this Name Server change before setting `DELETION_COORDINATOR_TOKEN` on the Funnelcake side. Provision the corresponding Worker secret before enabling the coordinator. No secret value is included here.

Refs divinevideo/divine-funnelcake#1084
