### PR TITLE
fix(admin-search): find pasted public keys without search errors

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -58,6 +58,174 @@ describe('searchUsernames', () => {
     expect(result.results[0].email).toBe('bob@example.com')
   })
 
+  // A full pubkey wrapped as %<key>% exceeds SQLite's 50-char LIKE pattern
+  // limit and raises "LIKE or GLOB pattern too complex". These cover the
+  // exact-match path that avoids it.
+  const FULL_HEX = '7a03f75a183a470fcb759f3462ea6b153be5448eb5d207d4e4cc0978ec3660bc'
+  const FULL_NPUB = 'npub10gplwksc8frsljm4nu6x96ntz5a723ywkhfq048yesyh3mpkvz7qj4cdrw'
+  const hexRecords: MockRecord[] = [
+    {
+      id: 10, name: 'keyholder', username_display: 'keyholder', username_canonical: 'keyholder',
+      pubkey: FULL_HEX, email: 'keyholder@example.com', status: 'active',
+      created_at: 1700001000, updated_at: 1700001000, claimed_at: 1700001000,
+      reserved_reason: null, claim_source: 'unknown',
+    },
+  ]
+
+  it('should find a record by full 64-character hex pubkey', async () => {
+    const db = createFakeD1(hexRecords)
+    const result = await searchUsernames(db, { query: FULL_HEX })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(FULL_HEX)
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('should find a record by npub (decoded to hex)', async () => {
+    const db = createFakeD1(hexRecords)
+    const result = await searchUsernames(db, { query: FULL_NPUB })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(FULL_HEX)
+  })
+
+  it('should return empty results (not error) for an over-long non-pubkey query', async () => {
+    const db = createFakeD1(hexRecords)
+    const result = await searchUsernames(db, { query: 'z'.repeat(60) })
+
+    expect(result.results).toHaveLength(0)
+    expect(result.pagination.total).toBe(0)
+  })
+
+  it('should still substring-match a short pubkey prefix', async () => {
+    const db = createFakeD1(hexRecords)
+    const result = await searchUsernames(db, { query: FULL_HEX.slice(0, 12) })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(FULL_HEX)
+  })
+
+  it('should match a legacy mixed-case stored pubkey case-insensitively', async () => {
+    const stored = FULL_HEX.toUpperCase()
+    const db = createFakeD1([
+      {
+        id: 11, name: 'legacy', username_display: 'legacy', username_canonical: 'legacy',
+        pubkey: stored, email: null, status: 'active',
+        created_at: 1700002000, updated_at: 1700002000, claimed_at: 1700002000,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+    const result = await searchUsernames(db, { query: FULL_HEX })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(stored)
+  })
+
+  // The bug is an off-by-one at pattern length 50 (query > 48 chars). These pin
+  // both sides of that edge so drift in MAX_LIKE_PATTERN_LENGTH or the `+ 2`
+  // formula turns one of them red.
+  it('should run a substring search at the 48-character LIKE limit', async () => {
+    const note = 'n'.repeat(48)
+    const db = createFakeD1([
+      {
+        id: 12, name: 'noted', username_display: 'noted', username_canonical: 'noted',
+        pubkey: 'noted-pk', email: null, admin_notes: note, status: 'active',
+        created_at: 1700002100, updated_at: 1700002100, claimed_at: 1700002100,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+    const result = await searchUsernames(db, { query: note })
+
+    expect(result.results).toHaveLength(1)
+  })
+
+  it('should return empty just past the LIKE limit (49 characters) without erroring', async () => {
+    const note = 'n'.repeat(49)
+    const db = createFakeD1([
+      {
+        id: 13, name: 'noted2', username_display: 'noted2', username_canonical: 'noted2',
+        pubkey: 'noted-pk2', email: null, admin_notes: note, status: 'active',
+        created_at: 1700002200, updated_at: 1700002200, claimed_at: 1700002200,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+    const result = await searchUsernames(db, { query: note })
+
+    expect(result.results).toHaveLength(0)
+    expect(result.pagination.total).toBe(0)
+  })
+
+  it('should scope a recovered-status filter to the exact pubkey', async () => {
+    const otherHex = 'b'.repeat(64)
+    const db = createFakeD1([
+      {
+        id: 14, name: 'vinerec', username_display: 'vinerec', username_canonical: 'vinerec',
+        pubkey: FULL_HEX, email: null, status: 'active',
+        reserved_reason: 'Imported from Vine account', claim_source: 'vine-import',
+        created_at: 1700003000, updated_at: 1700003000, claimed_at: 1700003000,
+      },
+      {
+        id: 15, name: 'othervine', username_display: 'othervine', username_canonical: 'othervine',
+        pubkey: otherHex, email: null, status: 'active',
+        reserved_reason: 'Imported from Vine account', claim_source: 'vine-import',
+        created_at: 1700003100, updated_at: 1700003100, claimed_at: 1700003100,
+      },
+    ])
+    const result = await searchUsernames(db, { query: FULL_HEX, status: 'recovered' })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(FULL_HEX)
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('should filter by an exact tag and count only tagged rows', async () => {
+    const db = createFakeD1([
+      {
+        id: 16, name: 'tagged', username_display: 'tagged', username_canonical: 'tagged',
+        pubkey: 'tagged-pk', email: null, status: 'active',
+        created_at: 1700004000, updated_at: 1700004000, claimed_at: 1700004000,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+      {
+        id: 17, name: 'untagged', username_display: 'untagged', username_canonical: 'untagged',
+        pubkey: 'untagged-pk', email: null, status: 'active',
+        created_at: 1700004100, updated_at: 1700004100, claimed_at: 1700004100,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+    await addTag(db, 16, 'vip', 'admin')
+    const result = await searchUsernames(db, { query: '', tag: 'vip' })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].name).toBe('tagged')
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('should combine an exact pubkey match with a tag filter', async () => {
+    const otherHex = 'c'.repeat(64)
+    const db = createFakeD1([
+      {
+        id: 18, name: 'keyed', username_display: 'keyed', username_canonical: 'keyed',
+        pubkey: FULL_HEX, email: null, status: 'active',
+        created_at: 1700004200, updated_at: 1700004200, claimed_at: 1700004200,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+      {
+        id: 19, name: 'otherkeyed', username_display: 'otherkeyed', username_canonical: 'otherkeyed',
+        pubkey: otherHex, email: null, status: 'active',
+        created_at: 1700004300, updated_at: 1700004300, claimed_at: 1700004300,
+        reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+    await addTag(db, 18, 'vip', 'admin')
+    await addTag(db, 19, 'vip', 'admin')
+    const result = await searchUsernames(db, { query: FULL_HEX, tag: 'vip' })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].pubkey).toBe(FULL_HEX)
+    expect(result.pagination.total).toBe(1)
+  })
+
   it('should filter by status', async () => {
     const db = createFakeD1(mockRecords)
     const result = await searchUsernames(db, { query: '', status: 'active' })

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -89,7 +89,7 @@ describe('searchUsernames', () => {
     expect(result.results[0].pubkey).toBe(FULL_HEX)
   })
 
-  it('should return empty results (not error) for an over-long non-pubkey query', async () => {
+  it('should return empty results for an unmatched over-long non-pubkey query', async () => {
     const db = createFakeD1(hexRecords)
     const result = await searchUsernames(db, { query: 'z'.repeat(60) })
 
@@ -121,9 +121,8 @@ describe('searchUsernames', () => {
     expect(result.results[0].pubkey).toBe(stored)
   })
 
-  // The bug is an off-by-one at pattern length 50 (query > 48 chars). These pin
-  // both sides of that edge so drift in MAX_LIKE_PATTERN_LENGTH or the `+ 2`
-  // formula turns one of them red.
+  // ASCII terms can use substring matching through 48 characters. Longer terms
+  // fall back to exact equality instead of returning an error or false negative.
   it('should run a substring search at the 48-character LIKE limit', async () => {
     const note = 'n'.repeat(48)
     const db = createFakeD1([
@@ -139,7 +138,7 @@ describe('searchUsernames', () => {
     expect(result.results).toHaveLength(1)
   })
 
-  it('should return empty just past the LIKE limit (49 characters) without erroring', async () => {
+  it('should exact-match admin notes just past the LIKE limit', async () => {
     const note = 'n'.repeat(49)
     const db = createFakeD1([
       {
@@ -151,8 +150,43 @@ describe('searchUsernames', () => {
     ])
     const result = await searchUsernames(db, { query: note })
 
-    expect(result.results).toHaveLength(0)
-    expect(result.pagination.total).toBe(0)
+    expect(result.results).toHaveLength(1)
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('should exact-match a long email instead of silently dropping the search', async () => {
+    const email = `${'account'.repeat(7)}@example.com`
+    const db = createFakeD1([{
+      id: 20, name: 'longemail', username_display: 'longemail', username_canonical: 'longemail',
+      pubkey: 'long-email-pk', email, status: 'active',
+      created_at: 1700004400, updated_at: 1700004400,
+      reserved_reason: null, claim_source: 'unknown',
+    }])
+
+    const result = await searchUsernames(db, { query: email })
+
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].email).toBe(email)
+  })
+
+  it('should measure the LIKE limit in UTF-8 bytes', async () => {
+    const substringTerm = '界'.repeat(16) // 48 bytes; 50 with surrounding wildcards
+    const exactTerm = '語'.repeat(17) // 51 bytes; must avoid LIKE
+    const db = createFakeD1([
+      {
+        id: 21, name: 'multibyte-substring', username_display: 'multibyte-substring', username_canonical: 'multibyte-substring',
+        pubkey: 'multibyte-substring-pk', email: null, admin_notes: `before${substringTerm}after`, status: 'active',
+        created_at: 1700004500, updated_at: 1700004500, reserved_reason: null, claim_source: 'unknown',
+      },
+      {
+        id: 22, name: 'multibyte-exact', username_display: 'multibyte-exact', username_canonical: 'multibyte-exact',
+        pubkey: 'multibyte-exact-pk', email: null, admin_notes: exactTerm, status: 'active',
+        created_at: 1700004600, updated_at: 1700004600, reserved_reason: null, claim_source: 'unknown',
+      },
+    ])
+
+    expect((await searchUsernames(db, { query: substringTerm })).results[0].id).toBe(21)
+    expect((await searchUsernames(db, { query: exactTerm })).results[0].id).toBe(22)
   })
 
   it('should scope a recovered-status filter to the exact pubkey', async () => {
@@ -223,6 +257,20 @@ describe('searchUsernames', () => {
 
     expect(result.results).toHaveLength(1)
     expect(result.results[0].pubkey).toBe(FULL_HEX)
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('should combine pending-release status with a tag filter', async () => {
+    const db = createFakeD1([{
+      id: 23, name: 'pendingtagged', username_display: 'pendingtagged', username_canonical: 'pendingtagged',
+      pubkey: 'pending-tagged-pk', email: null, status: 'pending-release',
+      created_at: 1700004700, updated_at: 1700004700, reserved_reason: null, claim_source: 'unknown',
+    }])
+    await addTag(db, 23, 'vip', 'admin')
+
+    const result = await searchUsernames(db, { query: '', status: 'pending-release', tag: 'vip' })
+
+    expect(result.results).toHaveLength(1)
     expect(result.pagination.total).toBe(1)
   })
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -796,8 +796,8 @@ export async function assignUsername(
 }
 
 function escapeLikePattern(str: string): string {
-  // Escape special LIKE characters (% and _) to prevent injection
-  return str.replace(/[%_]/g, '\\$&')
+  // Escape the escape character and LIKE wildcards so searches treat them literally.
+  return str.replace(/[\\%_]/g, '\\$&')
 }
 
 export async function searchUsernames(
@@ -807,6 +807,8 @@ export async function searchUsernames(
   const { query, status, sort = 'relevance', page = 1, limit = 50 } = params
   const offset = (page - 1) * limit
   const trimmedQuery = query ? query.trim() : ''
+  const escapedQuery = trimmedQuery ? escapeLikePattern(trimmedQuery) : ''
+  const searchPattern = escapedQuery ? `%${escapedQuery}%` : ''
 
   // A full public key (hex or npub) is an exact identity, and wrapped as
   // `%<key>%` its LIKE pattern overflows SQLite's limit. Match pubkey exactly
@@ -820,31 +822,27 @@ export async function searchUsernames(
     }
   }
 
-  // A non-pubkey query (full pubkeys are handled above) can only be served as a
-  // `%term%` substring match, which SQLite refuses once the pattern exceeds the
-  // cap ("LIKE or GLOB pattern too complex"). Return empty rather than error.
-  // Known casualty: a >48-char email/admin_notes fragment can't be searched.
-  if (!pubkeyExact && trimmedQuery && escapeLikePattern(trimmedQuery).length + 2 > MAX_LIKE_PATTERN_LENGTH) {
-    return {
-      results: [],
-      pagination: { page, limit, total: 0, total_pages: 0 },
-    }
-  }
+  // SQLite applies its LIKE pattern limit to UTF-8 bytes, not JavaScript string
+  // length. Oversized terms still support exact lookup across every searchable
+  // field, which keeps full email and note searches useful without risking a 500.
+  const useExactFallback = !pubkeyExact && searchPattern.length > 0 &&
+    new TextEncoder().encode(searchPattern).byteLength > MAX_LIKE_PATTERN_LENGTH
 
   // Build WHERE clause
   let whereClause = ''
   const queryParams: any[] = []
-  const escapedQuery = !pubkeyExact && trimmedQuery ? escapeLikePattern(trimmedQuery) : ''
 
   if (pubkeyExact) {
     // Exact pubkey match (hex or decoded npub). LOWER() mirrors every other
     // pubkey lookup in this file so legacy mixed-case hex rows still match.
     whereClause = 'LOWER(pubkey) = LOWER(?)'
     queryParams.push(pubkeyExact)
-  } else if (escapedQuery) {
+  } else if (useExactFallback) {
+    whereClause = `(LOWER(name) = LOWER(?) OR LOWER(username_display) = LOWER(?) OR LOWER(username_canonical) = LOWER(?) OR LOWER(pubkey) = LOWER(?) OR LOWER(email) = LOWER(?) OR LOWER(admin_notes) = LOWER(?) OR EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND LOWER(ut.tag) = LOWER(?)))`
+    queryParams.push(trimmedQuery, trimmedQuery, trimmedQuery, trimmedQuery, trimmedQuery, trimmedQuery, trimmedQuery)
+  } else if (searchPattern) {
     // Search across name, pubkey, email, admin_notes, and tags
-    const searchPattern = `%${escapedQuery}%`
-    whereClause = `(name LIKE ? OR username_display LIKE ? OR username_canonical LIKE ? OR pubkey LIKE ? OR email LIKE ? OR admin_notes LIKE ? OR EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ?))`
+    whereClause = `(name LIKE ? ESCAPE '\\' OR username_display LIKE ? ESCAPE '\\' OR username_canonical LIKE ? ESCAPE '\\' OR pubkey LIKE ? ESCAPE '\\' OR email LIKE ? ESCAPE '\\' OR admin_notes LIKE ? ESCAPE '\\' OR EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ? ESCAPE '\\'))`
     queryParams.push(searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern)
   }
 
@@ -901,20 +899,20 @@ export async function searchUsernames(
     orderClause = 'updated_at DESC, created_at DESC'
   } else if (sort === 'newest') {
     orderClause = 'created_at DESC'
-  } else if (escapedQuery) {
+  } else if (!pubkeyExact && searchPattern && !useExactFallback) {
     // sort === 'relevance' with a search query: rank by match quality
     const canonical = trimmedQuery.toLowerCase()
     const prefixPattern = `${escapedQuery}%`
     const containsPattern = `%${escapedQuery}%`
     orderClause = `CASE
       WHEN username_canonical = ? THEN 0
-      WHEN username_canonical LIKE ? THEN 1
-      WHEN name LIKE ? OR username_display LIKE ? THEN 2
+      WHEN username_canonical LIKE ? ESCAPE '\\' THEN 1
+      WHEN name LIKE ? ESCAPE '\\' OR username_display LIKE ? ESCAPE '\\' THEN 2
       WHEN EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag = ?) THEN 3
-      WHEN EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ?) THEN 4
+      WHEN EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ? ESCAPE '\\') THEN 4
       WHEN pubkey = ? OR email = ? THEN 5
-      WHEN pubkey LIKE ? OR email LIKE ? THEN 6
-      WHEN admin_notes LIKE ? THEN 7
+      WHEN pubkey LIKE ? ESCAPE '\\' OR email LIKE ? ESCAPE '\\' THEN 6
+      WHEN admin_notes LIKE ? ESCAPE '\\' THEN 7
       ELSE 8
     END, updated_at DESC, created_at DESC`
     orderParams.push(

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,8 +5,8 @@ import type { SyncItem, UsernameKVData } from '../utils/fastly-sync'
 import { validateAndNormalizePubkey } from '../utils/validation'
 
 // SQLite raises "LIKE or GLOB pattern too complex" once a LIKE pattern exceeds
-// SQLITE_MAX_LIKE_PATTERN_LENGTH (50). Our search wraps the term as `%term%`,
-// so any term longer than 48 chars would overflow it.
+// SQLITE_MAX_LIKE_PATTERN_LENGTH (50 UTF-8 bytes). The surrounding wildcards
+// consume two bytes; multibyte text and escaped literals consume more per term.
 const MAX_LIKE_PATTERN_LENGTH = 50
 
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,6 +2,12 @@
 // ABOUTME: Provides type-safe D1 database operations
 
 import type { SyncItem, UsernameKVData } from '../utils/fastly-sync'
+import { validateAndNormalizePubkey } from '../utils/validation'
+
+// SQLite raises "LIKE or GLOB pattern too complex" once a LIKE pattern exceeds
+// SQLITE_MAX_LIKE_PATTERN_LENGTH (50). Our search wraps the term as `%term%`,
+// so any term longer than 48 chars would overflow it.
+const MAX_LIKE_PATTERN_LENGTH = 50
 
 export type ClaimSource = 'self-service' | 'admin' | 'bulk-upload' | 'vine-import' | 'public-reservation' | 'unknown'
 export type SearchSort = 'relevance' | 'newest' | 'oldest' | 'updated'
@@ -800,14 +806,43 @@ export async function searchUsernames(
 ): Promise<SearchResult> {
   const { query, status, sort = 'relevance', page = 1, limit = 50 } = params
   const offset = (page - 1) * limit
+  const trimmedQuery = query ? query.trim() : ''
+
+  // A full public key (hex or npub) is an exact identity, and wrapped as
+  // `%<key>%` its LIKE pattern overflows SQLite's limit. Match pubkey exactly
+  // instead — which is also what an admin means by pasting a whole key.
+  let pubkeyExact: string | null = null
+  if (trimmedQuery.startsWith('npub1') || /^[0-9a-f]{64}$/i.test(trimmedQuery)) {
+    try {
+      pubkeyExact = validateAndNormalizePubkey(trimmedQuery)
+    } catch {
+      pubkeyExact = null
+    }
+  }
+
+  // A non-pubkey query (full pubkeys are handled above) can only be served as a
+  // `%term%` substring match, which SQLite refuses once the pattern exceeds the
+  // cap ("LIKE or GLOB pattern too complex"). Return empty rather than error.
+  // Known casualty: a >48-char email/admin_notes fragment can't be searched.
+  if (!pubkeyExact && trimmedQuery && escapeLikePattern(trimmedQuery).length + 2 > MAX_LIKE_PATTERN_LENGTH) {
+    return {
+      results: [],
+      pagination: { page, limit, total: 0, total_pages: 0 },
+    }
+  }
 
   // Build WHERE clause
   let whereClause = ''
   const queryParams: any[] = []
-  const escapedQuery = query && query.length > 0 ? escapeLikePattern(query) : ''
+  const escapedQuery = !pubkeyExact && trimmedQuery ? escapeLikePattern(trimmedQuery) : ''
 
-  // Search across name, pubkey, email, admin_notes, and tags
-  if (escapedQuery) {
+  if (pubkeyExact) {
+    // Exact pubkey match (hex or decoded npub). LOWER() mirrors every other
+    // pubkey lookup in this file so legacy mixed-case hex rows still match.
+    whereClause = 'LOWER(pubkey) = LOWER(?)'
+    queryParams.push(pubkeyExact)
+  } else if (escapedQuery) {
+    // Search across name, pubkey, email, admin_notes, and tags
     const searchPattern = `%${escapedQuery}%`
     whereClause = `(name LIKE ? OR username_display LIKE ? OR username_canonical LIKE ? OR pubkey LIKE ? OR email LIKE ? OR admin_notes LIKE ? OR EXISTS (SELECT 1 FROM username_tags ut WHERE ut.username_id = usernames.id AND ut.tag LIKE ?))`
     queryParams.push(searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern, searchPattern)
@@ -868,7 +903,7 @@ export async function searchUsernames(
     orderClause = 'created_at DESC'
   } else if (escapedQuery) {
     // sort === 'relevance' with a search query: rank by match quality
-    const canonical = query!.toLowerCase()
+    const canonical = trimmedQuery.toLowerCase()
     const prefixPattern = `${escapedQuery}%`
     const containsPattern = `%${escapedQuery}%`
     orderClause = `CASE

--- a/src/db/search-sqlite.test.ts
+++ b/src/db/search-sqlite.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Exercises admin search SQL against real SQLite rather than the D1 fake.
+// ABOUTME: Verifies LIKE escaping and oversized-query fallbacks at the database boundary.
+
+import { describe, expect, it } from 'vitest'
+import { searchUsernames } from './queries'
+import { createSqliteD1, sqliteAvailable } from './sqlite-test-helpers'
+
+function seedSearchRow(
+  sqlite: ReturnType<typeof createSqliteD1>['sqlite'],
+  canonical: string,
+  fields: { email?: string; adminNotes?: string }
+) {
+  sqlite.prepare(
+    `INSERT INTO usernames (
+       name, username_display, username_canonical, email, admin_notes,
+       status, recyclable, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, 'active', 1, 100, 100)`
+  ).run(canonical, canonical, canonical, fields.email ?? null, fields.adminNotes ?? null)
+}
+
+describe.skipIf(!sqliteAvailable())('admin search against real SQLite', () => {
+  it('treats percent, underscore, and backslash as literal search text', async () => {
+    const { db, sqlite } = createSqliteD1()
+    seedSearchRow(sqlite, 'literal-underscore', { email: 'first_last@example.com' })
+    seedSearchRow(sqlite, 'wildcard-lookalike', { email: 'firstXlast@example.com' })
+    seedSearchRow(sqlite, 'literal-percent', { adminNotes: 'team%ops' })
+    seedSearchRow(sqlite, 'literal-backslash', { adminNotes: String.raw`path\name` })
+
+    expect((await searchUsernames(db, { query: 'first_last@example.com' })).results.map((row) => row.name))
+      .toEqual(['literal-underscore'])
+    expect((await searchUsernames(db, { query: 'team%ops' })).results.map((row) => row.name))
+      .toEqual(['literal-percent'])
+    expect((await searchUsernames(db, { query: String.raw`path\name` })).results.map((row) => row.name))
+      .toEqual(['literal-backslash'])
+  })
+
+  it('exact-matches an email whose UTF-8 LIKE pattern exceeds the limit', async () => {
+    const { db, sqlite } = createSqliteD1()
+    const email = `${'account'.repeat(7)}@example.com`
+    seedSearchRow(sqlite, 'long-email', { email })
+
+    const result = await searchUsernames(db, { query: email })
+
+    expect(result.results.map((row) => row.name)).toEqual(['long-email'])
+    expect(result.pagination.total).toBe(1)
+  })
+})

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -6,6 +6,10 @@ import type { Username } from './queries'
 
 export type MockRecord = Partial<Username> & { name: string; username_canonical: string }
 
+const USERNAME_STATUSES = [
+  'active', 'reserved', 'revoked', 'burned', 'pending-confirmation', 'pending-release',
+]
+
 export function createExecutionContext(
   overrides: Partial<ExecutionContext> = {}
 ): ExecutionContext {
@@ -50,8 +54,7 @@ export function createFakeD1(
       // contain "active", but applyStatusFilter gates on sql.includes('status = ?')
       // which is only present when a status filter was actually requested.
       function extractStatus(): string | null {
-        const statuses = ['active', 'reserved', 'revoked', 'burned', 'pending-confirmation']
-        return boundParams.find((p) => typeof p === 'string' && statuses.includes(p)) || null
+        return boundParams.find((p) => typeof p === 'string' && USERNAME_STATUSES.includes(p)) || null
       }
 
       // Filter records by search term (matches name, display, canonical, pubkey, email, admin_notes, tags)
@@ -79,8 +82,9 @@ export function createFakeD1(
       // Enforcing it here lets tests catch query paths (e.g. a 64-char hex
       // pubkey wrapped as %..%) that would throw against real D1.
       function assertLikePatternLimit(): void {
+        if (!sql.includes('LIKE ?')) return
         for (const p of boundParams) {
-          if (typeof p === 'string' && p.includes('%') && p.length > 50) {
+          if (typeof p === 'string' && p.includes('%') && new TextEncoder().encode(p).byteLength > 50) {
             throw new Error('LIKE or GLOB pattern too complex: SQLITE_ERROR')
           }
         }
@@ -104,6 +108,19 @@ export function createFakeD1(
         )
       }
 
+      // Oversized non-pubkey terms use exact equality across searchable fields.
+      function applyExactSearch(data: MockRecord[]): MockRecord[] {
+        const term = boundParams[0]
+        if (typeof term !== 'string') return data
+        const canonical = term.toLowerCase()
+        return data.filter((u) => {
+          const values = [u.name, u.username_display, u.username_canonical, u.pubkey, u.email, u.admin_notes]
+          const userTags = tags.filter((t) => t.username_id === u.id).map((t) => t.tag)
+          return values.some((value) => value?.toLowerCase() === canonical) ||
+            userTags.some((tag) => tag.toLowerCase() === canonical)
+        })
+      }
+
       // Filter records by status
       function applyStatusFilter(data: MockRecord[]): MockRecord[] {
         if (!sql.includes('status = ?')) return data
@@ -112,22 +129,15 @@ export function createFakeD1(
         return data.filter((u) => u.status === status)
       }
 
-      // Exact tag filter (WHERE ... EXISTS(... ut.tag = ?)). Scope to the WHERE
-      // clause (the relevance ORDER BY CASE also uses ut.tag = ?), and pick the
-      // tag param while skipping % patterns, status literals, and 64-hex pubkeys
-      // — so it survives an exact-pubkey search that binds a pubkey ahead of it.
-      // Assumes a real tag is none of those, which holds: tags are trimmed,
-      // lowercased, and ≤50 chars, so never a status word or a 64-hex string.
+      // Exact tag filters are the final placeholder in WHERE. Count only WHERE
+      // placeholders so relevance parameters in ORDER BY cannot be mistaken for
+      // the tag, regardless of the query or status value.
       function applyTagFilter(data: MockRecord[]): MockRecord[] {
-        if (!sql.split('ORDER BY')[0].includes('ut.tag = ?')) return data
-        const tagParam = boundParams.find(
-          (p) =>
-            typeof p === 'string' &&
-            !p.includes('%') &&
-            !['active', 'reserved', 'revoked', 'burned', 'pending-confirmation'].includes(p) &&
-            !/^[0-9a-f]{64}$/i.test(p)
-        ) as string | undefined
-        if (!tagParam) return data
+        const wherePart = sql.split('ORDER BY')[0]
+        if (!wherePart.includes('ut.tag = ?')) return data
+        const whereParamCount = wherePart.match(/\?/g)?.length ?? 0
+        const tagParam = boundParams[whereParamCount - 1]
+        if (typeof tagParam !== 'string') return data
         const taggedIds = new Set(tags.filter((t) => t.tag === tagParam).map((t) => t.username_id))
         return data.filter((u) => u.id != null && taggedIds.has(u.id))
       }
@@ -192,6 +202,16 @@ export function createFakeD1(
 
               // COUNT query
               if (sql.includes('COUNT(*)')) {
+                if (sql.includes('LOWER(name) = LOWER(?)')) {
+                  let filtered = applyExactSearch([...records])
+                  if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
+                    filtered = applyRecoveredFilter(filtered)
+                  } else {
+                    filtered = applyStatusFilter(filtered)
+                  }
+                  filtered = applyTagFilter(filtered)
+                  return { count: filtered.length }
+                }
                 // Search COUNT by exact pubkey (WHERE LOWER(pubkey) = LOWER(?)).
                 // Checked before LIKE because a recovered-status filter injects
                 // `reserved_reason LIKE '%Vine%'`, which must not shadow the
@@ -318,8 +338,10 @@ export function createFakeD1(
               // and must not be mistaken for an exact-pubkey search.
               let filtered = [...records]
               const wherePart = sql.split('ORDER BY')[0]
+              const isExactSearch = wherePart.includes('LOWER(name) = LOWER(?)')
               const isExactPubkeySearch = wherePart.includes('pubkey) = LOWER(?)') || wherePart.includes('pubkey = ?')
-              if (isExactPubkeySearch) filtered = applyExactPubkey(filtered)
+              if (isExactSearch) filtered = applyExactSearch(filtered)
+              else if (isExactPubkeySearch) filtered = applyExactPubkey(filtered)
               else if (sql.includes('LIKE')) filtered = applySearch(filtered)
               if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
                 filtered = applyRecoveredFilter(filtered)

--- a/src/db/test-helpers.ts
+++ b/src/db/test-helpers.ts
@@ -74,12 +74,62 @@ export function createFakeD1(
         )
       }
 
+      // Mirror SQLite's SQLITE_MAX_LIKE_PATTERN_LENGTH (50): a LIKE pattern
+      // longer than 50 chars raises "LIKE or GLOB pattern too complex".
+      // Enforcing it here lets tests catch query paths (e.g. a 64-char hex
+      // pubkey wrapped as %..%) that would throw against real D1.
+      function assertLikePatternLimit(): void {
+        for (const p of boundParams) {
+          if (typeof p === 'string' && p.includes('%') && p.length > 50) {
+            throw new Error('LIKE or GLOB pattern too complex: SQLITE_ERROR')
+          }
+        }
+      }
+
+      // Exact pubkey search, used when the query is a full pubkey/npub and the
+      // substring path would overflow the LIKE limit. Model SQLite collation:
+      // `LOWER(pubkey) = LOWER(?)` is case-insensitive, while a bare
+      // `pubkey = ?` is BINARY (case-sensitive) — so a missing LOWER() in
+      // production (which breaks legacy mixed-case rows) fails a test here.
+      function applyExactPubkey(data: MockRecord[]): MockRecord[] {
+        const pk = boundParams.find(
+          (p) => typeof p === 'string' && /^[0-9a-f]{64}$/i.test(p)
+        ) as string | undefined
+        if (!pk) return data
+        const caseInsensitive = sql.includes('LOWER(pubkey)')
+        return data.filter((u) =>
+          caseInsensitive
+            ? u.pubkey?.toLowerCase() === pk.toLowerCase()
+            : u.pubkey === pk
+        )
+      }
+
       // Filter records by status
       function applyStatusFilter(data: MockRecord[]): MockRecord[] {
         if (!sql.includes('status = ?')) return data
         const status = extractStatus()
         if (!status) return data
         return data.filter((u) => u.status === status)
+      }
+
+      // Exact tag filter (WHERE ... EXISTS(... ut.tag = ?)). Scope to the WHERE
+      // clause (the relevance ORDER BY CASE also uses ut.tag = ?), and pick the
+      // tag param while skipping % patterns, status literals, and 64-hex pubkeys
+      // — so it survives an exact-pubkey search that binds a pubkey ahead of it.
+      // Assumes a real tag is none of those, which holds: tags are trimmed,
+      // lowercased, and ≤50 chars, so never a status word or a 64-hex string.
+      function applyTagFilter(data: MockRecord[]): MockRecord[] {
+        if (!sql.split('ORDER BY')[0].includes('ut.tag = ?')) return data
+        const tagParam = boundParams.find(
+          (p) =>
+            typeof p === 'string' &&
+            !p.includes('%') &&
+            !['active', 'reserved', 'revoked', 'burned', 'pending-confirmation'].includes(p) &&
+            !/^[0-9a-f]{64}$/i.test(p)
+        ) as string | undefined
+        if (!tagParam) return data
+        const taggedIds = new Set(tags.filter((t) => t.tag === tagParam).map((t) => t.username_id))
+        return data.filter((u) => u.id != null && taggedIds.has(u.id))
       }
 
       // Apply recovered filter (special case — not a simple status match)
@@ -107,6 +157,7 @@ export function createFakeD1(
           boundParams = params
           return {
             first: async () => {
+              assertLikePatternLimit()
               // Stats COUNT queries on username_tags (not search queries with EXISTS subqueries)
               if (sql.includes('COUNT(DISTINCT username_id)') && sql.includes('FROM username_tags')) {
                 if (sql.includes('tag = ?')) {
@@ -141,7 +192,21 @@ export function createFakeD1(
 
               // COUNT query
               if (sql.includes('COUNT(*)')) {
-                // Search COUNT (has LIKE patterns) — handle first to avoid matching stats patterns
+                // Search COUNT by exact pubkey (WHERE LOWER(pubkey) = LOWER(?)).
+                // Checked before LIKE because a recovered-status filter injects
+                // `reserved_reason LIKE '%Vine%'`, which must not shadow the
+                // pubkey predicate.
+                if (sql.includes('pubkey = ?') || sql.includes('pubkey) = LOWER(?)')) {
+                  let filtered = applyExactPubkey([...records])
+                  if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
+                    filtered = applyRecoveredFilter(filtered)
+                  } else {
+                    filtered = applyStatusFilter(filtered)
+                  }
+                  filtered = applyTagFilter(filtered)
+                  return { count: filtered.length }
+                }
+                // Search COUNT (has LIKE patterns) — handle before stats patterns
                 if (sql.includes('LIKE')) {
                   let filtered = [...records]
                   filtered = applySearch(filtered)
@@ -150,6 +215,7 @@ export function createFakeD1(
                   } else {
                     filtered = applyStatusFilter(filtered)
                   }
+                  filtered = applyTagFilter(filtered)
                   return { count: filtered.length }
                 }
                 // Stats: admin_notes presence
@@ -171,13 +237,14 @@ export function createFakeD1(
                   return { count: records.filter(u => (u.updated_at || 0) >= since).length }
                 }
 
-                // Non-search COUNT (status filter only, no LIKE)
+                // Non-search COUNT (status and/or tag filter, no LIKE)
                 let filtered = [...records]
                 if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
                   filtered = applyRecoveredFilter(filtered)
                 } else {
                   filtered = applyStatusFilter(filtered)
                 }
+                filtered = applyTagFilter(filtered)
                 return { count: filtered.length }
               }
 
@@ -208,6 +275,7 @@ export function createFakeD1(
             },
 
             all: async () => {
+              assertLikePatternLimit()
               // Tag queries (but not search queries that reference tags in EXISTS subqueries)
               if (sql.includes('username_tags') && !sql.includes('FROM usernames')) {
                 // SELECT tag FROM username_tags WHERE username_id = ?
@@ -243,27 +311,24 @@ export function createFakeD1(
                 return { results: [] }
               }
 
-              // Search query
+              // Search query. Exact-pubkey is checked before LIKE because a
+              // recovered-status filter injects `reserved_reason LIKE '%Vine%'`,
+              // which must not shadow the pubkey predicate. Scope the check to the
+              // WHERE clause: the relevance ORDER BY CASE also contains `pubkey = ?`
+              // and must not be mistaken for an exact-pubkey search.
               let filtered = [...records]
-              if (sql.includes('LIKE')) filtered = applySearch(filtered)
+              const wherePart = sql.split('ORDER BY')[0]
+              const isExactPubkeySearch = wherePart.includes('pubkey) = LOWER(?)') || wherePart.includes('pubkey = ?')
+              if (isExactPubkeySearch) filtered = applyExactPubkey(filtered)
+              else if (sql.includes('LIKE')) filtered = applySearch(filtered)
               if (sql.includes("status = 'active'") && sql.includes('reserved_reason')) {
                 filtered = applyRecoveredFilter(filtered)
               } else {
                 filtered = applyStatusFilter(filtered)
               }
 
-              // Tag filter via exact-match EXISTS subquery in WHERE clause (AND ut.tag = ?)
-              // The ORDER BY CASE also uses ut.tag = ? for relevance ranking — distinguish
-              // by checking for the pattern in the WHERE clause (before ORDER BY)
-              const whereClause = sql.split('ORDER BY')[0]
-              if (whereClause.includes('ut.tag = ?')) {
-                // The exact tag param is the last non-% string before limit/offset
-                const tagParam = boundParams.find(p => typeof p === 'string' && !p.includes('%') && !['active', 'reserved', 'revoked', 'burned', 'pending-confirmation'].includes(p))
-                if (tagParam) {
-                  const taggedIds = new Set(tags.filter(t => t.tag === tagParam).map(t => t.username_id))
-                  filtered = filtered.filter(u => u.id != null && taggedIds.has(u.id))
-                }
-              }
+              // Tag filter (WHERE ... EXISTS(... ut.tag = ?))
+              filtered = applyTagFilter(filtered)
 
               const { limit, offset } = extractPagination()
 


### PR DESCRIPTION
## Summary

Admin username search failed with a bare "search failed" when an operator pasted a full public key. It can now find records by a complete 64-character hex key or `npub`, and every other accepted search term avoids SQLite's pattern-length failure.

Full public keys use an exact, case-insensitive pubkey lookup. Other terms continue to use substring search while their escaped UTF-8 pattern fits SQLite's 50-byte limit; longer terms fall back to case-insensitive exact matching across usernames, pubkeys, emails, admin notes, and tags. Literal `%`, `_`, and `\` characters are escaped correctly instead of acting as wildcards or suppressing valid matches.

This does not change the admin UI or its API response shape. Exact pubkey lookup may still scan rows when no status filter satisfies the existing partial pubkey index.

## Related Issue

- Closes #81

## Validation

- [x] `npm run test:once` — 401 passing across 21 files
- [x] `npm run build:admin`
- [x] Real-SQLite coverage for literal LIKE characters and oversized exact-email lookup
- [x] Unit coverage for full hex/`npub`, legacy mixed-case keys, UTF-8 byte boundaries, long exact email and notes, tags, recovered records, and `pending-release`

## Manual Test Plan / Notes

- Paste a full hex pubkey and its equivalent `npub`; both should return the same record.
- Search for a complete long email address; it should return an exact match without a server error.
- Search text containing literal `%`, `_`, or `\`; those characters should be treated literally.
- End-to-end validation through the deployed admin UI remains a post-deploy check because the route is behind Cloudflare Access and local Wrangler pins the request host.

## Visuals / API Examples

- No visual change; backend query logic and tests only.

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid sensitive external identities.
